### PR TITLE
Reposition AgentForge around an SDLC platform roadmap

### DIFF
--- a/.agentops/agentops.yaml
+++ b/.agentops/agentops.yaml
@@ -9,4 +9,4 @@ providers:
   default: disabled
 reporting:
   github:
-    tracker_issue: 1
+    tracker_issue: 45

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,27 @@
+---
+name: Bug
+about: Report incorrect, unsafe, or regressed behavior.
+title: "[Bug] "
+labels: ["type: bug", "status: ready"]
+assignees: []
+---
+
+## Problem / Motivation
+
+## Expected Behavior
+
+## Actual Behavior
+
+## Scope / Impact
+
+## Reproduction Notes
+
+## Acceptance Criteria
+
+- [ ]
+
+## Dependencies
+
+## Suggested Labels
+
+## Suggested Milestone

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Platform vision and roadmap
+    url: https://github.com/H9-Foundry/AgentForge/blob/main/docs/PLATFORM_VISION.md
+    about: Read the current platform framing before opening broad roadmap work.
+  - name: Issue taxonomy
+    url: https://github.com/H9-Foundry/AgentForge/blob/main/docs/ISSUE_TAXONOMY.md
+    about: Use the documented labels, milestones, and issue structure when proposing work.

--- a/.github/ISSUE_TEMPLATE/docs-proposal.md
+++ b/.github/ISSUE_TEMPLATE/docs-proposal.md
@@ -1,0 +1,25 @@
+---
+name: Docs / Proposal
+about: Propose documentation, positioning, planning, or design work.
+title: "[Docs/Proposal] "
+labels: ["type: docs", "status: needs-design"]
+assignees: []
+---
+
+## Problem / Motivation
+
+## Desired Outcome
+
+## Proposed Scope
+
+## Non-Goals
+
+## Acceptance Criteria
+
+- [ ]
+
+## Dependencies
+
+## Suggested Labels
+
+## Suggested Milestone

--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,25 @@
+---
+name: Epic
+about: Track a multi-slice workstream or roadmap domain.
+title: "[Epic] "
+labels: ["type: epic", "status: needs-design"]
+assignees: []
+---
+
+## Problem / Motivation
+
+## Desired Outcome
+
+## Proposed Scope
+
+## Non-Goals
+
+## Acceptance Criteria
+
+- [ ]
+
+## Dependencies
+
+## Suggested Labels
+
+## Suggested Milestone

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,25 @@
+---
+name: Feature
+about: Propose or track a bounded implementation slice.
+title: "[Feature] "
+labels: ["type: feature", "status: ready"]
+assignees: []
+---
+
+## Problem / Motivation
+
+## Desired Outcome
+
+## Proposed Scope
+
+## Non-Goals
+
+## Acceptance Criteria
+
+- [ ]
+
+## Dependencies
+
+## Suggested Labels
+
+## Suggested Milestone

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+## Related Issue
+
+## What Changed
+
+## Validation
+
+- [ ] `pnpm lint`
+- [ ] `pnpm test`
+- [ ] `pnpm typecheck`
+- [ ] `pnpm build`
+
+## Additional Validation
+
+- [ ] `pnpm build:packages` if public packages or package builds changed
+- [ ] `pnpm pack:public` and `pnpm release:verify` if release or package metadata changed
+
+## Risks / Deferred Work
+
+## Checklist
+
+- [ ] docs updated if behavior, roadmap, or contributor workflow changed
+- [ ] issue state updated to match the implementation
+- [ ] no capability claims were added for unimplemented workflows or integrations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,40 +1,67 @@
 # Contributing
 
-## Development Workflow
+AgentForge is an open-source SDLC workflow platform core with a deliberately narrow current implementation wedge. Contributions should preserve that honesty: improve what exists, extend roadmap work explicitly, and avoid claiming lifecycle coverage that has not been implemented.
 
-1. Install dependencies with `pnpm install`.
-2. Run `pnpm lint`, `pnpm test`, `pnpm typecheck`, `pnpm build`, and `pnpm build:packages` before proposing changes.
-3. Keep changes scoped to the package, agent, adapter, or doc surface you are modifying.
-4. Update tests and documentation when behavior or public contracts change.
-5. If you touch public packages or release automation, also run `pnpm pack:public` and `pnpm release:verify`.
-6. Maintainers should use signed commits for normal repo work. See [docs/maintainer-signing.md](docs/maintainer-signing.md).
+## Start Here
+
+- read [README.md](README.md)
+- read [docs/PLATFORM_VISION.md](docs/PLATFORM_VISION.md)
+- read [docs/ROADMAP.md](docs/ROADMAP.md)
+- read [docs/ISSUE_TAXONOMY.md](docs/ISSUE_TAXONOMY.md)
+- read [docs/github-issue-source-of-truth.md](docs/github-issue-source-of-truth.md)
 
 ## Planning And Tracking
 
-- GitHub issues are the planning and progress source of truth.
-- Update the active issue before closing substantial work.
-- Record deferred work as follow-up issues instead of burying it in TODO comments.
+- GitHub Issues are the planning and progress source of truth.
+- Use the issue templates under `.github/ISSUE_TEMPLATE/`.
+- Match work to the correct roadmap milestone.
+- Use the documented label taxonomy for type, area, priority, and status.
+- Open an epic when work spans multiple packages, workflows, or phases.
+- Open a feature issue for bounded implementation slices.
+- Record deferred work as follow-up issues instead of hiding it in TODO comments.
+
+## Development Workflow
+
+1. Install dependencies with `pnpm install`.
+2. Create or link the relevant GitHub issue before broad work.
+3. Keep changes scoped to the package, workflow, adapter, or doc surface you are modifying.
+4. Update tests and documentation when behavior or public contracts change.
+5. Run `pnpm lint`, `pnpm test`, `pnpm typecheck`, and `pnpm build` before proposing changes.
+6. If you touch public packages or release automation, also run `pnpm build:packages`, `pnpm pack:public`, and `pnpm release:verify`.
+7. Maintainers should use signed commits for normal repo work. See [docs/maintainer-signing.md](docs/maintainer-signing.md).
 
 ## Repository Structure
 
-- `packages/*`: contracts, runtime, CLI, and shared infrastructure
-- `agents/*`: official starter agents
-- `adapters/*`: policy-aware tool wrappers
-- `.agentops/*`: starter runtime config and workflows
-- `docs/*`: architecture, policy, security, and contributor guides
+- `packages/*`: public runtime, policy, context, audit, schema, SDK, and CLI packages
+- `agents/*`: official in-repo starter agents
+- `adapters/*`: internal starter adapters with policy-aware mediation
+- `.agentops/*`: starter local config and workflow assets
+- `docs/*`: platform, roadmap, architecture, policy, security, and contributor guides
 - `examples/*`: sample repositories and extension templates
 
 ## Safety Expectations
 
