### PR TITLE
Fix explain-last-run bundle parsing

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -193,4 +193,31 @@ describe("cli smoke flows", () => {
     };
     expect(bundle.blockedPlugins[0]?.reason).toContain("Plugin review required");
   });
+
+  it("explains historical bundles with missing optional arrays", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentops-cli-explain-"));
+    writeFileSync(join(root, "package.json"), '{"name":"fixture"}');
+    initProject(root);
+
+    const runRoot = join(root, ".agentops", "runs", "2026-03-17-example");
+    mkdirSync(runRoot, { recursive: true });
+    writeFileSync(
+      join(runRoot, "bundle.json"),
+      JSON.stringify(
+        {
+          runId: "2026-03-17-example",
+          status: "completed"
+        },
+        null,
+        2
+      )
+    );
+
+    const explanation = explainLastRun(root);
+    expect(explanation.runId).toBe("2026-03-17-example");
+    expect(explanation.status).toBe("completed");
+    expect(explanation.findings).toBe(0);
+    expect(explanation.blockedActions).toBe(0);
+    expect(explanation.blockedPlugins).toBe(0);
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -124,6 +124,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
 function normalizeWorkflow(input: unknown): WorkflowDefinition {
   const parsed = input as Record<string, unknown>;
   return workflowDefinitionSchema.parse({
@@ -473,20 +477,23 @@ export function explainLastRun(cwd = process.cwd()): LastRunExplanation {
     throw new Error("No recorded runs found.");
   }
 
-  const bundle = JSON.parse(readFileSync(join(runsRoot, latest, "bundle.json"), "utf8")) as {
-    runId: string;
-    status: string;
-    findings: unknown[];
-    blockedPlugins: unknown[];
-    entries: { blockedActions: unknown[] }[];
-  };
+  const bundle = JSON.parse(readFileSync(join(runsRoot, latest, "bundle.json"), "utf8")) as Record<string, unknown>;
+  const findings = asArray(bundle.findings);
+  const blockedPlugins = asArray(bundle.blockedPlugins);
+  const runEntries = asArray(bundle.entries);
 
   return {
-    runId: bundle.runId,
-    status: bundle.status,
-    findings: bundle.findings.length,
-    blockedActions: bundle.entries.reduce((total, entry) => total + entry.blockedActions.length, 0),
-    blockedPlugins: bundle.blockedPlugins.length,
+    runId: typeof bundle.runId === "string" ? bundle.runId : latest,
+    status: typeof bundle.status === "string" ? bundle.status : "unknown",
+    findings: findings.length,
+    blockedActions: runEntries.reduce<number>((total, entry) => {
+      if (!isRecord(entry)) {
+        return total;
+      }
+
+      return total + asArray(entry.blockedActions).length;
+    }, 0),
+    blockedPlugins: blockedPlugins.length,
     jsonPath: join(runsRoot, latest, "bundle.json"),
     markdownPath: join(runsRoot, latest, "summary.md")
   };


### PR DESCRIPTION
## Summary
- make `explainLastRun()` tolerate historical or partial `bundle.json` files instead of assuming every array field exists
- default missing `findings`, `blockedPlugins`, and `entries[*].blockedActions` to empty arrays
- add a regression test for a minimal historical run bundle

## Validation
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

Closes #84