### PR TITLE
Define the self-hosting posture and context-slice contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ AgentForge is moving from a single secure `pr-review` wedge toward a broader SDL
 - **Ecosystem And Plugins:** improve adapters, plugin surfaces, and registry-facing workflows
 - **Enterprise / Governance / Scale:** add compatibility, governance, and scale-oriented controls
 
+Current dogfooding posture:
+
+- use AgentForge on AgentForge for planning, design, review, QA, and release verification
+- do not treat it as a broad autonomous implementation engine yet
+
+See [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) and [docs/CONTEXT_SLICE_CONTRACTS.md](docs/CONTEXT_SLICE_CONTRACTS.md).
+
 Roadmap docs:
 
 - [docs/PLATFORM_VISION.md](docs/PLATFORM_VISION.md)

--- a/docs/CONTEXT_SLICE_CONTRACTS.md
+++ b/docs/CONTEXT_SLICE_CONTRACTS.md
@@ -1,0 +1,393 @@
+# Context Slice Contracts
+
+This document defines the design target for issue [#74](https://github.com/H9-Foundry/AgentForge/issues/74).
+
+It describes how AgentForge should represent, budget, truncate, and audit context slices as the platform expands beyond the initial `pr-review` workflow.
+
+It does **not** claim that all of these contracts are implemented in the runtime today.
+
+## Why This Exists
+
+The current context engine already produces a useful workflow-state envelope:
+
+- repository metadata
+- change metadata
+- execution context
+- effective policy snapshot
+
+That is enough for the initial workflow wedge, but it is still too implicit for a broader SDLC platform.
+
+Without explicit context-slice contracts, future workflows will tend to:
+
+- over-assemble repository data
+- pass large unstructured blobs to reasoning nodes
+- hide truncation decisions
+- make audit trails weaker
+
+## Design Goals
+
+- keep context assembly minimal and reviewable
+- make slice categories explicit and typed
+- make truncation visible instead of implicit
+- separate deterministic metadata slices from large-content slices
+- let policy narrow context access without silently widening defaults
+
+## Non-Goals
+
+- implementing token-based provider budgeting in this slice
+- allowing arbitrary repository dumps into agent inputs
+- making context assembly provider-specific
+- weakening blocked-path or approval behavior
+
+## Current Baseline
+
+Today, `createWorkflowState()` builds a normalized envelope with:
+
+- `repo`
+- `changes`
+- `context`
+- `policy`
+- placeholders for findings, proposed actions, blocked plugins, agent results, and audit trail
+
+What is still missing:
+
+- explicit slice categories
+- explicit slice provenance
+- explicit budget/truncation metadata
+- explicit denied/omitted slice reporting
+
+## Proposed Slice Model
+
+Each slice should eventually be represented as a structured object with:
+
+- `id`
+  - unique identifier within the run
+- `category`
+  - which slice family this belongs to
+- `origin`
+  - where the data came from
+- `selector`
+  - what was requested to produce the slice
+- `content`
+  - the actual structured payload
+- `budget`
+  - the limit or policy used for assembly
+- `status`
+  - how fully the request was satisfied
+- `redaction`
+  - whether redaction was applied
+
+### Proposed Categories
+
+Initial category set:
+
+- `repo_metadata`
+- `change_summary`
+- `path_inventory`
+- `file_excerpt`
+- `history_summary`
+- `policy_snapshot`
+- `workflow_runtime_state`
+- `prior_artifact`
+- `external_input`
+
+These categories are narrow on purpose. New categories should only be added when they represent a stable new contract, not a one-off workflow convenience.
+
+## Category Definitions
+
+### `repo_metadata`
+
+Purpose:
+
+- stable repository facts needed by most workflows
+
+Typical content:
+
+- repo root
+- repo name
+- branch
+- package manager
+- detected languages
+- CI/provider flags
+
+Budget rule:
+
+- no truncation expected under normal operation
+
+### `change_summary`
+
+Purpose:
+
+- structured summary of what changed without embedding file bodies
+
+Typical content:
+
+- changed files
+- staged files
+- untracked files
+- impacted paths
+- diff stats
+- file detail summaries
+
+Budget rule:
+
+- full structured summary preferred
+- if the changed-file set is large, truncate only detailed per-file lists first and retain aggregate counts
+
+### `path_inventory`
+
+Purpose:
+
+- bounded lists of files or directories selected for a workflow step
+
+Typical content:
+
+- selected path list
+- selection reason
+- whether the list came from diff analysis, a manifest, or deterministic scanning
+
+Budget rule:
+
+- cap the item list
+- always retain total-match count and truncated count
+
+### `file_excerpt`
+
+Purpose:
+
+- bounded content windows from specific files
+
+Typical content:
+
+- path
+- line range or region identifier
+- excerpt text
+- excerpt rationale
+
+Budget rule:
+
+- never pass full-repository source dumps as one slice
+- prefer targeted excerpts
+- cap both per-file excerpt size and total slice count per node
+
+### `history_summary`
+
+Purpose:
+
+- bounded repository history or prior-change context
+
+Typical content:
+
+- branch or commit identifiers
+- summarized history window
+- selected commit metadata
+
+Budget rule:
+
+- summarize first
+- expand only when a workflow explicitly requests it and policy permits it
+
+### `policy_snapshot`
+
+Purpose:
+
+- the effective policy information relevant to the current node
+
+Typical content:
+
+- environment
+- defaults
+- path rules
+- plugin rules
+- relevant tool decisions
+
+Budget rule:
+
+- include only the effective, relevant subset for the node where possible
+
+### `workflow_runtime_state`
+
+Purpose:
+
+- bounded run-state information from earlier workflow steps
+
+Typical content:
+
+- current workflow
+- current node
+- prior node outputs by reference
+- approval state
+
+Budget rule:
+
+- prefer references and summaries over raw duplication of prior outputs
+
+### `prior_artifact`
+
+Purpose:
+
+- consume outputs from earlier runs or workflow stages
+
+Typical content:
+
+- artifact type
+- artifact identifier
+- summary metadata
+- selected structured payload
+
+Budget rule:
+
+- prefer structured summaries
+- retrieve full payloads only when a workflow explicitly depends on them
+
+### `external_input`
+
+Purpose:
+
+- user-provided or system-provided inputs that are not repository-native
+
+Typical content:
+
+- issue metadata
+- manual intake fields
+- imported design references
+
+Budget rule:
+
+- treat as untrusted input
+- summarize and redact before broad reuse
+
+## Slice Status Model
+
+Each requested slice should record one of:
+
+- `full`
+  - the request was satisfied completely
+- `partial`
+  - only part of the requested content was provided
+- `truncated`
+  - content was reduced because of budget limits
+- `denied`
+  - policy or path rules blocked the request
+- `omitted`
+  - the slice was unnecessary or unavailable
+
+This should be auditable, not hidden in implementation details.
+
+## Initial Budget And Truncation Rules
+
+These rules are the proposed default design target for future implementation.
+
+### Structured Metadata First
+
+Prefer full fidelity for:
+
+- repo metadata
+- aggregate diff stats
+- effective policy metadata
+- workflow/run identifiers
+
+These are small and should not be truncated unless something is abnormal.
+
+### Lists Before File Bodies
+
+For larger contexts:
+
+- preserve counts before details
+- preserve path summaries before file excerpts
+- preserve file excerpts before full file bodies
+
+If something must be dropped, drop the least reusable high-volume detail first.
+
+### Bounded File Content
+
+For `file_excerpt` slices:
+
+- excerpts should be tied to explicit paths and regions
+- selection should be reasoned from diff impact, deterministic scanning, or prior findings
+- the runtime should never package all changed-file content as the default slice behavior
+
+### Explicit Overflow Reporting
+
+Whenever a slice is truncated, the recorded slice metadata should include:
+
+- requested amount
+- provided amount
+- truncation reason
+- enough summary detail for a human or later workflow step to know what was omitted
+
+## Enforcement Responsibilities
+
+### Context Engine
+
+Should be responsible for:
+
+- deterministic collection of base repository and change metadata
+- constructing slice candidates
+- applying deterministic budget/truncation rules where possible
+
+### Runtime
+
+Should be responsible for:
+
+- deciding which slice categories a node may request
+- binding slice requests to the node capability envelope
+- passing only allowed slices to agents or deterministic nodes
+- recording requested versus provided slice behavior
+
+### Policy Engine
+
+Should be responsible for:
+
+- restricting slice categories or selectors when policy requires it
+- enforcing blocked-path implications before slice assembly
+- defining whether certain slice families are denied or narrowed in local vs CI contexts
+
+## Audit Requirements
+
+The audit trail should eventually capture:
+
+- requested slice categories
+- selectors used for assembly
+- slice status
+- truncation events
+- denied slice requests
+- redaction applied to slices
+
+That visibility is required if AgentForge is going to stay credible as it expands into broader SDLC workflows.
+
+## Implementation Follow-Ups
+
+This design should eventually drive follow-up work in:
+
+- `packages/schemas`
+  - slice schemas, status enums, and audit fields
+- `packages/shared-types`
+  - typed slice contracts
+- `packages/context-engine`
+  - structured slice assembly and truncation metadata
+- `packages/runtime`
+  - node-level slice request mediation
+- `packages/policy-engine`
+  - slice-category and selector restrictions
+
+## Relationship To Other Phase 1 Issues
+
+- [#75](https://github.com/H9-Foundry/AgentForge/issues/75)
+  - policy overlays and approval classes must align with slice access rules
+- [#76](https://github.com/H9-Foundry/AgentForge/issues/76)
+  - workflow metadata should eventually declare which slice categories are expected
+- [#77](https://github.com/H9-Foundry/AgentForge/issues/77)
+  - lifecycle artifacts should be consumable as `prior_artifact` slices
+- [#78](https://github.com/H9-Foundry/AgentForge/issues/78)
+  - planning/discovery workflow design should use these slice categories instead of ad hoc context sections
+
+## Recommended Implementation Order
+
+1. finalize slice categories and status model
+2. finalize default budget/truncation rules
+3. add schema/types for slice metadata
+4. add runtime and context-engine reporting for requested versus provided slices
+5. add policy-level slice restrictions
+
+That keeps the platform bounded before broader workflow families are introduced.

--- a/docs/PLATFORM_VISION.md
+++ b/docs/PLATFORM_VISION.md
@@ -76,6 +76,24 @@ AgentForge should expand from the `pr-review` wedge into adjacent SDLC workflows
 - operations and incident response handoff
 - maintenance, upgrades, and documentation hygiene
 
+## Self-Hosting Posture
+
+AgentForge should be used on the AgentForge repository itself, but only in a narrow-assist mode for now.
+
+Allowed near-term self-hosting roles:
+
+- planning and design-doc generation
+- PR review, QA checks, and structured findings
+- release and readiness verification
+
+Not yet supported as official self-hosting behavior:
+
+- broad autonomous implementation
+- unconstrained write-heavy workflows
+- hidden side effects behind planning or design prompts
+
+See [docs/SELF_HOSTING.md](SELF_HOSTING.md).
+
 ## Longer-Term Platform Direction
 
 Longer-term platform work is expected to include:

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -59,6 +59,11 @@ The current shipped baseline is:
   - side-effect classes
   - context-slice contracts
   - runtime/policy/audit handoff
+- [docs/CONTEXT_SLICE_CONTRACTS.md](CONTEXT_SLICE_CONTRACTS.md)
+  - slice categories
+  - budget and truncation rules
+  - requested versus provided slice reporting
+  - context-engine/runtime/policy enforcement points
 
 ## Phase 2: General SDLC Expansion
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -1,0 +1,128 @@
+# Self-Hosting Posture
+
+This document defines how AgentForge should be used on the AgentForge repository itself.
+
+It is intentionally conservative. The goal is to let AgentForge help build AgentForge without pretending the platform is already mature enough for broad autonomous implementation.
+
+## Current Decision
+
+AgentForge should dogfood itself in **narrow-assist mode** for now.
+
+That means:
+
+- use AgentForge for planning and design work
+- use AgentForge for review, QA checks, and release verification
+- keep implementation changes human-led unless they are later introduced as tightly approval-gated, low-risk, explicitly supported workflows
+
+## Why This Is The Current Posture
+
+The platform is already credible in a few areas:
+
+- repo-aware workflow execution
+- secure-by-default policy mediation
+- auditable findings and summaries
+- release readiness and package verification checks
+
+The platform is not yet mature enough for broad self-directed implementation across SDLC domains because the following foundation work is still in progress:
+
+- context-slice contracts and budget enforcement
+- lifecycle-domain policy overlays and approval classes
+- manifest metadata for domain, maturity, and trust scope
+- lifecycle artifact schema families
+
+Those gaps are tracked in:
+
+- [#74](https://github.com/H9-Foundry/AgentForge/issues/74)
+- [#75](https://github.com/H9-Foundry/AgentForge/issues/75)
+- [#76](https://github.com/H9-Foundry/AgentForge/issues/76)
+- [#77](https://github.com/H9-Foundry/AgentForge/issues/77)
+
+## What AgentForge May Do On Itself Today
+
+### 1. Planning And Design
+
+Allowed:
+
+- backlog decomposition
+- roadmap and support-matrix updates
+- design-doc generation
+- proposal artifacts linked to GitHub issues
+
+Expected output:
+
+- structured docs
+- explicit issue linkage
+- auditable rationale
+
+### 2. Review And QA
+
+Allowed:
+
+- repository scanning
+- PR review
+- risk detection
+- test-gap detection
+- structured findings and summaries
+
+Expected output:
+
+- findings
+- proposed actions
+- run artifacts
+- blocked-action visibility when something is not allowed
+
+### 3. Release And Readiness
+
+Allowed:
+
+- `agentforge release guide`
+- `agentforge release check`
+- `agentforge release verify`
+- release documentation and trust-review work
+
+Expected output:
+
+- machine-readable or structured readiness results
+- clear pass/fail reporting
+- auditable release-preflight artifacts
+
+## What AgentForge Should Not Do On Itself Yet
+
+Not yet supported as official self-hosting behavior:
+
+- broad autonomous code-writing workflows
+- broad autonomous build/change/deploy flows
+- unconstrained networked implementation loops
+- hidden side effects behind planning or design prompts
+- workflows that rely on large implicit context grabs
+
+That work should wait until the Phase 1 foundation contracts are fully defined and at least partially implemented.
+
+## Rules For Self-Hosted Use
+
+Any self-hosted AgentForge workflow should remain:
+
+- read-only by default
+- approval-gated for side effects
+- minimal-context
+- schema-validated
+- auditable
+
+Additionally:
+
+- planning artifacts must link back to GitHub issues
+- review or QA runs must emit structured findings or an explicit no-findings result
+- release-oriented checks must stay deterministic and machine-readable where possible
+- documentation must not describe a self-hosted capability as official until it actually exists in the repo
+
+## Graduation Criteria For Broader Self-Hosting
+
+AgentForge should not move from narrow-assist mode to broader self-hosted implementation until:
+
+1. context-slice categories and truncation rules are defined
+2. policy overlays and approval classes are defined
+3. manifest metadata for workflow domain and trust scope is defined
+4. lifecycle artifact schemas are defined
+5. at least one broader lifecycle workflow MVP is specified against those contracts
+
+At that point, the project can consider tightly approval-gated implementation-assist workflows, but not before.

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -74,6 +74,15 @@ This matrix separates current official support from roadmap intent.
 | general CI runtime support | Partial | Some workflow behavior exists in CI, but general CI workflow support is not complete. |
 | hosted multi-tenant service | Planned | Not implemented. |
 
+## Self-Hosting Scope
+
+| Self-hosted use | Maturity | Notes |
+| --- | --- | --- |
+| planning/design on the AgentForge repo | Partial | Supported as a process and docs pattern, not as a dedicated official workflow yet. |
+| PR review and QA on the AgentForge repo | Official | Covered by the current `pr-review` wedge and audit outputs. |
+| release/readiness verification on the AgentForge repo | Official | Covered by `release guide`, `release check`, and `release verify`. |
+| autonomous implementation on the AgentForge repo | Planned | Not an official supported mode yet. |
+
 ## Compatibility Notes
 
 - Current support is strongest for local repository execution and GitHub-centric release workflows.

--- a/docs/runtime-model.md
+++ b/docs/runtime-model.md
@@ -81,4 +81,4 @@ The current model is enough for the initial `pr-review` wedge, but broader SDLC 
 - context-slice contracts and budget handling
 - clearer runtime versus policy responsibilities
 
-See [docs/RUNTIME_INTERACTION_HARDENING.md](RUNTIME_INTERACTION_HARDENING.md) for the Phase 1 design target that will drive the next runtime, policy, and schema hardening work.
+See [docs/RUNTIME_INTERACTION_HARDENING.md](RUNTIME_INTERACTION_HARDENING.md) for the Phase 1 design target and [docs/CONTEXT_SLICE_CONTRACTS.md](CONTEXT_SLICE_CONTRACTS.md) for the dedicated slice-category, budget, truncation, and audit contract.


### PR DESCRIPTION
## Summary
- document the narrow-assist self-hosting posture for using AgentForge on the AgentForge repo
- add a dedicated context-slice contract doc covering categories, budgets, truncation, and audit expectations
- link the new docs back into the runtime model, roadmap, support matrix, platform vision, and README

## Issue Tracking
Advances #48, #75, #76, #77
Closes #74

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build