-- Keep execution read-only by default.
-- Do not bypass policy evaluation, approval gates, or blocked-path checks.
-- Treat repository content and external text as untrusted input.
-- Keep schemas and manifests explicit when extending runtime behavior.
-- Local agent plugins must be registered in `.agentops/agentops.yaml` and pass the current policy trust rules before they execute.
+- keep execution read-only by default
+- do not bypass policy evaluation, approval gates, blocked-path checks, or trust enforcement
+- treat repository content and external text as untrusted input
+- keep schemas and manifests explicit when extending runtime behavior
+- local agent plugins must be registered in `.agentops/agentops.yaml` and pass the current policy trust rules before they execute
+
+## Roadmap Hygiene
+
+- use `Platform Phase 1` through `Platform Phase 4` milestones for new roadmap work
+- keep labels consistent with [docs/ISSUE_TAXONOMY.md](docs/ISSUE_TAXONOMY.md)
+- update roadmap docs when the platform direction materially changes
+- avoid merging broad planning changes without updating both the docs and the GitHub issue state
 
 ## Before Opening A Pull Request
 
-- Explain the change in the relevant GitHub issue.
-- Note any unverified behavior or residual risks.
-- Prefer small reviewable slices over broad mixed changes.
-- If you are a maintainer, confirm your commits show as `Verified` on GitHub before merging changes intended to satisfy issue `#40`.
+- explain the change in the relevant GitHub issue
+- note any unverified behavior or residual risks
+- prefer small reviewable slices over broad mixed changes
+- use the pull request template
+- if you are a maintainer, confirm your commits show as `Verified` on GitHub
+
+## Help
+
+If you are unsure whether work belongs in the current implementation, the near-term roadmap, or the longer-term platform vision, open a docs/proposal issue first and link it to the appropriate roadmap milestone.

--- a/README.md
+++ b/README.md
@@ -1,48 +1,100 @@
 # AgentForge
 
-AgentForge is an open-source, secure-by-default, repo-first runtime for software engineering workflows. The initial delivery target is a runnable local PR-review slice that feels more like GitHub Actions for engineering agents than a chat assistant.
+AgentForge is an open-source, secure-by-default SDLC workflow platform core for repository-aware software engineering automation.
 
-## Phase 1 Scope
-- TypeScript monorepo with explicit package boundaries
-- Contract-first schemas and shared types
-- Context engine and policy engine v1
-- Deterministic workflow runtime with constrained reasoning hooks
-- Safe adapters for git, filesystem, shell, and minimal GitHub integration stubs
-- CLI commands for `init`, `scan`, `run`, and `explain last-run`
-- Official starter workflow and starter agents
+It is workflow-first, not chat-first: workflows define the job, policy defines what is allowed, the runtime decides what executes, tools perform the work, and humans approve side effects when required.
 
-## Workspace Layout
-- `packages/*`: core runtime, contracts, CLI, SDK, and support packages
-- `agents/*`: official starter agents
-- `adapters/*`: policy-aware tool wrappers
-- `docs/`: architecture and workflow notes
-- `examples/`: starter fixture repositories and config examples
-- `.agentops/`: runtime config, workflow definitions, and generated run artifacts
+## Project Definition
 
-## Development
-```bash
-pnpm install
-pnpm lint
-pnpm typecheck
-pnpm test
-pnpm build
-pnpm build:packages
-```
+AgentForge provides the runtime, policy, context, audit, and packaging foundation for software engineering workflows that need to reason over a repository without abandoning deterministic controls. The current product wedge is a local, repo-first `pr-review` workflow that demonstrates the model end to end.
 
-Use the packaged CLI for local workflow and release-shape checks:
+## Problem Statement
 
-```bash
-node packages/cli/dist/bin.js init
-node packages/cli/dist/bin.js run pr-review
-node packages/cli/dist/bin.js explain last-run
-node packages/cli/dist/bin.js release guide
-node packages/cli/dist/bin.js release check --json
-node packages/cli/dist/bin.js release verify --json
-```
+Most engineering automation is split between brittle scripted CI, loosely governed chat assistants, and bespoke internal tooling. That leaves teams with three recurring problems:
 
-## Release Surface
+- too much implicit trust in unstructured LLM output
+- too much context passed to tools and models
+- too little auditability around what was read, proposed, blocked, or executed
 
