### PR TITLE
Define the full-queue execution flow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ AgentForge is an open-source SDLC workflow platform core with a deliberately nar
 - read [docs/PLATFORM_VISION.md](docs/PLATFORM_VISION.md)
 - read [docs/ROADMAP.md](docs/ROADMAP.md)
 - read [docs/ISSUE_TAXONOMY.md](docs/ISSUE_TAXONOMY.md)
+- read [docs/QUEUE_EXECUTION_FLOW.md](docs/QUEUE_EXECUTION_FLOW.md)
 - read [docs/github-issue-source-of-truth.md](docs/github-issue-source-of-truth.md)
 
 ## Planning And Tracking
@@ -25,10 +26,12 @@ AgentForge is an open-source SDLC workflow platform core with a deliberately nar
 1. Install dependencies with `pnpm install`.
 2. Create or link the relevant GitHub issue before broad work.
 3. Keep changes scoped to the package, workflow, adapter, or doc surface you are modifying.
-4. Update tests and documentation when behavior or public contracts change.
-5. Run `pnpm lint`, `pnpm test`, `pnpm typecheck`, and `pnpm build` before proposing changes.
-6. If you touch public packages or release automation, also run `pnpm build:packages`, `pnpm pack:public`, and `pnpm release:verify`.
-7. Maintainers should use signed commits for normal repo work. See [docs/maintainer-signing.md](docs/maintainer-signing.md).
+4. Follow the active queue order in [docs/QUEUE_EXECUTION_FLOW.md](docs/QUEUE_EXECUTION_FLOW.md) and the live tracker [#83](https://github.com/H9-Foundry/AgentForge/issues/83).
+5. Produce a design-first slice when a feature is not yet decision-complete.
+6. Update tests and documentation when behavior or public contracts change.
+7. Run `pnpm lint`, `pnpm test`, `pnpm typecheck`, and `pnpm build` before proposing changes.
+8. If you touch public packages or release automation, also run `pnpm build:packages`, `pnpm pack:public`, and `pnpm release:verify`.
+9. Maintainers should use signed commits for normal repo work. See [docs/maintainer-signing.md](docs/maintainer-signing.md).
 
 ## Repository Structure
 
@@ -53,6 +56,17 @@ AgentForge is an open-source SDLC workflow platform core with a deliberately nar
 - keep labels consistent with [docs/ISSUE_TAXONOMY.md](docs/ISSUE_TAXONOMY.md)
 - update roadmap docs when the platform direction materially changes
 - avoid merging broad planning changes without updating both the docs and the GitHub issue state
+- keep only one active slice per dependency chain unless parallel execution is explicitly safe
+- move issues between `needs-design`, `ready`, `in-progress`, and `blocked` deliberately
+
+## Maintainer Loop
+
+1. pick the next issue from the active queue lane
+2. set the issue status and link the branch or PR
+3. produce the smallest useful design or implementation slice
+4. run the required validation commands
+5. dogfood through currently supported AgentForge surfaces when the slice type requires it
+6. merge the slice and update or close the issue
 
 ## Before Opening A Pull Request
 
@@ -61,6 +75,7 @@ AgentForge is an open-source SDLC workflow platform core with a deliberately nar
 - prefer small reviewable slices over broad mixed changes
 - use the pull request template
 - if you are a maintainer, confirm your commits show as `Verified` on GitHub
+- record the validation commands and any dogfooding evidence in the PR body or linked issue comment
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Current dogfooding posture:
 - use AgentForge on AgentForge for planning, design, review, QA, and release verification
 - do not treat it as a broad autonomous implementation engine yet
 
-See [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md) and [docs/CONTEXT_SLICE_CONTRACTS.md](docs/CONTEXT_SLICE_CONTRACTS.md).
+See [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md), [docs/CONTEXT_SLICE_CONTRACTS.md](docs/CONTEXT_SLICE_CONTRACTS.md), and [docs/QUEUE_EXECUTION_FLOW.md](docs/QUEUE_EXECUTION_FLOW.md).
 
 Roadmap docs:
 

--- a/docs/ISSUE_TAXONOMY.md
+++ b/docs/ISSUE_TAXONOMY.md
@@ -117,10 +117,84 @@ Each issue should include:
 - update epic tracker checklists as child work lands
 - prefer opening follow-up issues over burying deferred work in comments or TODOs
 
+## Status Definitions
+
+### `status: needs-design`
+
+Use when:
+
+- the work is real and prioritized
+- the implementation direction is not yet decision-complete
+- the issue should not be actively implemented yet
+
+### `status: ready`
+
+Use when:
+
+- the issue is bounded enough to execute
+- dependencies are satisfied or explicitly manageable
+- the expected output and validation path are clear
+
+### `status: in-progress`
+
+Use when:
+
+- a branch or PR exists, or
+- a maintainer is actively executing the slice right now
+
+Do not mark multiple issues in the same dependency chain as `in-progress` unless parallel work is genuinely safe and bounded.
+
+### `status: blocked`
+
+Use when:
+
+- external dependencies, repo constraints, or higher-priority prerequisite work prevent execution
+- the issue cannot move forward without a specific unblock step
+
+## Epic Advancement Rules
+
+An epic may move from `needs-design` to `in-progress` when:
+
+- at least one child issue or bounded slice is actively being executed, and
+- the epic has enough design direction to guide issue ordering
+
+An epic can remain open and `in-progress` while child issues continue landing.
+
+## Ready And Done Definitions
+
+An issue is **ready** when:
+
+- the problem and desired outcome are clear
+- acceptance criteria are concrete
+- dependencies are explicit
+- the expected validation path is known
+
+An issue is **done** when:
+
+- the linked PR merged
+- required tests and checks passed
+- issue state reflects the final result
+- residual risk or deferred work is captured explicitly
+
+## When To Split Child Issues
+
+Split a child issue from an epic when:
+
+- the work is reviewable in one PR or a small linked set of PRs
+- the output is a concrete design artifact, schema change, runtime change, or workflow slice
+- it would benefit from its own acceptance criteria and dependency tracking
+
+Continue working directly under an epic only when:
+
+- the epic still lacks decision-complete child slices
+- the immediate work is purely backlog shaping or sequencing
+- splitting would create low-signal issue noise rather than clarity
+
 ## Workflow Expectations
 
 - contributors should open or reference an issue before broad implementation work
 - maintainers should keep milestone and status labels current
 - roadmap docs should be updated when milestone shape or platform direction changes
+- maintainers should follow [docs/QUEUE_EXECUTION_FLOW.md](QUEUE_EXECUTION_FLOW.md) for active queue sequencing and dogfooding gates
 
 For the operational model behind this taxonomy, see [docs/github-issue-source-of-truth.md](github-issue-source-of-truth.md).

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -1,0 +1,168 @@
+# Queue Execution Flow
+
+This document defines how maintainers should work through the AgentForge backlog.
+
+It is a **maintainer operating flow**, not a shipped product workflow. The only official runtime workflow remains `.agentops/workflows/pr-review.yaml`, plus the existing release/readiness tooling.
+
+The live execution tracker for this process is [#83](https://github.com/H9-Foundry/AgentForge/issues/83).
+
+## Operating Posture
+
+AgentForge should be used on itself in **narrow-assist mode** while capability expands.
+
+Allowed self-hosted use during queue execution:
+
+- planning and design-doc generation
+- PR review, QA, and test-gap detection
+- release and readiness verification
+
+Not yet supported as official self-hosted behavior:
+
+- broad autonomous implementation
+- broad write-heavy workflow execution
+- any queue process represented as a shipped runtime workflow asset
+
+See [docs/SELF_HOSTING.md](SELF_HOSTING.md).
+
+## Queue Lanes
+
+The backlog is managed in four lanes.
+
+### Active Lane
+
+Work that is currently being executed now.
+
+Rules:
+
+- only one active design or implementation slice per core dependency chain
+- must already be linked to an issue
+- must have explicit validation and dogfooding gates
+
+Current active lane:
+
+1. [#76](https://github.com/H9-Foundry/AgentForge/issues/76) manifest metadata
+2. [#77](https://github.com/H9-Foundry/AgentForge/issues/77) artifact schemas
+3. child implementation issues under [#50](https://github.com/H9-Foundry/AgentForge/issues/50)
+4. child implementation issues under [#48](https://github.com/H9-Foundry/AgentForge/issues/48) and [#49](https://github.com/H9-Foundry/AgentForge/issues/49)
+
+### Ready Lane
+
+Work that is explicitly designed or queued next, but should not start until the active dependency chain is satisfied.
+
+Current ready lane:
+
+5. [#78](https://github.com/H9-Foundry/AgentForge/issues/78) planning/discovery workflow MVP
+6. [#79](https://github.com/H9-Foundry/AgentForge/issues/79) architecture/design workflow MVP
+
+### Mapped Lane
+
+Work that is part of the roadmap and ordered relative to dependencies, but not yet active.
+
+Current mapped lane:
+
+7. [#53](https://github.com/H9-Foundry/AgentForge/issues/53) build/implementation workflow support
+8. [#54](https://github.com/H9-Foundry/AgentForge/issues/54) test/QA workflow expansion
+9. [#55](https://github.com/H9-Foundry/AgentForge/issues/55) security/DevSecOps workflow expansion
+10. [#59](https://github.com/H9-Foundry/AgentForge/issues/59) release/CI-CD workflow expansion
+11. [#61](https://github.com/H9-Foundry/AgentForge/issues/61) maintenance/dependency/docs workflow expansion
+12. [#60](https://github.com/H9-Foundry/AgentForge/issues/60) operations/incident workflow expansion
+
+### Deferred Lane
+
+Work that remains part of the roadmap but should not be pulled forward until earlier workflow and contract work exists.
+
+Current deferred lane:
+
+- [#62](https://github.com/H9-Foundry/AgentForge/issues/62) plugin and registry roadmap
+- [#63](https://github.com/H9-Foundry/AgentForge/issues/63) evals and benchmarks framework
+- [#64](https://github.com/H9-Foundry/AgentForge/issues/64) additional SCM and CI integrations roadmap
+- [#65](https://github.com/H9-Foundry/AgentForge/issues/65) supply-chain and release trust hardening
+
+## Do-Not-Start-Before Rules
+
+- Do not start broader workflow MVP work before the Phase 1 contract docs exist.
+- Do not start build, QA, security, release, maintenance, or operations workflow design until the planning/discovery and architecture/design MVP specs are written.
+- Do not start Phase 3 ecosystem and Phase 4 governance work as active implementation unless the earlier workflow contracts and MVP specs are stable enough to support them.
+
+## Maintainer Loop
+
+For each slice:
+
+1. pick the next issue from the active lane
+2. set the issue to `status: in-progress` and link the branch/PR
+3. produce the smallest useful design or implementation slice
+4. run validation
+5. dogfood using currently supported AgentForge surfaces
+6. merge the slice
+7. close the issue or move the parent epic/tracker state forward
+
+Prefer child issues over broad epic-only work once a slice becomes concrete enough to review independently.
+
+## Validation Gates
+
+### Design And Docs Slices
+
+Required:
+
+- linked GitHub issue
+- structured design or planning artifact in `docs/`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm typecheck`
+- `pnpm build`
+- one repo review pass using the current supported workflow or equivalent review pass before merge
+- issue comment or PR body that records the validation commands
+
+Not required:
+
+- new workflow assets
+- `pnpm build:packages` unless package contracts or CLI behavior changed
+
+### Schema / Runtime / Policy Code Slices
+
+Required:
+
+- focused tests for changed behavior
+- `pnpm lint`
+- `pnpm test`
+- `pnpm typecheck`
+- `pnpm build`
+- `pnpm build:packages` if public package contracts changed
+- `agentforge run pr-review`
+- `agentforge explain last-run`
+- docs/support updates only if capability actually becomes available
+
+### Release / Public Package Slices
+
+Add:
+
+- `agentforge release check --json`
+- `agentforge release verify --json`
+
+## Dogfooding Rules
+
+While the queue is being executed, AgentForge should be used on itself for:
+
+- planning and design
+- PR review and QA
+- release/readiness verification
+
+It should **not** be used as a general autonomous implementation engine until:
+
+- context-slice contracts are defined and partly implemented
+- lifecycle policy overlays and approval classes are defined and partly implemented
+- manifest metadata is defined and partly implemented
+- artifact schemas are defined and partly implemented
+
+## Definition Of Done For A Queue Slice
+
+A slice is done when:
+
+- the linked issue is updated accurately
+- the PR merged cleanly
+- required validation commands passed
+- dogfooding evidence was captured where required
+- docs remain honest about current capability
+- residual risks are called out explicitly
+
+The queue tracker stays open until the current dependency chain and active execution rules change materially.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -70,6 +70,16 @@ The current shipped baseline is:
   - precedence and narrowing semantics
   - policy-to-audit expectations
 
+## Execution Flow
+
+The backlog execution model is documented in [docs/QUEUE_EXECUTION_FLOW.md](QUEUE_EXECUTION_FLOW.md).
+
+Use [#83](https://github.com/H9-Foundry/AgentForge/issues/83) as the live execution tracker for:
+
+- active versus ready versus mapped versus deferred queue lanes
+- dependency ordering across the next slices
+- dogfooding and validation gates for each slice
+
 ## Phase 2: General SDLC Expansion
 
 ### Target Outcomes


### PR DESCRIPTION
## Summary
- add a queue-execution operating doc for the full backlog
- wire the queue flow into the roadmap, issue taxonomy, contributing guide, and README
- keep the queue process explicitly documented as a maintainer operating model rather than a shipped product workflow

## Issue Tracking
Advances #83
Related #84

## Validation
- pnpm lint
- pnpm test
- pnpm typecheck
- pnpm build
- node packages/cli/dist/bin.js run pr-review --json

## Dogfooding Notes
- the `pr-review` run succeeded and produced a clean run artifact
- `node packages/cli/dist/bin.js explain last-run --json` exposed a CLI bug, tracked separately in #84