### PR TITLE
Document maintainer signing and verify signed-commit flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 3. Keep changes scoped to the package, agent, adapter, or doc surface you are modifying.
 4. Update tests and documentation when behavior or public contracts change.
 5. If you touch public packages or release automation, also run `pnpm pack:public` and `pnpm release:verify`.
+6. Maintainers should use signed commits for normal repo work. See [docs/maintainer-signing.md](docs/maintainer-signing.md).
 
 ## Planning And Tracking
 
@@ -36,3 +37,4 @@
 - Explain the change in the relevant GitHub issue.
 - Note any unverified behavior or residual risks.
 - Prefer small reviewable slices over broad mixed changes.
+- If you are a maintainer, confirm your commits show as `Verified` on GitHub before merging changes intended to satisfy issue `#40`.

--- a/docs/maintainer-signing.md
+++ b/docs/maintainer-signing.md
@@ -1,0 +1,110 @@
+# Maintainer Signing
+
+AgentForge maintainers use SSH commit signing through 1Password.
+
+## Expected Local Configuration
+
+The canonical local Git settings are:
+
+```bash
+git config --global gpg.format ssh
+git config --global gpg.ssh.program /Applications/1Password.app/Contents/MacOS/op-ssh-sign
+git config --global user.signingkey "ssh-rsa AAAA..."
+git config --global commit.gpgsign true
+```
+
+Maintain your normal `user.name` and `user.email` settings separately. GitHub must recognize the SSH signing key for commits to show as `Verified`.
+
+If you also want local SSH signature verification through `git log --show-signature`, configure `gpg.ssh.allowedSignersFile` separately. That local verification file is optional for GitHub’s `Verified` status.
+
+## Normal Maintainer Workflow
+
+Use signed commits for normal branch work and pull requests. Do not disable signing for regular maintainer changes.
+
+Recommended flow:
+
+```bash
+git checkout -b codex/example-change
+# edit files
+git add <files>
+git commit -m "Describe the change"
+git push -u origin codex/example-change
+```
+
+Open a pull request and confirm GitHub shows the commit as `Verified`.
+
+## Rebase And Cherry-Pick Recovery
+
+The most common failure during terminal automation is not the signer itself. It is Git trying to open an editor during `rebase --continue` in a noninteractive environment.
+
+For maintainer rebases or cherry-picks driven from a terminal automation flow, use:
+
+```bash
+git -c core.editor=: rebase --continue
+```
+
+This keeps commit signing enabled while avoiding the editor prompt that blocks noninteractive rebases.
+
+If you need to continue a cherry-pick in the same kind of environment, the same pattern applies:
+
+```bash
+git -c core.editor=: cherry-pick --continue
+```
+
+## Troubleshooting
+
+### Editor Or Terminal Problem
+
+Symptoms:
+
+- `Terminal is dumb, but EDITOR unset`
+- `Waiting for your editor to close the file...`
+
+Meaning:
+
+- Git is trying to open an editor for the rebased commit message
+- this is not evidence that SSH signing is broken
+
+Fix:
+
+- rerun with `git -c core.editor=: rebase --continue`
+
+### Genuine Signer Failure
+
+Symptoms:
+
+- `1Password: agent returned an error`
+- `fatal: failed to write commit object`
+
+Meaning:
+
+- the SSH signing agent did not complete the signature request
+
+Checks:
+
+- confirm 1Password is unlocked
+- confirm the Git SSH signing key is still available in 1Password
+- retry a plain signed commit in a disposable temp repo before changing repo policy
+
+### Local Verification File Missing
+
+Symptoms:
+
+- `gpg.ssh.allowedSignersFile needs to be configured and exist for ssh signature verification`
+- `git log --show-signature` reports `No signature` or status `N` locally even though the commit was signed
+
+Meaning:
+
+- the commit may still be validly signed
+- local Git cannot verify SSH signatures without an allowed signers file
+
+Fix:
+
+- treat GitHub’s `Verified` badge as the repo-level source of truth
+- configure `gpg.ssh.allowedSignersFile` separately only if you want local SSH signature verification
+
+### Acceptable Temporary Exceptions
+
+For disposable local test repos or automated fixture repos, `--no-gpg-sign` is acceptable when the goal is only to create scratch commits for tests.
+
+Do not use `--no-gpg-sign` for normal AgentForge maintainer work once required signed commits are enabled on `main`.

--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -36,7 +36,7 @@ Until AgentForge has a second active maintainer, `main` should stay protected wi
 - require a changeset whenever public packages change
 - prefer no-op direct pushes to `main`; use pull requests even for maintainer-owned release work
 - keep `require_code_owner_reviews` disabled until another maintainer or reviewer identity exists
-- keep required signed commits deferred until local signing is stable end to end
+- use signed maintainer commits as the intended steady state and track the branch-protection cutover in issue `#40`
 
 Use this lightweight release checklist for solo releases:
 
@@ -45,6 +45,7 @@ Use this lightweight release checklist for solo releases:
 - required PR checks are green
 - no blocking security or Dependabot alerts are open
 - `Release Packages` succeeded on `main`
+- maintainer commits for release-related PRs are signed and visible as `Verified`
 
 ## Trusted Publishing
 


### PR DESCRIPTION
Refs #40

## Summary
- add a maintainer signing runbook for SSH signing through 1Password
- update contributor and release docs to describe signed commits as the intended maintainer end state
- use this PR as the GitHub verification artifact for a signed maintainer commit before enabling required signed commits on main

## Local verification
- plain signed commit succeeds in a disposable temp repo
- conflict-resolution rebase succeeds with `git -c core.editor=: rebase --continue`
- local `git log --show-signature` still needs an optional `gpg.ssh.allowedSignersFile`, which is now documented