-Curated public packages:
+AgentForge exists to make software engineering workflows safer to automate by default while still leaving room for bounded reasoning where it adds value.
+
+## Why This Is Useful
+
+- Keep workflow definitions explicit and reviewable.
+- Keep the runtime deterministic before agentic behavior is introduced.
+- Keep policies authoritative over tools, manifests, and workflow requests.
+- Keep side effects approval-gated instead of silently happening inside prompts or tool wrappers.
+- Keep artifacts, redactions, trust metadata, and run summaries auditable.
+- Keep the architecture extensible through plugins without defaulting to a plugin free-for-all.
+
+## Current Status And Maturity
+
+AgentForge is an early open-source platform core, not a complete end-to-end SDLC platform yet.
+
+### Available Now
+
+- secure-by-default runtime, policy, context, audit, and schema foundation
+- one official local workflow slice: `.agentops/workflows/pr-review.yaml`
+- official starter agents for context collection, security audit, code review, and test generation
+- internal starter adapters for filesystem, git, shell, and GitHub-aware mediation
+- public npm packages for the runtime core, CLI, contracts, and audit surfaces
+- GitHub Actions release automation, trusted publishing, and package verification tooling
+- local/manual plugin registration with policy-based trust enforcement
+
+### In Progress
+
+- platform narrative, roadmap, and SDLC planning hygiene
+- broader workflow coverage across planning, design, build, QA, security, release, operations, and maintenance
+- clearer support matrix for workflows, agents, adapters, environments, and integrations
+
+### Planned
+
+- broader official workflow catalog across the SDLC
+- expanded policy, schema, and runtime interaction model
+- richer GitHub integration plus additional SCM/CI adapters
+- plugin ecosystem and registry-facing surfaces
+- evals, benchmarks, and compatibility guarantees
+- enterprise governance, tenancy, and scale-oriented controls
+
+## SDLC Lifecycle Coverage
+
+| SDLC Domain | Status | Notes |
+| --- | --- | --- |
+| Plan / intake / discovery | Planned | Not implemented yet; currently represented only in roadmap and issue backlog. |
+| Architecture / design | Planned | No official workflow yet. |
+| Build / implementation | Planned | No implementation workflow yet beyond secure runtime scaffolding. |
+| Review / test / QA | Available now | The `pr-review` wedge covers review, security audit, and proposed test-generation outputs. |
+| Security / compliance / DevSecOps | Partial | Policy, trust, redaction, and audit exist; broader security workflows are planned. |
+| Release / CI/CD | Partial | Release verification and package publishing exist; broader CI/CD workflow coverage is planned. |
+| Operate / incidents / observability handoff | Planned | Not implemented yet. |
+| Maintain / upgrades / docs hygiene | Partial | Release hygiene and dependency maintenance are present; dedicated workflows are planned. |
+
+See [docs/SDLC_COVERAGE.md](docs/SDLC_COVERAGE.md) for the detailed lifecycle map and [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md) for the current support matrix.
+
+## Architecture Summary
+
+AgentForge follows a strict separation of concerns:
+
+- **LLMs reason** when a workflow node explicitly permits bounded reasoning.
+- **The runtime decides** workflow sequencing, tool mediation, and audit capture.
+- **Tools execute** only through explicit adapters with schemas and side-effect classifications.
+- **Policy permits** reads, writes, network, paths, and tools.
+- **Humans approve side effects** when policy or runtime requires it.
+
+Current runtime flow:
+
+1. The CLI loads `.agentops` configuration, policy, and workflow definition.
+2. The context engine builds a normalized repository-aware state envelope.
+3. The policy engine resolves the effective policy snapshot.
+4. The runtime executes ordered workflow nodes with minimal context slices.
+5. Adapters are invoked only after policy mediation.
+6. Audit bundles and summaries are written under `.agentops/runs/<run-id>/`.
+
+See [docs/architecture.md](docs/architecture.md), [docs/runtime-model.md](docs/runtime-model.md), [docs/policy-model.md](docs/policy-model.md), and [docs/security-model.md](docs/security-model.md).
+
+## Package And Workspace Overview
+
+### Public Packages
 
 - `@h9-foundry/agentforge-cli`
 - `@h9-foundry/agentforge-schemas`
@@ -53,29 +105,96 @@ Curated public packages:
 - `@h9-foundry/agentforge-runtime`
 - `@h9-foundry/agentforge-audit`
 
-Internal workspace packages remain private until their APIs stabilize.
+### Internal Workspace Surfaces
 
-## Release Bootstrap
+- `packages/registry-client`: future registry-facing surface, not a production registry integration yet
+- `agents/*`: official starter agents shipped in-repo
+- `adapters/*`: internal starter adapters with explicit side-effect classes and policy mediation
+- `.agentops/*`: starter config and workflow assets
+- `examples/*`: starter repositories and extension examples
 
-Package publishing uses GitHub OIDC trusted publishing for `@h9-foundry/agentforge-*`.
+Internal packages remain private until their APIs stabilize and their support expectations are documented.
 
-- Run `npm login` once on the workstation that Codex uses. The CLI expects machine-level auth in `~/.npmrc`.
-- Use `agentforge release guide` for the external npm bootstrap steps and reference URLs.
-- Use `agentforge release check --json` to validate npm auth, package metadata, release workflow config, Changesets config, and local release-shape checks.
-- Use `agentforge release verify --json` before the first publish to validate packed tarballs from a clean-room consumer install.
+## Quickstart
 
-## Security And Release Notes
+Install and build the workspace:
 
-- [SECURITY.md](./SECURITY.md)
-- [docs/security-model.md](./docs/security-model.md)
-- [docs/release-trust.md](./docs/release-trust.md)
-- [docs/github-actions.md](./docs/github-actions.md)
+```bash
+pnpm install
+pnpm build
+pnpm build:packages
+```
 
-## Contributor And Extension Guides
+Initialize local config and run the current official workflow slice:
 
-- [CONTRIBUTING.md](./CONTRIBUTING.md)
-- [docs/runtime-model.md](./docs/runtime-model.md)
-- [docs/policy-model.md](./docs/policy-model.md)
-- [docs/agent-manifest-guide.md](./docs/agent-manifest-guide.md)
-- [docs/plugin-author-guide.md](./docs/plugin-author-guide.md)
-- [examples/README.md](./examples/README.md)
+```bash
+node packages/cli/dist/bin.js init
+node packages/cli/dist/bin.js scan
+node packages/cli/dist/bin.js run pr-review
+node packages/cli/dist/bin.js explain last-run
+```
+
+Release tooling:
+
+```bash
+node packages/cli/dist/bin.js release guide
+node packages/cli/dist/bin.js release check --json
+node packages/cli/dist/bin.js release verify --json
+```
+
+See [docs/quickstart.md](docs/quickstart.md) for a more explicit walkthrough.
+
+## Examples
+
+- [examples/README.md](examples/README.md)
+- [examples/sample-repo/README.md](examples/sample-repo/README.md)
+- [examples/custom-agent-template/README.md](examples/custom-agent-template/README.md)
+
+## Security And Trust Model
+
+AgentForge is intentionally conservative:
+
+- read-only by default
+- network denied by default
+- writes require approval
+- blocked paths win over broader allow rules
+- policy decisions override workflow intent and adapter capability
+- approval-gated tools are blocked before execution
+- run outputs are structured, redacted, and auditable
+- plugin trust metadata is validated against policy before execution
+
+See [SECURITY.md](SECURITY.md), [docs/security-model.md](docs/security-model.md), [docs/release-trust.md](docs/release-trust.md), and [docs/plugin-author-guide.md](docs/plugin-author-guide.md).
+
+## Roadmap Summary
+
+AgentForge is moving from a single secure `pr-review` wedge toward a broader SDLC workflow platform core.
+
+- **Platform Foundation:** strengthen runtime, policy, schema, and platform framing
+- **General SDLC Expansion:** add workflow support across planning, design, build, QA, security, release, operations, and maintenance
+- **Ecosystem And Plugins:** improve adapters, plugin surfaces, and registry-facing workflows
+- **Enterprise / Governance / Scale:** add compatibility, governance, and scale-oriented controls
+
+Roadmap docs:
+
+- [docs/PLATFORM_VISION.md](docs/PLATFORM_VISION.md)
+- [docs/ROADMAP.md](docs/ROADMAP.md)
+- [docs/SDLC_COVERAGE.md](docs/SDLC_COVERAGE.md)
+- [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md)
+- [docs/GAP_ANALYSIS_GENERAL_SDLC.md](docs/GAP_ANALYSIS_GENERAL_SDLC.md)
+- [docs/ISSUE_TAXONOMY.md](docs/ISSUE_TAXONOMY.md)
+
+## Contributor Entry Points
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [docs/github-issue-source-of-truth.md](docs/github-issue-source-of-truth.md)
+- [docs/agent-manifest-guide.md](docs/agent-manifest-guide.md)
+- [docs/maintainer-signing.md](docs/maintainer-signing.md)
+
+## Issues, Milestones, And Help
+
+- Use GitHub Issues for planning, bugs, features, and proposals.
+- Follow the platform roadmap milestones in the GitHub milestone list.
+- Start with the roadmap docs before proposing broad new workflow claims or integration work.
+- Use the issue templates in `.github/ISSUE_TEMPLATE/` so planning data stays consistent.
+
+If you need help or want to contribute, open an issue in this repository with the relevant template and link it to the appropriate roadmap phase or epic.

