### PR TITLE
Handle private npm provenance in release workflow

### DIFF
--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -13,7 +13,6 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  NPM_CONFIG_PROVENANCE: true
 
 jobs:
   release:
@@ -49,6 +48,16 @@ jobs:
 
       - name: Verify packed public packages
         run: pnpm release:verify
+
+      - name: Configure npm publish mode
+        run: |
+          if [ "${{ github.event.repository.private }}" = "true" ]; then
+            echo "NPM_CONFIG_PROVENANCE=false" >> "$GITHUB_ENV"
+            echo "npm package provenance is disabled for this private repository because npm only accepts provenance from public GitHub repositories." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "NPM_CONFIG_PROVENANCE=true" >> "$GITHUB_ENV"
+            echo "npm package provenance is enabled for this public repository." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Create release PR or publish
         uses: changesets/action@v1.7.0

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -12,6 +12,7 @@ AgentForge includes a GitHub Actions wrapper for the starter `pr-review` workflo
   - skips artifact attestation on private repositories unless `AGENTFORGE_ENABLE_PRIVATE_ATTESTATION=true` is set after GitHub attestation support is enabled
 - `.github/workflows/release-packages.yml`
   - Changesets version PRs and trusted npm publishing for the curated public subset
+  - disables npm package provenance automatically on private repositories because npm only accepts provenance from public GitHub repositories
 
 ## What It Does
 - installs dependencies

--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -37,11 +37,13 @@ It is designed to:
 - dry-run the curated public package tarballs
 - verify the curated tarballs from a clean-room consumer install
 - open or update version PRs through Changesets
-- publish with npm trusted publishing and provenance when a release commit lands on `main`
+- publish with npm trusted publishing when a release commit lands on `main`
 
 `.github/workflows/publish-gate.yml` runs the same tarball-based verification on pull requests and manual dispatches so the first publish is blocked until the packed artifacts behave like consumer installs.
 
 This workflow should not fall back to a long-lived npm token. If npm trusted publishing is not configured yet, keep the workflow gated and fix the external setup first.
+
+For public repositories, `release-packages.yml` also enables npm package provenance automatically. For private repositories, it disables npm provenance automatically while keeping trusted publishing enabled, because npm currently rejects sigstore provenance bundles from private GitHub repositories.
 
 AgentForge does not store npm credentials in repo config. Codex-assisted npm setup depends on machine-level npm auth on the workstation, typically through `npm login` writing `~/.npmrc`.
 


### PR DESCRIPTION
## Summary
- disable npm package provenance automatically for private repositories
- keep GitHub OIDC trusted publishing enabled
- document the private-repo publish behavior

## Why
The hosted 0.3.1 release failed because npm rejects provenance bundles from private GitHub repositories.
