### PR TITLE
Implement lifecycle artifact envelope schema

### DIFF
--- a/.changeset/lifecycle-artifact-envelope-schema.md
+++ b/.changeset/lifecycle-artifact-envelope-schema.md
@@ -1,0 +1,6 @@
+---
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add a shared lifecycle artifact envelope schema and inferred types for future SDLC artifact families.

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   agentManifestSchema,
   auditBundleSchema,
   getJsonSchemas,
+  lifecycleArtifactEnvelopeSchema,
   policyDocumentSchema,
   schemaFixtures,
   workflowDefinitionSchema
@@ -30,6 +31,7 @@ describe("schema fixtures", () => {
 
     expect(jsonSchemas.agentManifest).toBeDefined();
     expect(jsonSchemas.workflowDefinition).toBeDefined();
+    expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
   });
 
   it("validates audit bundle metadata", () => {
@@ -84,5 +86,27 @@ describe("schema fixtures", () => {
         ]
       })
     ).not.toThrow();
+  });
+
+  it("validates the shared lifecycle artifact envelope fixture", () => {
+    expect(() =>
+      lifecycleArtifactEnvelopeSchema.parse(schemaFixtures.lifecycleArtifactEnvelope)
+    ).not.toThrow();
+  });
+
+  it("rejects invalid lifecycle artifact envelopes", () => {
+    expect(() =>
+      lifecycleArtifactEnvelopeSchema.parse({
+        ...schemaFixtures.lifecycleArtifactEnvelope,
+        artifactKind: "incident-report"
+      })
+    ).toThrow();
+
+    expect(() =>
+      lifecycleArtifactEnvelopeSchema.parse({
+        ...schemaFixtures.lifecycleArtifactEnvelope,
+        summary: ""
+      })
+    ).toThrow();
   });
 });

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -13,6 +13,16 @@ export const toolResultStatusSchema = z.enum(["success", "blocked", "failed"]);
 export const runStatusSchema = z.enum(["success", "partial", "failed"]);
 export const trustTierSchema = z.enum(["core", "verified", "community", "untrusted"]);
 export const trustSourceSchema = z.enum(["official", "local", "third-party"]);