--- a/docs/GAP_ANALYSIS_GENERAL_SDLC.md
+++ b/docs/GAP_ANALYSIS_GENERAL_SDLC.md
@@ -1,0 +1,63 @@
+# Gap Analysis: General SDLC Platform
+
+This document explains the gap between the current AgentForge implementation and the broader SDLC platform direction.
+
+## What Already Exists
+
+- secure-by-default runtime core
+- explicit policy engine with read/write/network/tool gating
+- context engine for repository-aware workflow state
+- schema and type packages for shared contracts
+- audit bundle and markdown summary generation
+- public CLI and runtime packages
+- one official local `pr-review` workflow
+- official starter agents for context, security audit, code review, and proposed test generation
+- release verification, trusted publishing, and package validation flow
+- local plugin registration and trust enforcement baseline
+
+## What Is Partial
+
+- GitHub integration exists but is still narrow
+- release automation is mature relative to the rest of the product, but broader CI/CD workflow coverage is not
+- security posture is strong, but security-specific workflow coverage is still thin
+- internal adapters exist, but they are not yet a documented public integration surface
+- the repo has a credible architecture core, but the platform narrative and backlog are still catching up
+
+## What Is Missing
+
+- official workflows for planning, design, build, operations, and maintenance
+- lifecycle-specific agents beyond the PR-review wedge
+- official adapter and integration catalog beyond internal starter adapters
+- evals and benchmark framework
+- compatibility commitments and support matrix discipline
+- richer SCM/CI and observability integrations
+- enterprise governance and scale surfaces
+
+## What Should Be Phase 2
+
+- broaden from `pr-review` to adjacent SDLC workflow slices
+- expand runtime interaction contracts for more workflow shapes
+- expand policy and schemas to support lifecycle-specific workflows
+- mature GitHub integration and release/CI workflow support
+- add explicit support matrix and compatibility work
+
+## What Should Be Postponed
+
+- plugin marketplace or broad registry claims before trust and lifecycle rules are stronger
+- enterprise governance features before the workflow/runtime core is proven across more SDLC domains
+- broad multi-tenant or hosted claims before lifecycle support and compatibility are clearer
+
+## What Should Not Be Built Yet
+
+- unrestricted shell or network execution paths
+- generic “agent can do anything” workflow layers
+- broad integrations without policy-aware adapter contracts
+- roadmap claims that imply official support where only experiments exist
+
+## Recommended Sequencing
+
+1. finish platform framing, issue taxonomy, and backlog hygiene
+2. harden runtime, policy, and schemas for broader workflow classes
+3. add the next official workflow slices one domain at a time
+4. expand integrations and plugin surfaces only after the workflow core is clearer
+5. layer on compatibility, evals, governance, and scale once the platform wedge is broader

--- a/docs/ISSUE_TAXONOMY.md
+++ b/docs/ISSUE_TAXONOMY.md
@@ -1,0 +1,126 @@
+# Issue Taxonomy
+
+GitHub Issues are the primary planning source of truth for AgentForge.
+
+## Principles
+
+- use issues for active work, decisions, risks, and deferred work
+- keep epics separate from implementation issues
+- keep milestones phase-oriented
+- keep issue status and priority explicit through labels
+- keep docs and issue state aligned
+
+## Milestone Strategy
+
+Use the platform roadmap milestones:
+
+- `Platform Phase 1: Platform Foundation`
+- `Platform Phase 2: General SDLC Expansion`
+- `Platform Phase 3: Ecosystem and Plugins`
+- `Platform Phase 4: Enterprise / Governance / Scale`
+
+Historical implementation milestones can remain for completed foundation work, but new SDLC-platform work should use the platform milestone set.
+
+## Label Families
+
+### Type
+
+- `type: epic`
+- `type: feature`
+- `type: bug`
+- `type: docs`
+- `type: tech-debt`
+
+### Area
+
+- `area: runtime`
+- `area: cli`
+- `area: policy`
+- `area: context`
+- `area: agents`
+- `area: adapters`
+- `area: github`
+- `area: security`
+- `area: docs`
+- `area: evals`
+- `area: plugins`
+- `area: registry`
+- `area: release`
+- `area: observability`
+- `area: workflow`
+
+### Priority
+
+- `priority: p0`
+- `priority: p1`
+- `priority: p2`
+- `priority: p3`
+
+### Status
+
+- `status: blocked`
+- `status: needs-design`
+- `status: ready`
+- `status: in-progress`
+
+## Epic vs Feature Guidance
+
+### Epic
+
+Use an epic when the work:
+
+- spans multiple packages or workflow surfaces
+- needs child issues
+- carries roadmap-level sequencing or risk
+- represents a lifecycle/domain expansion, not just one implementation slice
+
+### Feature
+
+Use a feature when the work:
+
+- is reviewable in one PR or a small set of linked PRs
+- has a bounded output
+- is subordinate to an epic or milestone
+
+### Docs / Proposal
+
+Use a docs/proposal issue when the work is about:
+
+- narrative, documentation, or contributor process
+- design exploration without immediate implementation
+
+### Bug
+
+Use a bug when behavior exists and is incorrect, unsafe, or regressed.
+
+### Tech Debt
+
+Use tech-debt when the work is cleanup or maintenance that improves reliability, clarity, or future delivery without being a user-facing feature.
+
+## Recommended Issue Structure
+
+Each issue should include:
+
+1. **Problem / motivation**
+2. **Desired outcome**
+3. **Proposed scope**
+4. **Non-goals**
+5. **Acceptance criteria**
+6. **Dependencies**
+7. **Suggested labels**
+8. **Suggested milestone**
+
+## Dependency Conventions
+
+- link parent epics from child issues
+- list blocking issues explicitly in a `Dependencies` section
+- update epic tracker checklists as child work lands
+- prefer opening follow-up issues over burying deferred work in comments or TODOs
+
+## Workflow Expectations
+
+- contributors should open or reference an issue before broad implementation work
+- maintainers should keep milestone and status labels current
+- roadmap docs should be updated when milestone shape or platform direction changes
+
+For the operational model behind this taxonomy, see [docs/github-issue-source-of-truth.md](github-issue-source-of-truth.md).

