### PR TITLE
Prepare AgentForge for public OSS cutover

### DIFF
--- a/.changeset/soft-bears-camp.md
+++ b/.changeset/soft-bears-camp.md
@@ -1,0 +1,12 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+"@h9-foundry/agentforge-sdk": patch
+"@h9-foundry/agentforge-context-engine": patch
+"@h9-foundry/agentforge-policy-engine": patch
+"@h9-foundry/agentforge-runtime": patch
+"@h9-foundry/agentforge-audit": patch
+---
+
+Refresh package metadata and documentation for the public open-source release cutover.

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           if [ "${{ github.event.repository.private }}" = "true" ]; then
             echo "NPM_CONFIG_PROVENANCE=false" >> "$GITHUB_ENV"
-            echo "npm package provenance is disabled for this private repository because npm only accepts provenance from public GitHub repositories." >> "$GITHUB_STEP_SUMMARY"
+            echo "npm package provenance is disabled because this repository is private. Make the repository public to re-enable provenance automatically." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "NPM_CONFIG_PROVENANCE=true" >> "$GITHUB_ENV"
             echo "npm package provenance is enabled for this public repository." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-provenance.yml
+++ b/.github/workflows/release-provenance.yml
@@ -61,5 +61,5 @@ jobs:
       - name: Note skipped provenance attestation
         if: ${{ github.event.repository.private == true && vars.AGENTFORGE_ENABLE_PRIVATE_ATTESTATION != 'true' }}
         run: |
-          echo "GitHub artifact attestation is skipped for this private repository." >> "$GITHUB_STEP_SUMMARY"
-          echo "Set AGENTFORGE_ENABLE_PRIVATE_ATTESTATION=true after enabling private attestations for the org to re-enable this step." >> "$GITHUB_STEP_SUMMARY"
+          echo "GitHub artifact attestation is skipped because this repository is private." >> "$GITHUB_STEP_SUMMARY"
+          echo "Make the repository public, or set AGENTFORGE_ENABLE_PRIVATE_ATTESTATION=true after enabling private attestations for the org, to re-enable this step." >> "$GITHUB_STEP_SUMMARY"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 H9 Foundry
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -66,16 +66,16 @@ Package publishing uses GitHub OIDC trusted publishing for `@h9-foundry/agentfor
 
 ## Security And Release Notes
 
-- [SECURITY.md](/Users/ethan/Repo/AgentOps/SECURITY.md)
-- [docs/security-model.md](/Users/ethan/Repo/AgentOps/docs/security-model.md)
-- [docs/release-trust.md](/Users/ethan/Repo/AgentOps/docs/release-trust.md)
-- [docs/github-actions.md](/Users/ethan/Repo/AgentOps/docs/github-actions.md)
+- [SECURITY.md](./SECURITY.md)
+- [docs/security-model.md](./docs/security-model.md)
+- [docs/release-trust.md](./docs/release-trust.md)
+- [docs/github-actions.md](./docs/github-actions.md)
 
 ## Contributor And Extension Guides
 
-- [CONTRIBUTING.md](/Users/ethan/Repo/AgentOps/CONTRIBUTING.md)
-- [docs/runtime-model.md](/Users/ethan/Repo/AgentOps/docs/runtime-model.md)
-- [docs/policy-model.md](/Users/ethan/Repo/AgentOps/docs/policy-model.md)
-- [docs/agent-manifest-guide.md](/Users/ethan/Repo/AgentOps/docs/agent-manifest-guide.md)
-- [docs/plugin-author-guide.md](/Users/ethan/Repo/AgentOps/docs/plugin-author-guide.md)
-- [examples/README.md](/Users/ethan/Repo/AgentOps/examples/README.md)
+- [CONTRIBUTING.md](./CONTRIBUTING.md)
+- [docs/runtime-model.md](./docs/runtime-model.md)
+- [docs/policy-model.md](./docs/policy-model.md)
+- [docs/agent-manifest-guide.md](./docs/agent-manifest-guide.md)
+- [docs/plugin-author-guide.md](./docs/plugin-author-guide.md)
+- [examples/README.md](./examples/README.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,4 +43,4 @@ Phase 1 is deliberately narrow: one secure-by-default local workflow slice, with
 - policy wins over manifests and runtime requests
 - blocked paths and redaction are enforced before artifacts are written
 
-For more detail on execution and policy behavior, see [docs/runtime-model.md](/Users/ethan/Repo/AgentOps/docs/runtime-model.md) and [docs/policy-model.md](/Users/ethan/Repo/AgentOps/docs/policy-model.md).
+For more detail on execution and policy behavior, see [docs/runtime-model.md](./runtime-model.md) and [docs/policy-model.md](./policy-model.md).

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -9,10 +9,12 @@ AgentForge includes a GitHub Actions wrapper for the starter `pr-review` workflo
   - comments on PRs and the configured tracker issue
 - `.github/workflows/release-provenance.yml`
   - build artifact provenance for the workspace
-  - skips artifact attestation on private repositories unless `AGENTFORGE_ENABLE_PRIVATE_ATTESTATION=true` is set after GitHub attestation support is enabled
+  - attests the workspace build artifact by default when the repository is public
+  - falls back to a documented skip path for private repositories unless `AGENTFORGE_ENABLE_PRIVATE_ATTESTATION=true` is set after GitHub attestation support is enabled
 - `.github/workflows/release-packages.yml`
   - Changesets version PRs and trusted npm publishing for the curated public subset
-  - disables npm package provenance automatically on private repositories because npm only accepts provenance from public GitHub repositories
+  - enables npm package provenance automatically when the repository is public
+  - falls back to trusted publishing without provenance when the repository is private because npm only accepts provenance from public GitHub repositories
 
 ## What It Does
 - installs dependencies

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -4,7 +4,7 @@ AgentForge currently supports local/manual agent plugins only. There is no remot
 
 ## Package Shape
 
-Start from [examples/custom-agent-template/README.md](/Users/ethan/Repo/AgentOps/examples/custom-agent-template/README.md).
+Start from [examples/custom-agent-template/README.md](../examples/custom-agent-template/README.md).
 
 Your local plugin package should export a `RuntimeAgent` through one of these shapes:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -19,6 +19,6 @@ pnpm pack:public
 pnpm release:verify
 ```
 
