### PR TITLE
Add newcomer usability track to queue planning

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ AgentForge is an open-source SDLC workflow platform core with a deliberately nar
 
 ## Start Here
 
+- if you are new and want to evaluate the current wedge quickly, follow the CLI-first path in [README.md](README.md) and [docs/quickstart.md](docs/quickstart.md) first
+- if you want to improve first-time usability, start with the newcomer-usability track under [#97](https://github.com/H9-Foundry/AgentForge/issues/97)
 - read [README.md](README.md)
 - read [docs/PLATFORM_VISION.md](docs/PLATFORM_VISION.md)
 - read [docs/ROADMAP.md](docs/ROADMAP.md)
@@ -20,6 +22,7 @@ AgentForge is an open-source SDLC workflow platform core with a deliberately nar
 - Open an epic when work spans multiple packages, workflows, or phases.
 - Open a feature issue for bounded implementation slices.
 - Record deferred work as follow-up issues instead of hiding it in TODO comments.
+- Treat newcomer usability as a standing quality concern for public docs, CLI ergonomics, and the first-run experience, not as a final polish pass.
 
 ## Development Workflow
 
@@ -67,6 +70,8 @@ AgentForge is an open-source SDLC workflow platform core with a deliberately nar
 4. run the required validation commands
 5. dogfood through currently supported AgentForge surfaces when the slice type requires it
 6. merge the slice and update or close the issue
+
+For public or user-visible changes, also record whether the slice improves, preserves, or worsens first-time usability and whether the CLI-first docs/examples need an update.
 
 ## Before Opening A Pull Request
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,11 @@ Current dogfooding posture:
 - use AgentForge on AgentForge for planning, design, review, QA, and release verification
 - do not treat it as a broad autonomous implementation engine yet
 
+Current onboarding focus:
+
+- keep the current wedge CLI-first and as frictionless as possible for new evaluators
+- improve README, quickstart, examples, and contributor entry points in parallel with the Phase 1 foundation work
+
 See [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md), [docs/CONTEXT_SLICE_CONTRACTS.md](docs/CONTEXT_SLICE_CONTRACTS.md), and [docs/QUEUE_EXECUTION_FLOW.md](docs/QUEUE_EXECUTION_FLOW.md).
 
 Roadmap docs:
@@ -203,5 +208,6 @@ Roadmap docs:
 - Follow the platform roadmap milestones in the GitHub milestone list.
 - Start with the roadmap docs before proposing broad new workflow claims or integration work.
 - Use the issue templates in `.github/ISSUE_TEMPLATE/` so planning data stays consistent.
+- Follow the newcomer-usability track if you want to improve the first-run CLI and onboarding experience: [#97](https://github.com/H9-Foundry/AgentForge/issues/97)
 
 If you need help or want to contribute, open an issue in this repository with the relevant template and link it to the appropriate roadmap phase or epic.

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -26,7 +26,7 @@ See [docs/SELF_HOSTING.md](SELF_HOSTING.md).
 
 ## Queue Lanes
 
-The backlog is managed in four lanes.
+The backlog is managed in four lanes plus one parallel safe lane for newcomer usability work.
 
 ### Active Lane
 
@@ -53,6 +53,25 @@ Current ready lane:
 
 5. [#78](https://github.com/H9-Foundry/AgentForge/issues/78) planning/discovery workflow MVP
 6. [#79](https://github.com/H9-Foundry/AgentForge/issues/79) architecture/design workflow MVP
+
+### Parallel Safe Lane
+
+Work that improves first-time evaluation and contributor usability without reordering the core foundation dependency chain.
+
+Current parallel safe lane:
+
+- [#97](https://github.com/H9-Foundry/AgentForge/issues/97) CLI-first onboarding and newcomer usability
+- [#98](https://github.com/H9-Foundry/AgentForge/issues/98) CLI-first README and quick trial path
+- [#99](https://github.com/H9-Foundry/AgentForge/issues/99) first-run output example and artifact walkthrough
+- [#100](https://github.com/H9-Foundry/AgentForge/issues/100) quickstart and sample repo external-evaluation flow
+- [#101](https://github.com/H9-Foundry/AgentForge/issues/101) contributor onboarding split
+- [#102](https://github.com/H9-Foundry/AgentForge/issues/102) CLI help and first-run UX review
+
+Rules:
+
+- this lane can run in parallel with the active foundation chain when it does not depend on runtime or policy changes
+- it must not reorder `#90` through `#94`
+- it should optimize first for evaluators trying the current wedge and early contributors making small changes
 
 ### Mapped Lane
 
@@ -131,6 +150,10 @@ Required:
 - `agentforge run pr-review`
 - `agentforge explain last-run`
 - docs/support updates only if capability actually becomes available
+- one explicit usability note in the PR or linked issue comment that answers:
+  - does this slice improve, preserve, or worsen first-time usability?
+  - do README, quickstart, or examples need an update?
+  - can a new evaluator still complete the documented CLI-first wedge without reading maintainer-only docs?
 
 ### Release / Public Package Slices
 
@@ -163,6 +186,7 @@ A slice is done when:
 - required validation commands passed
 - dogfooding evidence was captured where required
 - docs remain honest about current capability
+- newcomer usability impact was assessed for user-visible or public-contract changes
 - residual risks are called out explicitly
 
 The queue tracker stays open until the current dependency chain and active execution rules change materially.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -44,6 +44,7 @@ The current shipped baseline is:
 - runtime interaction model hardening
 - policy engine expansion
 - manifest and schema expansion
+- CLI-first onboarding and newcomer usability
 - support matrix and compatibility framing
 - contributor and community scaffolding
 
@@ -89,6 +90,13 @@ Use [#83](https://github.com/H9-Foundry/AgentForge/issues/83) as the live execut
 - active versus ready versus mapped versus deferred queue lanes
 - dependency ordering across the next slices
 - dogfooding and validation gates for each slice
+
+Use [#97](https://github.com/H9-Foundry/AgentForge/issues/97) as the parallel Phase 1 newcomer-usability track for:
+
+- CLI-first first-run evaluation
+- concrete output examples and artifact walkthroughs
+- quickstart and sample-repo usability
+- newcomer versus maintainer contribution paths
 
 ## Phase 2: General SDLC Expansion
 


### PR DESCRIPTION
## Summary
- add a newcomer-usability track to the Phase 1 roadmap and queue execution docs
- point top-level contributor and roadmap guidance at the new CLI-first onboarding workstream
- align the GitHub backlog with a parallel safe lane that can improve first-run usability without reordering the core foundation chain

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- the full `pnpm test` suite emitted clean passing suite output, but the captured tool session did not return a final summary line before stalling
- GitHub-side backlog updates were also made under `#97` and `#83`:
  - created the newcomer-usability umbrella and child issues `#97` through `#102`
  - updated `#83` to add the parallel safe lane
  - added usability-gate comments to `#90` through `#94`
  - added inheritance notes to `#78` and `#79`

Refs #97
Refs #83