--- a/docs/PLATFORM_VISION.md
+++ b/docs/PLATFORM_VISION.md
@@ -1,0 +1,114 @@
+# Platform Vision
+
+## Positioning
+
+AgentForge is the open-source workflow/runtime core for secure, repository-aware SDLC automation.
+
+It is not trying to become a generic chat shell with tools attached. The platform model is:
+
+- workflows define intent
+- context assembly stays minimal and explicit
+- policy decides what is allowed
+- runtime decides what actually executes
+- tools remain explicit adapters
+- humans approve side effects when policy requires it
+
+## Product Wedge
+
+The current wedge is intentionally narrow:
+
+- one official local `pr-review` workflow
+- one secure-by-default runtime path from config loading through audit output
+- one coherent set of policy, trust, redaction, and release controls
+
+This wedge proves the core operating model before AgentForge expands across the rest of the SDLC.
+
+## Problem Framing
+
+Engineering teams increasingly want automation that can reason about repositories, diffs, policies, and release processes. The current market usually forces a bad tradeoff:
+
+- deterministic CI that is rigid but explainable
+- agentic assistants that are flexible but often under-governed
+
+AgentForge is designed to close that gap by keeping deterministic control around bounded reasoning.
+
+## Core Principles
+
+- workflow-first, not chat-first
+- secure by default
+- read-only by default
+- approval-gated side effects
+- deterministic before agentic
+- minimal context slices
+- structured outputs
+- auditable actions
+- plugin-extensible architecture
+- honest capability boundaries
+
+## Personas
+
+### Maintainers
+
+Need a safe way to automate repository workflows without turning the repo into an unconstrained agent sandbox.
+
+### Platform Engineers
+
+Need reusable runtime, policy, audit, and workflow contracts for internal engineering automation.
+
+### Security And Governance Owners
+
+Need explicit policy gates, trust metadata, redaction, side-effect approvals, and audit bundles that can be inspected after the fact.
+
+### Contributors And Plugin Authors
+
+Need a clear extension surface for workflows, agents, adapters, and plugins without guessing at hidden behavior.
+
+## Near-Term Expansion
+
+AgentForge should expand from the `pr-review` wedge into adjacent SDLC workflows while preserving the same execution model:
+
+- planning and discovery
+- architecture and design review
+- build and implementation assistance
+- review, test, and QA
+- security and compliance
+- release and CI/CD
+- operations and incident response handoff
+- maintenance, upgrades, and documentation hygiene
+
+## Longer-Term Platform Direction
+
+Longer-term platform work is expected to include:
+
+- a broader catalog of official workflows
+- richer official agents and deterministic nodes
+- more SCM/CI and observability adapters
+- stronger evals and benchmarking
+- plugin and registry-facing lifecycle support
+- compatibility matrices and enterprise governance features
+
+These are platform directions, not shipped capabilities today.
+
+## Strategic Boundaries
+
+AgentForge should not:
+
+- weaken policy defaults for convenience
+- treat untrusted repository content as instruction authority
+- hide side effects behind prompts
+- imply support for workflows or integrations that do not exist
+- couple all lifecycle domains into one monolithic package
+
+## Current Reality vs Vision
+
+### Current Reality
+
+- secure workflow runtime core is real
+- policy engine, context engine, schemas, audit, and CLI are real
+- release and publishing hardening are real
+- plugin trust baseline is real
+- lifecycle coverage outside `pr-review` is mostly not built yet
+
+### Platform Vision
+
+Expand the same secure operating model into a general-purpose SDLC automation platform, without abandoning determinism, policy control, or auditability.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,140 @@
+# Roadmap
+
+This roadmap separates current implementation from near-term platform work and longer-term expansion.
+
+## Roadmap Structure
+
+- **Platform Phase 1: Platform Foundation**
+  - clarify product framing
+  - harden runtime, policy, schemas, and interaction contracts
+  - establish planning taxonomy, support matrix, and contribution scaffolding
+- **Platform Phase 2: General SDLC Expansion**
+  - add official workflow support across more lifecycle domains
+  - expand policy and manifest/schema capabilities to support those workflows
+  - mature GitHub and release-oriented automation
+- **Platform Phase 3: Ecosystem And Plugins**
+  - broaden adapters and integration points
+  - strengthen plugin and registry-facing surfaces
+  - add evals and compatibility scaffolding
+- **Platform Phase 4: Enterprise / Governance / Scale**
+  - governance, compatibility, tenancy, observability, and scale-oriented controls
+
+## Current Baseline
+
+The current shipped baseline is:
+
+- secure runtime, policy, context, schema, audit, and CLI core
+- one official local `pr-review` workflow
+- one set of official starter agents
+- internal starter adapters
+- release, package verification, and trusted publishing automation
+
+## Phase 1: Platform Foundation
+
+### Target Outcomes
+
+- AgentForge docs and backlog reflect the broader SDLC platform direction honestly
+- runtime interaction model is ready for broader workflow classes
+- policy and schemas are prepared for lifecycle expansion without relaxing defaults
+- issue taxonomy, milestones, and contributor workflow are coherent
+
+### Major Workstreams
+
+- product and documentation repositioning
+- runtime interaction model hardening
+- policy engine expansion
+- manifest and schema expansion
+- support matrix and compatibility framing
+- contributor and community scaffolding
+
+### Dependencies
+
+- roadmap docs and issue taxonomy should land before broad backlog growth
+- runtime and policy hardening should precede broad new workflow claims
+
+## Phase 2: General SDLC Expansion
+
+### Target Outcomes
+
+- official workflow coverage exists beyond PR review
+- lifecycle-specific agents and deterministic nodes start to emerge
+- GitHub integration matures beyond the current narrow reporting/release path
+
+### Major Workstreams
+
+- planning and discovery workflows
+- architecture and design workflows
+- build and implementation workflows
+- test and QA workflows
+- security and DevSecOps workflows
+- release and CI/CD workflows
+- operations and incident handoff workflows
+- maintenance and dependency/docs workflows
+
+### Dependencies
+
+- relies on Phase 1 schema, runtime, and policy expansion
+- requires clearer support boundaries for official vs planned workflows
+
+## Phase 3: Ecosystem And Plugins
+
+### Target Outcomes
+
+- plugin story becomes more usable without weakening trust enforcement
+- adapters and registry-facing surfaces become more explicit
+- eval and benchmark infrastructure exists to compare workflow quality
+
+### Major Workstreams
+
+- plugin and registry roadmap
+- additional SCM/CI integrations
+- evals and benchmarks
+- compatibility and support matrix expansion
+
+## Phase 4: Enterprise / Governance / Scale
+
+### Target Outcomes
+
+- policy, release trust, compatibility, and observability work support larger organizations
+- governance and operational scale concerns are first-class
+
+### Major Workstreams
+
+- supply-chain and release trust hardening
+- governance and scale controls
+- compatibility commitments
+- observability and operational maturity
+
+## Major Risks
+
+- broadening the platform narrative faster than the implementation
+- weakening security posture in the name of feature coverage
+- creating too many loosely specified workflow promises
+- plugin and integration growth outpacing policy and trust controls
+- roadmap sprawl without a consistent issue taxonomy
+
+## Dependency Map
+
+| Workstream | Depends On |
+| --- | --- |
+| Product repositioning | none |
+| README and docs overhaul | product repositioning |
+| Runtime interaction model hardening | current runtime baseline |
+| Policy engine expansion | current policy baseline |
+| Manifest/schema expansion | runtime and policy direction |
+| Planning/discovery workflows | runtime + policy + schema expansion |
+| Architecture/design workflows | runtime + policy + schema expansion |
+| Build/implementation workflows | runtime + policy + schema expansion |
+| Test/QA workflows | runtime + schema expansion |
+| Security/DevSecOps workflows | policy + audit + adapter expansion |
+| Release/CI-CD workflows | GitHub maturity + trust hardening |
+| Operations/incident workflows | context + adapters + audit maturity |
+| Maintenance workflows | GitHub maturity + workflow catalog growth |
+| Plugin/registry roadmap | trust model + schema expansion |
+| Evals and benchmarks | workflow catalog + support matrix |
+| Additional SCM/CI integrations | adapter model + policy gates |
+| Support matrix and compatibility | roadmap taxonomy + integration visibility |
+
+## Source Of Truth
+
+The roadmap phases are represented in GitHub milestones and issues. The docs in this directory describe intent; GitHub Issues remain the execution source of truth.

