### PR TITLE
Fix checks for bot-created release PRs

### DIFF
--- a/.github/workflows/agentforge-pr-review.yml
+++ b/.github/workflows/agentforge-pr-review.yml
@@ -6,6 +6,10 @@ env:
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       workflow_name:
@@ -24,6 +28,17 @@ permissions:
 
 jobs:
   pr-review:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request' &&
+        !startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+      )
     runs-on: ubuntu-latest
     env:
       AGENTFORGE_WORKFLOW_NAME: ${{ github.event.inputs.workflow_name || 'pr-review' }}
@@ -33,6 +48,8 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4.4.0

--- a/.github/workflows/publish-gate.yml
+++ b/.github/workflows/publish-gate.yml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, synchronize, reopened]
 
 permissions:
   contents: read
@@ -14,12 +18,25 @@ env:
 
 jobs:
   validate-public-packages:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event_name == 'pull_request' &&
+        !startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        startsWith(github.event.pull_request.head.ref, 'changeset-release/')
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
         uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4.4.0

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -7,6 +7,7 @@ AgentForge includes a GitHub Actions wrapper for the starter `pr-review` workflo
 - `.github/workflows/agentforge-pr-review.yml`
   - pull request and manual workflow execution
   - comments on PRs and the configured tracker issue
+  - validates bot-created `changeset-release/*` version PRs through a same-repo `pull_request_target` path so protected-branch checks still attach to Changesets release PRs
 - `.github/workflows/release-provenance.yml`
   - build artifact provenance for the workspace
   - attests the workspace build artifact by default when the repository is public
@@ -23,6 +24,7 @@ AgentForge includes a GitHub Actions wrapper for the starter `pr-review` workflo
 - uploads the JSON bundle and markdown summary as workflow artifacts
 - appends the run summary to the GitHub Actions step summary
 - comments on the pull request when triggered by `pull_request`
+- comments on bot-created `changeset-release/*` release PRs when triggered through the same-repo `pull_request_target` path
 - comments on the configured tracker issue so GitHub issues remain the planning source of truth
 
 ## Permissions
@@ -32,6 +34,8 @@ AgentForge includes a GitHub Actions wrapper for the starter `pr-review` workflo
 - `id-token: write` for release provenance and trusted publishing workflows
 
 The repository workflows are configured for the Node 24 JavaScript action runtime transition. Trusted publishing should continue using GitHub OIDC instead of a long-lived npm token.
+
+For release PR validation, AgentForge uses `pull_request_target` only for same-repository `changeset-release/*` branches and checks out the PR head SHA with persisted credentials disabled. Human-authored PRs continue to use the standard `pull_request` path.
 
 ## Tracker Issue
 - The default tracker issue is `#1`


### PR DESCRIPTION
Closes #42

## Summary
- add a same-repo `pull_request_target` validation path for `changeset-release/*` PRs
- keep ordinary PRs on the existing `pull_request` path
- document the release PR validation path in the GitHub Actions docs

## Verification
- workflow logic reviewed for non-duplicate execution
- PR checks on this branch will validate the normal human PR path
