### PR TITLE
Export lifecycle artifact family types

### DIFF
--- a/.changeset/lifecycle-artifact-family-type-exports.md
+++ b/.changeset/lifecycle-artifact-family-type-exports.md
@@ -1,0 +1,5 @@
+---
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Export the initial lifecycle artifact family types from shared-types.

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -1,0 +1,33 @@
+import { describe, expectTypeOf, it } from "vitest";
+
+import type {
+  DesignArtifact,
+  DesignArtifactOption,
+  MaintenanceArtifact,
+  PlanningArtifact,
+  ReleaseArtifact,
+  ReleaseVerificationCheck,
+  ReleaseVersionTarget,
+  ReviewArtifact
+} from "./index.js";
+
+describe("shared lifecycle artifact types", () => {
+  it("exports family-specific artifact literals", () => {
+    expectTypeOf<PlanningArtifact["artifactKind"]>().toEqualTypeOf<"planning-brief">();
+    expectTypeOf<PlanningArtifact["lifecycleDomain"]>().toEqualTypeOf<"plan">();
+    expectTypeOf<DesignArtifact["artifactKind"]>().toEqualTypeOf<"design-record">();
+    expectTypeOf<DesignArtifact["lifecycleDomain"]>().toEqualTypeOf<"design">();
+    expectTypeOf<ReviewArtifact["artifactKind"]>().toEqualTypeOf<"review-report">();
+    expectTypeOf<ReviewArtifact["lifecycleDomain"]>().toEqualTypeOf<"review">();
+    expectTypeOf<ReleaseArtifact["artifactKind"]>().toEqualTypeOf<"release-report">();
+    expectTypeOf<ReleaseArtifact["lifecycleDomain"]>().toEqualTypeOf<"release">();
+    expectTypeOf<MaintenanceArtifact["artifactKind"]>().toEqualTypeOf<"maintenance-report">();
+    expectTypeOf<MaintenanceArtifact["lifecycleDomain"]>().toEqualTypeOf<"maintain">();
+  });
+
+  it("exports nested payload helper types", () => {
+    expectTypeOf<DesignArtifact["payload"]["optionsConsidered"]>().toEqualTypeOf<DesignArtifactOption[]>();
+    expectTypeOf<ReleaseArtifact["payload"]["verificationChecks"]>().toEqualTypeOf<ReleaseVerificationCheck[]>();
+    expectTypeOf<ReleaseArtifact["payload"]["versionTargets"]>().toEqualTypeOf<ReleaseVersionTarget[]>();
+  });
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -18,10 +18,23 @@ import {
   auditRedactionSchema,
   auditEntrySchema,
   blockedPluginSchema,
+  designArtifactOptionSchema,
+  designArtifactPayloadSchema,
+  designArtifactSchema,
   effectivePolicySnapshotSchema,
   findingSchema,
+  maintenanceArtifactPayloadSchema,
+  maintenanceArtifactSchema,
   policyDocumentSchema,
+  planningArtifactPayloadSchema,
+  planningArtifactSchema,
   proposedActionSchema,
+  releaseArtifactPayloadSchema,
+  releaseArtifactSchema,
+  releaseVerificationCheckSchema,
+  releaseVersionTargetSchema,
+  reviewArtifactPayloadSchema,
+  reviewArtifactSchema,
   trustMetadataSchema,
   trustSourceSchema,
   trustTierSchema,
@@ -46,6 +59,19 @@ export type LifecycleArtifactSourceReference = Infer<typeof lifecycleArtifactSou
 export type LifecycleArtifactRepoReference = Infer<typeof lifecycleArtifactRepoReferenceSchema>;
 export type LifecycleArtifactAuditLink = Infer<typeof lifecycleArtifactAuditLinkSchema>;
 export type LifecycleArtifactEnvelope = Infer<typeof lifecycleArtifactEnvelopeSchema>;
+export type PlanningArtifactPayload = Infer<typeof planningArtifactPayloadSchema>;
+export type PlanningArtifact = Infer<typeof planningArtifactSchema>;
+export type DesignArtifactOption = Infer<typeof designArtifactOptionSchema>;
+export type DesignArtifactPayload = Infer<typeof designArtifactPayloadSchema>;
+export type DesignArtifact = Infer<typeof designArtifactSchema>;
+export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
+export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;
+export type ReleaseVerificationCheck = Infer<typeof releaseVerificationCheckSchema>;
+export type ReleaseVersionTarget = Infer<typeof releaseVersionTargetSchema>;
+export type ReleaseArtifactPayload = Infer<typeof releaseArtifactPayloadSchema>;
+export type ReleaseArtifact = Infer<typeof releaseArtifactSchema>;
+export type MaintenanceArtifactPayload = Infer<typeof maintenanceArtifactPayloadSchema>;
+export type MaintenanceArtifact = Infer<typeof maintenanceArtifactSchema>;
 export type AgentOutput = Infer<typeof agentOutputSchema>;
 export type AgentManifest = Infer<typeof agentManifestSchema>;
 export type AgentPluginRegistration = Infer<typeof agentPluginRegistrationSchema>;


### PR DESCRIPTION
## Summary
- export the lifecycle artifact family types from `@h9-foundry/agentforge-shared-types`
- add focused compile-time coverage for the new shared type exports
- add release bookkeeping for the shared-types package

Closes #91.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `pnpm exec vitest run packages/shared-types/src/index.test.ts`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Usability impact
- preserves the current CLI-first newcomer path
- no CLI/help/output changes in this slice
- no README/quickstart/example refresh needed for this type-export-only change