--- a/docs/SDLC_COVERAGE.md
+++ b/docs/SDLC_COVERAGE.md
@@ -1,0 +1,82 @@
+# SDLC Coverage
+
+This document describes lifecycle coverage across AgentForge using three honest status markers:
+
+- **Available now**: implemented and shipped in the current repo
+- **In progress**: explicitly targeted in the near-term backlog
+- **Planned**: not implemented yet, but intentionally on the roadmap
+
+## Coverage Map
+
+| Lifecycle Domain | Status | Current Reality | Next Target |
+| --- | --- | --- | --- |
+| Plan / intake / discovery | Planned | No official workflow yet. | Add discovery/intake workflow definitions, schemas, and deterministic context assembly for planning artifacts. |
+| Architecture / design | Planned | No official workflow yet. | Add architecture review/design workflow slice and supporting manifests. |
+| Build / implementation | Planned | No official workflow yet. | Add implementation workflow support with explicit safe-side-effect policies. |
+| Review / test / QA | Available now | `pr-review` workflow with context, security audit, code review, and proposed test generation. | Broaden into dedicated review/test/QA workflow variants. |
+| Security / compliance / DevSecOps | In progress | Policy, redaction, trust metadata, release trust, and audit exist. | Add richer security workflow coverage and security-specific adapters/evals. |
+| Release / CI/CD | In progress | Release verification, trusted publishing, package validation, and GitHub workflows exist. | Add broader release/CI workflow coverage beyond package publishing. |
+| Operate / incident response / observability handoff | Planned | No official workflow yet. | Add incident-handoff and operational context workflows. |
+| Maintain / upgrade / docs / dependency hygiene | In progress | Dependency and release hygiene exist through GitHub workflows and repo maintenance practices. | Add explicit maintenance workflows and docs hygiene automation. |
+
+## Official Workflows
+
+### Available now
+
+- `pr-review`
+  - location: `.agentops/workflows/pr-review.yaml`
+  - purpose: demonstrate secure local repository review with audit output
+
+### In progress
+
+- none shipped yet; roadmap work exists but no official additional workflow assets are committed
+
+### Planned
+
+- planning/discovery
+- architecture/design review
+- build/implementation
+- dedicated test/QA
+- security/DevSecOps
+- release/CI-CD
+- operations/incident handoff
+- maintenance/dependency/docs hygiene
+
+## Official Agents
+
+### Available now
+
+- `context-collector`
+- `security-audit`
+- `code-review`
+- `test-generation`
+
+### Planned expansion areas
+
+- planning/discovery
+- architecture/design
+- implementation/build assistance
+- release coordination
+- incident and operational handoff
+- maintenance and upgrade hygiene
+
+## Official Adapters
+
+### Available now
+
+- filesystem
+- git
+- shell
+- GitHub
+
+### Planned expansion areas
+
+- broader SCM adapters
+- CI system adapters
+- issue/project-system adapters
+- observability and incident-system adapters
+- registry and supply-chain adapters
+
+## Guidance
+
+Do not interpret a lifecycle domain appearing in this document as implemented support. Unless it is listed under **Available now**, it is either roadmap work or a longer-term platform direction.

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -1,0 +1,81 @@
+# Support Matrix
+
+This matrix separates current official support from roadmap intent.
+
+## Maturity Levels
+
+- **Official**: implemented, documented, and treated as current supported surface
+- **Partial**: some supporting infrastructure exists, but the end-user workflow surface is incomplete
+- **Planned**: not implemented yet
+- **Internal**: present in the repository but not yet supported as public surface
+
+## Workflow Support
+
+| Workflow | Maturity | Notes |
+| --- | --- | --- |
+| `pr-review` | Official | The current official workflow wedge. |
+| planning / intake | Planned | Roadmap item only. |
+| architecture / design review | Planned | Roadmap item only. |
+| build / implementation | Planned | Roadmap item only. |
+| test / QA | Planned | The current `pr-review` flow touches QA, but there is no dedicated official QA workflow yet. |
+| security / DevSecOps | Planned | Security controls exist, but not a broader official security workflow family. |
+| release / CI-CD | Planned | Release automation exists, but not as a broader official SDLC workflow family. |
+| operations / incident handoff | Planned | Roadmap item only. |
+| maintenance / dependency/docs hygiene | Planned | Roadmap item only. |
+
+## Agent Support
+
+| Agent | Maturity | Notes |
+| --- | --- | --- |
+| `context-collector` | Official | Current starter agent. |
+| `security-audit` | Official | Current starter agent. |
+| `code-review` | Official | Current starter agent. |
+| `test-generation` | Official | Current starter agent. |
+| planning/discovery agents | Planned | Not implemented yet. |
+| architecture/design agents | Planned | Not implemented yet. |
+| build/implementation agents | Planned | Not implemented yet. |
+| release/operations/maintenance agents | Planned | Not implemented yet. |
+
+## Adapter And Integration Support
+
+| Surface | Maturity | Notes |
+| --- | --- | --- |
+| filesystem adapter | Internal | Used by the runtime, not a separately supported public package. |
+| git adapter | Internal | Used by the runtime, not a separately supported public package. |
+| shell adapter | Internal | Present, but side effects remain tightly constrained by policy. |
+| GitHub adapter | Internal | Current GitHub-aware mediation is narrow and intentionally bounded. |
+| additional SCM integrations | Planned | Not implemented yet. |
+| additional CI integrations | Planned | Not implemented yet. |
+| observability/incident integrations | Planned | Not implemented yet. |
+| registry integrations | Planned | `packages/registry-client` remains a future-facing surface. |
+
+## Package Support
+
+| Package | Maturity | Notes |
+| --- | --- | --- |
+| `@h9-foundry/agentforge-cli` | Official | Public CLI package. |
+| `@h9-foundry/agentforge-schemas` | Official | Public schema contracts. |
+| `@h9-foundry/agentforge-shared-types` | Official | Public inferred TS types. |
+| `@h9-foundry/agentforge-sdk` | Official | Public runtime interfaces. |
+| `@h9-foundry/agentforge-context-engine` | Official | Public context engine package. |
+| `@h9-foundry/agentforge-policy-engine` | Official | Public policy engine package. |
+| `@h9-foundry/agentforge-runtime` | Official | Public runtime package. |
+| `@h9-foundry/agentforge-audit` | Official | Public audit/reporting package. |
+| `packages/registry-client` | Internal | Future-facing registry surface. |
+| `agents/*` | Internal | Official in-repo agents, not yet public packages. |
+| `adapters/*` | Internal | Internal starter adapters, not yet public packages. |
+
+## Environment Support
+
+| Environment | Maturity | Notes |
+| --- | --- | --- |
+| local repository execution | Official | Primary current usage mode. |
+| GitHub-hosted release and validation workflows | Official | Current release automation path. |
+| general CI runtime support | Partial | Some workflow behavior exists in CI, but general CI workflow support is not complete. |
+| hosted multi-tenant service | Planned | Not implemented. |
+
+## Compatibility Notes
+
+- Current support is strongest for local repository execution and GitHub-centric release workflows.
+- Public compatibility commitments are intentionally narrow until broader workflow and integration support exists.
+- Planned support in this matrix should be treated as roadmap direction, not shipped capability.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # AgentForge Architecture
 