-For the GitHub CI wrapper and PR/issue reporting flow, see [docs/github-actions.md](/Users/ethan/Repo/AgentOps/docs/github-actions.md).
-For the Phase 1 security posture and build provenance approach, see [docs/security-model.md](/Users/ethan/Repo/AgentOps/docs/security-model.md) and [docs/release-trust.md](/Users/ethan/Repo/AgentOps/docs/release-trust.md).
-For contributor workflow and extension authoring, start with [CONTRIBUTING.md](/Users/ethan/Repo/AgentOps/CONTRIBUTING.md), [docs/agent-manifest-guide.md](/Users/ethan/Repo/AgentOps/docs/agent-manifest-guide.md), and [docs/plugin-author-guide.md](/Users/ethan/Repo/AgentOps/docs/plugin-author-guide.md).
+For the GitHub CI wrapper and PR/issue reporting flow, see [docs/github-actions.md](./github-actions.md).
+For the Phase 1 security posture and build provenance approach, see [docs/security-model.md](./security-model.md) and [docs/release-trust.md](./release-trust.md).
+For contributor workflow and extension authoring, start with [CONTRIBUTING.md](../CONTRIBUTING.md), [docs/agent-manifest-guide.md](./agent-manifest-guide.md), and [docs/plugin-author-guide.md](./plugin-author-guide.md).

--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -43,7 +43,7 @@ It is designed to:
 
 This workflow should not fall back to a long-lived npm token. If npm trusted publishing is not configured yet, keep the workflow gated and fix the external setup first.
 
-For public repositories, `release-packages.yml` also enables npm package provenance automatically. For private repositories, it disables npm provenance automatically while keeping trusted publishing enabled, because npm currently rejects sigstore provenance bundles from private GitHub repositories.
+`release-packages.yml` enables npm package provenance automatically when the repository is public. If the repository is private, it falls back to trusted publishing without npm provenance because npm currently rejects sigstore provenance bundles from private GitHub repositories.
 
 AgentForge does not store npm credentials in repo config. Codex-assisted npm setup depends on machine-level npm auth on the workstation, typically through `npm login` writing `~/.npmrc`.
 