+export const lifecycleArtifactKindSchema = z.enum([
+  "planning-brief",
+  "design-record",
+  "review-report",
+  "release-report",
+  "maintenance-report"
+]);
+export const lifecycleDomainSchema = z.enum(["plan", "design", "review", "release", "maintain"]);
+export const lifecycleArtifactSourceTypeSchema = z.enum(["workflow-run", "manual-input", "imported"]);
+export const lifecycleArtifactStatusSchema = z.enum(["draft", "complete", "superseded", "cancelled"]);
 
 export const trustMetadataSchema = z.object({
   tier: trustTierSchema.default("core"),
@@ -321,6 +331,49 @@ export const auditRedactionSchema = z.object({
   categories: z.array(z.string()).default([])
 });
 
+export const lifecycleArtifactWorkflowReferenceSchema = z.object({
+  name: z.string().min(1),
+  displayName: z.string().min(1).optional()
+});
+
+export const lifecycleArtifactSourceReferenceSchema = z.object({
+  sourceType: lifecycleArtifactSourceTypeSchema,
+  runId: z.string().min(1).optional(),
+  inputRefs: z.array(z.string()).default([]),
+  issueRefs: z.array(z.string()).default([])
+});
+
+export const lifecycleArtifactRepoReferenceSchema = z.object({
+  root: z.string().min(1),
+  name: z.string().min(1),
+  branch: z.string().default("unknown"),
+  commitSha: z.string().min(1).optional()
+});
+
+export const lifecycleArtifactAuditLinkSchema = z.object({
+  bundlePath: z.string().min(1).optional(),
+  entryIds: z.array(z.string()).default([]),
+  findingIds: z.array(z.string()).default([]),
+  proposedActionIds: z.array(z.string()).default([])
+});
+
+export const lifecycleArtifactEnvelopeSchema = z.object({
+  schemaVersion: z.string().min(1),
+  artifactKind: lifecycleArtifactKindSchema,
+  lifecycleDomain: lifecycleDomainSchema,
+  workflow: lifecycleArtifactWorkflowReferenceSchema,
+  source: lifecycleArtifactSourceReferenceSchema,
+  status: lifecycleArtifactStatusSchema,
+  generatedAt: z.string().datetime(),
+  updatedAt: z.string().datetime().optional(),
+  repo: lifecycleArtifactRepoReferenceSchema,
+  provenance: auditProvenanceSchema,
+  redaction: auditRedactionSchema,
+  auditLink: lifecycleArtifactAuditLinkSchema,
+  summary: z.string().min(1),
+  payload: z.record(z.string(), z.unknown())
+});
+
 export const auditBundleSchema = z.object({
   version: z.string().min(1),
   runId: z.string().min(1),
@@ -353,6 +406,11 @@ export const schemaRegistry = {
   auditComponent: auditComponentSchema,
   auditProvenance: auditProvenanceSchema,
   auditRedaction: auditRedactionSchema,
+  lifecycleArtifactWorkflowReference: lifecycleArtifactWorkflowReferenceSchema,
+  lifecycleArtifactSourceReference: lifecycleArtifactSourceReferenceSchema,
+  lifecycleArtifactRepoReference: lifecycleArtifactRepoReferenceSchema,
+  lifecycleArtifactAuditLink: lifecycleArtifactAuditLinkSchema,
+  lifecycleArtifactEnvelope: lifecycleArtifactEnvelopeSchema,
   agentOutput: agentOutputSchema,
   agentManifest: agentManifestSchema,
   agentPluginRegistration: agentPluginRegistrationSchema,
@@ -449,5 +507,51 @@ export const schemaFixtures = {
       { id: "review", kind: "reasoning", agent: "code-review", outputsTo: "agentResults.review" },
       { id: "report", kind: "report", outputsTo: "reports.final" }
     ]
+  },
+  lifecycleArtifactEnvelope: {
+    schemaVersion: "1.0.0",
+    artifactKind: "planning-brief",
+    lifecycleDomain: "plan",
+    workflow: {
+      name: "planning-discovery",
+      displayName: "Planning And Discovery"
+    },
+    source: {
+      sourceType: "workflow-run",
+      runId: "run-123",
+      inputRefs: ["docs/ROADMAP.md"],
+      issueRefs: ["#78"]
+    },
+    status: "complete",
+    generatedAt: "2026-03-17T12:00:00.000Z",
+    updatedAt: "2026-03-17T12:00:00.000Z",
+    repo: {
+      root: "/repo",
+      name: "AgentForge",
+      branch: "main",
+      commitSha: "abc123"
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: "1.0.0",
+      executionEnvironment: "local",
+      repoRoot: "/repo"
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: ["secrets"]
+    },
+    auditLink: {
+      bundlePath: ".agentops/runs/run-123/bundle.json",
+      entryIds: ["plan-collector"],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary: "Initial planning brief generated for queue item #78.",
+    payload: {
+      problemStatement: "Define the next planning workflow slice.",
+      recommendedNextSteps: ["Draft workflow spec", "Open child implementation issues"]
+    }
   }
 } as const;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -9,6 +9,11 @@ import {
   approvalCheckpointSchema,
   auditBundleSchema,
   auditComponentSchema,
+  lifecycleArtifactAuditLinkSchema,
+  lifecycleArtifactEnvelopeSchema,
+  lifecycleArtifactRepoReferenceSchema,
+  lifecycleArtifactSourceReferenceSchema,
+  lifecycleArtifactWorkflowReferenceSchema,
   auditProvenanceSchema,
   auditRedactionSchema,
   auditEntrySchema,
@@ -36,6 +41,11 @@ export type AuditEntry = Infer<typeof auditEntrySchema>;
 export type AuditComponent = Infer<typeof auditComponentSchema>;
 export type AuditProvenance = Infer<typeof auditProvenanceSchema>;
 export type AuditRedaction = Infer<typeof auditRedactionSchema>;
+export type LifecycleArtifactWorkflowReference = Infer<typeof lifecycleArtifactWorkflowReferenceSchema>;
+export type LifecycleArtifactSourceReference = Infer<typeof lifecycleArtifactSourceReferenceSchema>;
+export type LifecycleArtifactRepoReference = Infer<typeof lifecycleArtifactRepoReferenceSchema>;
+export type LifecycleArtifactAuditLink = Infer<typeof lifecycleArtifactAuditLinkSchema>;
+export type LifecycleArtifactEnvelope = Infer<typeof lifecycleArtifactEnvelopeSchema>;
 export type AgentOutput = Infer<typeof agentOutputSchema>;
 export type AgentManifest = Infer<typeof agentManifestSchema>;
 export type AgentPluginRegistration = Infer<typeof agentPluginRegistrationSchema>;


### PR DESCRIPTION
## Summary
- add the shared lifecycle artifact envelope contract to `@h9-foundry/agentforge-schemas`
- export the inferred envelope types from `@h9-foundry/agentforge-shared-types`
- add focused schema coverage and a changeset for the additive public contract expansion

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `pnpm exec vitest run packages/schemas/src/index.test.ts`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- the full `pnpm test` suite completed its test output cleanly, but the captured session did not return a final summary line; the targeted schema test above was rerun to provide an explicit pass/fail gate for this slice
- this keeps the new lifecycle artifact contract additive relative to the existing `auditBundle`

Closes #89