-Phase 1 is deliberately narrow: one secure-by-default local workflow slice, with the contracts and guardrails made explicit before broad feature expansion.
+AgentForge is currently an early SDLC platform core with one official workflow wedge: secure local repository review. The architecture is intentionally broader than that single workflow so the platform can expand across more lifecycle domains without abandoning deterministic control.
 
 ## Package Map
 
@@ -11,7 +11,7 @@ Phase 1 is deliberately narrow: one secure-by-default local workflow slice, with
 - `packages/context-engine`
   - repository metadata, git status, diff stats, and workflow state creation
 - `packages/policy-engine`
-  - policy loading, overlay resolution, path gating, tool gating, and redaction
+  - policy loading, overlay resolution, path gating, tool gating, trust evaluation, and redaction
 - `packages/runtime`
   - deterministic workflow orchestration, tool mediation, and audit capture
 - `packages/audit`
@@ -19,22 +19,31 @@ Phase 1 is deliberately narrow: one secure-by-default local workflow slice, with
 - `packages/sdk`
   - runtime interfaces for agents, adapters, and providers
 - `packages/cli`
-  - `init`, `scan`, `run`, and `explain last-run`
+  - current CLI commands for config scaffolding, scanning, workflow execution, explanation, and release verification
+- `packages/registry-client`
+  - future-facing registry surface, not a production registry feature today
 
 ## Runtime Flow
 
 1. The CLI loads `.agentops` config, policy, and workflow definition.
 2. The context engine creates a normalized workflow state envelope from repository and git metadata.
 3. The policy engine resolves the effective local or CI policy.
-4. The runtime executes workflow nodes in order, passing each agent only the context sections it requested.
+4. The runtime executes workflow nodes in order, passing each node only the context sections it requested.
 5. Tool requests are mediated through policy before adapter execution.
 6. Audit data is persisted as JSON and markdown under `.agentops/runs/<run-id>/`.
 
+## Current Official Workflow Surface
+
+- `.agentops/workflows/pr-review.yaml`
+
+That is the only official workflow asset today. Broader workflow coverage belongs to the roadmap, not to the current implementation claim.
+
 ## Extension Surfaces
 
-- `agents/*` are the reasoning or deterministic workflow nodes.
-- `adapters/*` are explicit tool wrappers with schemas, side-effect classes, permissions, and trust metadata.
-- `providers` remain optional in Phase 1 and are disabled by default in the starter flow.
+- `agents/*` are the reasoning or deterministic workflow nodes
+- `adapters/*` are explicit tool wrappers with schemas, side-effect classes, permissions, and trust metadata
+- plugin registration exists locally through `.agentops/agentops.yaml`
+- provider integration remains optional and disabled by default in the starter flow
 
 ## Design Constraints
 
@@ -42,5 +51,10 @@ Phase 1 is deliberately narrow: one secure-by-default local workflow slice, with
 - structured outputs for all agent behavior
 - policy wins over manifests and runtime requests
 - blocked paths and redaction are enforced before artifacts are written
+- approval-gated tools are blocked before execution
 
-For more detail on execution and policy behavior, see [docs/runtime-model.md](./runtime-model.md) and [docs/policy-model.md](./policy-model.md).
+## Architectural Direction
+
+The architecture is intended to support more SDLC workflows over time, but the runtime should only claim support for workflows, agents, adapters, and integrations that are actually present and documented.
+
+For more detail on execution and policy behavior, see [runtime-model.md](runtime-model.md) and [policy-model.md](policy-model.md).

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -38,6 +38,6 @@ The repository workflows are configured for the Node 24 JavaScript action runtim
 For release PR validation, AgentForge uses `pull_request_target` only for same-repository `changeset-release/*` branches and checks out the PR head SHA with persisted credentials disabled. Human-authored PRs continue to use the standard `pull_request` path.
 
 ## Tracker Issue
