### PR TITLE
Implement lifecycle artifact family schemas

### DIFF
--- a/.changeset/lifecycle-artifact-family-schemas.md
+++ b/.changeset/lifecycle-artifact-family-schemas.md
@@ -1,0 +1,5 @@
+---
+"@h9-foundry/agentforge-schemas": patch
+---
+
+Add the initial planning, design, review, release, and maintenance lifecycle artifact family schemas.

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -3,9 +3,14 @@ import { describe, expect, it } from "vitest";
 import {
   agentManifestSchema,
   auditBundleSchema,
+  designArtifactSchema,
   getJsonSchemas,
   lifecycleArtifactEnvelopeSchema,
+  maintenanceArtifactSchema,
   policyDocumentSchema,
+  planningArtifactSchema,
+  releaseArtifactSchema,
+  reviewArtifactSchema,
   schemaFixtures,
   workflowDefinitionSchema
 } from "./index.js";
@@ -32,6 +37,11 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.agentManifest).toBeDefined();
     expect(jsonSchemas.workflowDefinition).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
+    expect(jsonSchemas.planningArtifact).toBeDefined();
+    expect(jsonSchemas.designArtifact).toBeDefined();
+    expect(jsonSchemas.reviewArtifact).toBeDefined();
+    expect(jsonSchemas.releaseArtifact).toBeDefined();
+    expect(jsonSchemas.maintenanceArtifact).toBeDefined();
   });
 
   it("validates audit bundle metadata", () => {
@@ -106,6 +116,125 @@ describe("schema fixtures", () => {
       lifecycleArtifactEnvelopeSchema.parse({
         ...schemaFixtures.lifecycleArtifactEnvelope,
         summary: ""
+      })
+    ).toThrow();
+  });
+
+  it("validates the initial lifecycle artifact family schemas", () => {
+    const baseArtifact = {
+      ...schemaFixtures.lifecycleArtifactEnvelope,
+      source: {
+        ...schemaFixtures.lifecycleArtifactEnvelope.source,
+        issueRefs: ["#90"]
+      }
+    };
+
+    expect(() =>
+      planningArtifactSchema.parse({
+        ...baseArtifact,
+        artifactKind: "planning-brief",
+        lifecycleDomain: "plan",
+        payload: {
+          problemStatement: "Define the next planning workflow slice.",
+          objectives: ["Create a safe planning wedge"],
+          constraints: ["Keep the current wedge honest"],
+          assumptions: ["CLI remains the primary entry point"],
+          inScope: ["Planning artifact design"],
+          outOfScope: ["Runtime implementation"],
+          recommendedNextSteps: ["Draft MVP", "Open follow-up implementation issues"],
+          linkedIssues: ["#78"]
+        }
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      designArtifactSchema.parse({
+        ...baseArtifact,
+        artifactKind: "design-record",
+        lifecycleDomain: "design",
+        payload: {
+          decisionSummary: "Use workflow-scoped design artifacts.",
+          context: "The platform needs structured design outputs.",
+          optionsConsidered: [
+            { option: "artifact-first", summary: "Add explicit design artifacts." },
+            { option: "audit-only", summary: "Reuse only the audit bundle." }
+          ],
+          chosenApproach: "artifact-first",
+          tradeOffs: ["More schema surface to maintain"],
+          risks: ["Design records could drift from implementation"],
+          followUpWork: ["Implement runtime emission later"]
+        }
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      reviewArtifactSchema.parse({
+        ...baseArtifact,
+        artifactKind: "review-report",
+        lifecycleDomain: "review",
+        payload: {
+          findings: [schemaFixtures.finding],
+          recommendations: ["Address the blocked-path concern"],
+          riskLevel: "medium",
+          coverageNotes: ["Static review only"]
+        }
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      releaseArtifactSchema.parse({
+        ...baseArtifact,
+        artifactKind: "release-report",
+        lifecycleDomain: "release",
+        payload: {
+          releaseScope: "Patch release for schema contracts",
+          versionTargets: [{ name: "@h9-foundry/agentforge-schemas", version: "0.4.1" }],
+          readinessStatus: "ready",
+          verificationChecks: [{ name: "release-verify", status: "passed" }],
+          publishingPlan: ["Merge version PR", "Let GitHub Actions publish"],
+          trustStatus: "trusted-publishing-configured"
+        }
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      maintenanceArtifactSchema.parse({
+        ...baseArtifact,
+        artifactKind: "maintenance-report",
+        lifecycleDomain: "maintain",
+        payload: {
+          maintenanceScope: "Docs and dependency hygiene",
+          currentFindings: ["README needs clearer first-run guidance"],
+          recommendedActions: ["Rewrite quickstart", "Refresh sample repo docs"],
+          priorityAssessment: "high"
+        }
+      })
+    ).not.toThrow();
+  });
+
+  it("rejects mismatched lifecycle artifact family payloads", () => {
+    expect(() =>
+      planningArtifactSchema.parse({
+        ...schemaFixtures.lifecycleArtifactEnvelope,
+        artifactKind: "planning-brief",
+        lifecycleDomain: "plan",
+        payload: {
+          decisionSummary: "This is not a planning payload."
+        }
+      })
+    ).toThrow();
+
+    expect(() =>
+      reviewArtifactSchema.parse({
+        ...schemaFixtures.lifecycleArtifactEnvelope,
+        artifactKind: "review-report",
+        lifecycleDomain: "release",
+        payload: {
+          findings: [],
+          recommendations: [],
+          riskLevel: "low",
+          coverageNotes: []
+        }
       })
     ).toThrow();
   });

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -374,6 +374,118 @@ export const lifecycleArtifactEnvelopeSchema = z.object({
   payload: z.record(z.string(), z.unknown())
 });
 
+export const planningArtifactPayloadSchema = z.object({
+  problemStatement: z.string().min(1),
+  objectives: z.array(z.string().min(1)).min(1),
+  constraints: z.array(z.string().min(1)).default([]),
+  assumptions: z.array(z.string().min(1)).default([]),
+  inScope: z.array(z.string().min(1)).default([]),
+  outOfScope: z.array(z.string().min(1)).default([]),
+  recommendedNextSteps: z.array(z.string().min(1)).min(1),
+  stakeholders: z.array(z.string().min(1)).default([]),
+  risks: z.array(z.string().min(1)).default([]),
+  openQuestions: z.array(z.string().min(1)).default([]),
+  candidateWorkstreams: z.array(z.string().min(1)).default([]),
+  linkedIssues: z.array(z.string().min(1)).default([])
+});
+
+export const designArtifactOptionSchema = z.object({
+  option: z.string().min(1),
+  summary: z.string().min(1)
+});
+
+export const designArtifactPayloadSchema = z.object({
+  decisionSummary: z.string().min(1),
+  context: z.string().min(1),
+  optionsConsidered: z.array(designArtifactOptionSchema).min(1),
+  chosenApproach: z.string().min(1),
+  tradeOffs: z.array(z.string().min(1)).default([]),
+  risks: z.array(z.string().min(1)).default([]),
+  followUpWork: z.array(z.string().min(1)).default([]),
+  interfacesImpacted: z.array(z.string().min(1)).default([]),
+  schemaChangesNeeded: z.array(z.string().min(1)).default([]),
+  policyChangesNeeded: z.array(z.string().min(1)).default([]),
+  migrationNotes: z.array(z.string().min(1)).default([]),
+  compatibilityNotes: z.array(z.string().min(1)).default([])
+});
+
+export const reviewArtifactPayloadSchema = z.object({
+  findings: z.array(findingSchema).default([]),
+  recommendations: z.array(z.string().min(1)).default([]),
+  riskLevel: severitySchema,
+  coverageNotes: z.array(z.string().min(1)).default([]),
+  blockedItems: z.array(z.string().min(1)).default([]),
+  testGaps: z.array(z.string().min(1)).default([]),
+  securityConcerns: z.array(z.string().min(1)).default([]),
+  approvalRecommendations: z.array(z.string().min(1)).default([])
+});
+
+export const releaseVerificationCheckSchema = z.object({
+  name: z.string().min(1),
+  status: z.enum(["passed", "failed", "skipped"]),
+  detail: z.string().min(1).optional()
+});
+
+export const releaseVersionTargetSchema = z.object({
+  name: z.string().min(1),
+  version: z.string().min(1)
+});
+
+export const releaseArtifactPayloadSchema = z.object({
+  releaseScope: z.string().min(1),
+  versionTargets: z.array(releaseVersionTargetSchema).min(1),
+  readinessStatus: z.enum(["ready", "blocked", "partial"]),
+  verificationChecks: z.array(releaseVerificationCheckSchema).default([]),
+  publishingPlan: z.array(z.string().min(1)).default([]),
+  trustStatus: z.string().min(1),
+  publishedPackages: z.array(z.string().min(1)).default([]),
+  tagRefs: z.array(z.string().min(1)).default([]),
+  provenanceRefs: z.array(z.string().min(1)).default([]),
+  rollbackNotes: z.array(z.string().min(1)).default([]),
+  externalDependencies: z.array(z.string().min(1)).default([])
+});
+
+export const maintenanceArtifactPayloadSchema = z.object({
+  maintenanceScope: z.string().min(1),
+  currentFindings: z.array(z.string().min(1)).default([]),
+  recommendedActions: z.array(z.string().min(1)).default([]),
+  priorityAssessment: z.string().min(1),
+  dependencyUpdates: z.array(z.string().min(1)).default([]),
+  docsUpdates: z.array(z.string().min(1)).default([]),
+  stalenessSignals: z.array(z.string().min(1)).default([]),
+  followUpIssues: z.array(z.string().min(1)).default([])
+});
+
+export const planningArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("planning-brief"),
+  lifecycleDomain: z.literal("plan"),
+  payload: planningArtifactPayloadSchema
+});
+
+export const designArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("design-record"),
+  lifecycleDomain: z.literal("design"),
+  payload: designArtifactPayloadSchema
+});
+
+export const reviewArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("review-report"),
+  lifecycleDomain: z.literal("review"),
+  payload: reviewArtifactPayloadSchema
+});
+
+export const releaseArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("release-report"),
+  lifecycleDomain: z.literal("release"),
+  payload: releaseArtifactPayloadSchema
+});
+
+export const maintenanceArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("maintenance-report"),
+  lifecycleDomain: z.literal("maintain"),
+  payload: maintenanceArtifactPayloadSchema
+});
+
 export const auditBundleSchema = z.object({
   version: z.string().min(1),
   runId: z.string().min(1),
@@ -411,6 +523,19 @@ export const schemaRegistry = {
   lifecycleArtifactRepoReference: lifecycleArtifactRepoReferenceSchema,
   lifecycleArtifactAuditLink: lifecycleArtifactAuditLinkSchema,
   lifecycleArtifactEnvelope: lifecycleArtifactEnvelopeSchema,
+  planningArtifactPayload: planningArtifactPayloadSchema,
+  designArtifactOption: designArtifactOptionSchema,
+  designArtifactPayload: designArtifactPayloadSchema,
+  reviewArtifactPayload: reviewArtifactPayloadSchema,
+  releaseVerificationCheck: releaseVerificationCheckSchema,
+  releaseVersionTarget: releaseVersionTargetSchema,
+  releaseArtifactPayload: releaseArtifactPayloadSchema,
+  maintenanceArtifactPayload: maintenanceArtifactPayloadSchema,
+  planningArtifact: planningArtifactSchema,
+  designArtifact: designArtifactSchema,
+  reviewArtifact: reviewArtifactSchema,
+  releaseArtifact: releaseArtifactSchema,
+  maintenanceArtifact: maintenanceArtifactSchema,
   agentOutput: agentOutputSchema,
   agentManifest: agentManifestSchema,
   agentPluginRegistration: agentPluginRegistrationSchema,


### PR DESCRIPTION
## Summary
- add the initial planning, design, review, release, and maintenance artifact family schemas to `@h9-foundry/agentforge-schemas`
- compose each family from the shared lifecycle artifact envelope added in `#89`
- add focused schema validation coverage and a schemas package changeset for the additive public contract expansion

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `pnpm exec vitest run packages/schemas/src/index.test.ts`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Usability Note
This slice preserves the current first-time evaluator path. It adds new schema contracts but does not change the CLI commands, help surface, quickstart path, or current `pr-review` output flow, so README/quickstart/examples do not need refresh for this slice.

## Notes
- `shared-types` exports remain intentionally deferred to `#91`
- the broader fixture-heavy coverage wave remains intentionally deferred to `#92`
- the current `auditBundle` contract remains unchanged and additive

Closes #90