### PR TITLE
Verify npm trusted publishing release path

### DIFF
--- a/.changeset/trusted-publishing-verification.md
+++ b/.changeset/trusted-publishing-verification.md
@@ -1,0 +1,13 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+"@h9-foundry/agentforge-sdk": patch
+"@h9-foundry/agentforge-context-engine": patch
+"@h9-foundry/agentforge-policy-engine": patch
+"@h9-foundry/agentforge-runtime": patch
+"@h9-foundry/agentforge-audit": patch
+---
+
+Trigger a real GitHub-owned publish to verify npm trusted publishing after the
+initial bootstrap release.


### PR DESCRIPTION
## Summary
- add a minimal patch changeset to trigger a real GitHub-owned verification release
- validate that npm trusted publishers are now configured for the AgentForge public package set
- keep the change scoped to release orchestration only

## Verification
- pnpm changeset status