-- The default tracker issue is `#1`
+- The default tracker issue is the platform tracker `#45`
 - Manual dispatch can override the tracker issue number
-- The local `.agentops/agentops.yaml` template now includes `reporting.github.tracker_issue`
+- The local `.agentops/agentops.yaml` template now includes `reporting.github.tracker_issue: 45`

--- a/docs/github-issue-source-of-truth.md
+++ b/docs/github-issue-source-of-truth.md
@@ -1,31 +1,61 @@
 # GitHub Issues As Source Of Truth
 
-The intended operating model for AgentForge is to track active planning and delivery in GitHub issues rather than only in local markdown files.
+AgentForge uses GitHub Issues as the primary planning and delivery source of truth.
 
-## Issue Structure
-- One umbrella issue for the active phase, including scope, milestones, risks, and links to child issues.
-- One issue per milestone or reviewable implementation slice.
-- Follow-up issues for deferred work discovered during implementation.
+## Operating Model
 
-## Minimum Update Rules
-- Update the umbrella issue when scope, assumptions, or milestone order changes.
-- Update the active implementation issue when code lands or behavior changes.
-- Record tests run, passes, failures, risks, and deferred work in the issue update, not only in local notes.
-- Open a follow-up issue instead of burying deferred work in a code comment or commit message.
+- roadmap intent is documented in `docs/`
+- active execution state lives in GitHub Issues and milestones
+- epics track multi-slice work
+- feature, docs, bug, and tech-debt issues track implementation slices
 
-## Initial Issue Set For Phase 1
-- Phase 1 foundation umbrella
-- Monorepo bootstrap and tooling
-- Shared schemas and typed contracts
-- Context engine v1
-- Policy engine v1
-- Runtime kernel and audit bundle
-- Safe adapters
-- Starter agents and `pr-review` workflow
-- CLI commands and local artifact UX
-- Deferred: GitHub Action integration and PR reporting
+## Required Behaviors
 
-## Current Implementation
-- Phase 1 issue structure is now seeded in GitHub.
-- The repository includes a GitHub Actions workflow that can comment on pull requests and update the tracker issue from the latest run bundle.
-- The default tracker issue is `#1`, and the local `.agentops/agentops.yaml` template carries that value for future automation.
+- open or reference an issue before broad work starts
+- keep milestone, status, and dependency information current
+- update the relevant epic or tracker when scope, order, or risk changes
+- open follow-up issues for deferred work instead of burying it in code comments
+
+## Milestone Model
+
+New SDLC-platform work should use:
+
+- `Platform Phase 1: Platform Foundation`
+- `Platform Phase 2: General SDLC Expansion`
+- `Platform Phase 3: Ecosystem and Plugins`
+- `Platform Phase 4: Enterprise / Governance / Scale`
+
+Historical milestones from the original foundation work should remain as completed record, not as the active planning model.
+
+## Issue Taxonomy
+
+Use the label taxonomy defined in [docs/ISSUE_TAXONOMY.md](docs/ISSUE_TAXONOMY.md).
+
+At minimum, each issue should capture:
+
+- problem / motivation
+- desired outcome
+- proposed scope
+- non-goals
+- acceptance criteria
+- dependencies
+- labels
+- milestone
+
+## Tracker Shape
+
+The expected structure for major platform work is:
+
+- one umbrella tracker for the active repositioning or phase
+- one epic per major workstream
+- child implementation issues for the first reviewable slices
+
+## Current Direction
+
+The repository has moved beyond the original Phase 1 foundation work. The active platform direction is the broader SDLC workflow/runtime roadmap described in:
+
+- [docs/PLATFORM_VISION.md](PLATFORM_VISION.md)
+- [docs/ROADMAP.md](ROADMAP.md)
+- [docs/SDLC_COVERAGE.md](SDLC_COVERAGE.md)
+- [docs/SUPPORT_MATRIX.md](SUPPORT_MATRIX.md)
+- [docs/GAP_ANALYSIS_GENERAL_SDLC.md](GAP_ANALYSIS_GENERAL_SDLC.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,24 +1,55 @@
 # Quickstart
 
+This quickstart walks through the current official AgentForge wedge: secure local repository review with auditable outputs.
+
+## Install And Build
+
 ```bash
 pnpm install
 pnpm build
 pnpm build:packages
+```
+
+## Initialize Local Config
+
+```bash
 node packages/cli/dist/bin.js init
+```
+
+This writes starter config under `.agentops/`.
+
+## Inspect The Repository
+
+```bash
 node packages/cli/dist/bin.js scan
+```
+
+## Run The Current Official Workflow
+
+```bash
 node packages/cli/dist/bin.js run pr-review
+```
+
+## Inspect The Latest Run
+
+```bash
 node packages/cli/dist/bin.js explain last-run
 ```
 
-The starter configuration is written under `.agentops/`. Run artifacts are written under `.agentops/runs/<run-id>/`.
+Run artifacts are written under `.agentops/runs/<run-id>/`.
 
-To dry-run the publishable package set:
+## Validate The Public Package Set
 
 ```bash
 pnpm pack:public
 pnpm release:verify
 ```
 
-For the GitHub CI wrapper and PR/issue reporting flow, see [docs/github-actions.md](./github-actions.md).
-For the Phase 1 security posture and build provenance approach, see [docs/security-model.md](./security-model.md) and [docs/release-trust.md](./release-trust.md).
-For contributor workflow and extension authoring, start with [CONTRIBUTING.md](../CONTRIBUTING.md), [docs/agent-manifest-guide.md](./agent-manifest-guide.md), and [docs/plugin-author-guide.md](./plugin-author-guide.md).
+## Related Docs
+
+- [README.md](../README.md)
+- [architecture.md](architecture.md)
+- [security-model.md](security-model.md)
+- [release-trust.md](release-trust.md)
+- [PLATFORM_VISION.md](PLATFORM_VISION.md)
+- [ROADMAP.md](ROADMAP.md)


### PR DESCRIPTION
## Summary
- rewrite the product narrative around AgentForge as a secure-by-default SDLC workflow platform core
- add platform vision, roadmap, SDLC coverage, support matrix, issue taxonomy, and gap analysis docs
- add issue templates, a PR template, and contributor guidance for roadmap-driven planning

## Issue Tracking
Advances #45, #46, #47, #57, #58
Closes #66
Closes #67
Closes #68
Closes #69
Closes #70
Closes #71

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build