@@ -64,7 +64,7 @@ Use the CLI to separate guidance from verification:
 
 `.github/workflows/release-provenance.yml` remains useful even when package publishing is active. It attests the build artifact for the full workspace so reviewers can inspect a reproducible CI build independent of npm publication.
 
-For private repositories, artifact attestation is skipped unless the repository or organization enables it and sets `AGENTFORGE_ENABLE_PRIVATE_ATTESTATION=true`.
+When the repository is public, `release-provenance.yml` attests the build artifact by default. If the repository is private, artifact attestation is skipped unless the repository or organization enables it and sets `AGENTFORGE_ENABLE_PRIVATE_ATTESTATION=true`.
 
 ## Prerequisites
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,23 @@
   "name": "agentforge",
   "private": true,
   "version": "0.1.0",
+  "description": "AgentForge monorepo for secure-by-default, repo-first software engineering workflows.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git"
+  },
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "agentic-workflows",
+    "developer-tools",
+    "github-actions",
+    "policy-engine"
+  ],
   "type": "module",
   "packageManager": "pnpm@10.6.1",
   "scripts": {

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@h9-foundry/agentforge-audit",
   "version": "0.3.1",
+  "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git",
+    "directory": "packages/audit"
+  },
+  "homepage": "https://github.com/H9-Foundry/AgentForge/tree/main/packages/audit#readme",
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "audit",
+    "reports",
+    "security",
+    "workflows"
+  ],
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@h9-foundry/agentforge-cli",
   "version": "0.3.1",
+  "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://github.com/H9-Foundry/AgentForge/tree/main/packages/cli#readme",
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "cli",
+    "developer-tools",
+    "repo-automation",
+    "workflows"
+  ],
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
   "version": "0.3.1",
+  "description": "Repository and execution context collection for AgentForge workflows.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git",
+    "directory": "packages/context-engine"
+  },
+  "homepage": "https://github.com/H9-Foundry/AgentForge/tree/main/packages/context-engine#readme",
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "context",
+    "git",
+    "repository-analysis",
+    "workflows"
+  ],
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
   "version": "0.3.1",
+  "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git",
+    "directory": "packages/policy-engine"
+  },
+  "homepage": "https://github.com/H9-Foundry/AgentForge/tree/main/packages/policy-engine#readme",
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "policy",
+    "security",
+    "redaction",
+    "trust"
+  ],
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
   "version": "0.3.1",
+  "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git",
+    "directory": "packages/runtime"
+  },
+  "homepage": "https://github.com/H9-Foundry/AgentForge/tree/main/packages/runtime#readme",
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "runtime",
+    "workflows",
+    "orchestration",
+    "policy"
+  ],
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
   "version": "0.3.1",
+  "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git",
+    "directory": "packages/schemas"
+  },
+  "homepage": "https://github.com/H9-Foundry/AgentForge/tree/main/packages/schemas#readme",
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "schemas",
+    "zod",
+    "types",
+    "workflows"
+  ],
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
   "version": "0.3.1",
+  "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git",
+    "directory": "packages/sdk"
+  },
+  "homepage": "https://github.com/H9-Foundry/AgentForge/tree/main/packages/sdk#readme",
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "sdk",
+    "agents",
+    "adapters",
+    "typescript"
+  ],
   "type": "module",
   "publishConfig": {
     "access": "public"

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,25 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
   "version": "0.3.1",
+  "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
+  "license": "MIT",
+  "author": "H9 Foundry",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/H9-Foundry/AgentForge.git",
+    "directory": "packages/shared-types"
+  },
+  "homepage": "https://github.com/H9-Foundry/AgentForge/tree/main/packages/shared-types#readme",
+  "bugs": {
+    "url": "https://github.com/H9-Foundry/AgentForge/issues"
+  },
+  "keywords": [
+    "agentforge",
+    "typescript",
+    "types",
+    "contracts",
+    "schemas"
+  ],
   "type": "module",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Closes #33

## Summary
- add MIT licensing and public package metadata
- clean public docs links and public-first release wording
- prepare a patch changeset to verify the public provenance path after the repo visibility switch

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `pnpm pack:public`
- `pnpm release:verify`