### PR TITLE
Add runtime lifecycle artifact linkage

### DIFF
--- a/.changeset/runtime-lifecycle-artifact-linkage.md
+++ b/.changeset/runtime-lifecycle-artifact-linkage.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-runtime": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add runtime lifecycle artifact emission and audit linkage support.

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { agentOutputSchema } from "@h9-foundry/agentforge-schemas";
+import { agentOutputSchema, lifecycleArtifactSchema, schemaFixtures } from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
-import type { WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type { Finding, LifecycleArtifact, ProposedAction, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
 
 import { runWorkflow } from "./index.js";
 
@@ -63,6 +63,7 @@ const state: WorkflowStateEnvelope = {
   approvals: [],
   findings: [],
   proposedActions: [],
+  lifecycleArtifacts: [],
   blockedPlugins: [],
   agentResults: {},
   auditTrail: []
@@ -87,6 +88,7 @@ const noopAgent: RuntimeAgent = {
       summary: "Completed",
       findings: [],
       proposedActions: [],
+      lifecycleArtifacts: [],
       requestedTools: [],
       blockedActionFlags: [],
       metadata: {}
@@ -124,6 +126,7 @@ describe("runtime", () => {
     expect(result.state.auditTrail).toHaveLength(2);
     expect(result.bundle.redaction.applied).toBe(true);
     expect(result.bundle.components.some((component) => component.kind === "agent" && component.name === "noop")).toBe(true);
+    expect(result.state.lifecycleArtifacts).toHaveLength(0);
   });
 
   it("does not execute approval-gated tools", async () => {
@@ -146,6 +149,7 @@ describe("runtime", () => {
           summary: "Completed",
           findings: [],
           proposedActions: [],
+          lifecycleArtifacts: [],
           requestedTools: [],
           blockedActionFlags: [],
           metadata: {}
@@ -201,5 +205,74 @@ describe("runtime", () => {
 
     expect(executed).toBe(false);
     expect(result.bundle.entries[0]?.blockedActions[0]).toContain("approval");
+  });
+
+  it("records emitted lifecycle artifacts with audit linkage", async () => {
+    const artifactAgent: RuntimeAgent = {
+      ...noopAgent,
+      manifest: {
+        ...noopAgent.manifest,
+        name: "artifact-agent"
+      },
+      async execute() {
+        const finding: Finding = {
+          ...schemaFixtures.finding,
+          tags: [...schemaFixtures.finding.tags]
+        };
+        const proposedAction: ProposedAction = {
+          id: "action-1",
+          title: "Open follow-up issue",
+          summary: "Track the next implementation slice.",
+          sideEffectClass: "suggest",
+          targetPaths: [],
+          approvalRequired: true
+        };
+        const lifecycleArtifact: LifecycleArtifact = lifecycleArtifactSchema.parse(
+          JSON.parse(JSON.stringify(schemaFixtures.planningArtifact))
+        );
+
+        return {
+          summary: "Produced a planning artifact",
+          findings: [finding],
+          proposedActions: [proposedAction],
+          lifecycleArtifacts: [lifecycleArtifact],
+          requestedTools: [],
+          blockedActionFlags: [],
+          metadata: {}
+        };
+      }
+    };
+
+    const result = await runWorkflow({
+      workflow: {
+        version: 1,
+        name: "planning-discovery",
+        trigger: "manual",
+        nodes: [{ id: "plan", kind: "deterministic", agent: "artifact-agent", outputsTo: "agentResults.plan", contextSections: [], tools: [] }]
+      },
+      initialState: {
+        ...state,
+        workflow: "planning-discovery"
+      },
+      agents: new Map([["artifact-agent", artifactAgent]]),
+      adapters: new Map(),
+      policyEngine: {
+        snapshot: state.policy,
+        canReadPath: () => ({ allowed: true, effect: "allow", requiresApproval: false }),
+        canWritePath: () => ({ allowed: false, effect: "approval_required", requiresApproval: true, reason: "Write requires approval." }),
+        evaluateToolRequest: () => ({ allowed: false, effect: "deny", requiresApproval: false }),
+        redactSecrets: (value) => value
+      },
+      artifactJsonPath: ".agentops/runs/run-1/bundle.json",
+      artifactMarkdownPath: ".agentops/runs/run-1/summary.md"
+    });
+
+    expect(result.state.lifecycleArtifacts).toHaveLength(1);
+    expect(result.state.lifecycleArtifacts[0]?.source.runId).toBe("run-1");
+    expect(result.state.lifecycleArtifacts[0]?.auditLink.bundlePath).toBe(".agentops/runs/run-1/bundle.json");
+    expect(result.state.lifecycleArtifacts[0]?.auditLink.entryIds).toContain("run-1-plan");
+    expect(result.state.lifecycleArtifacts[0]?.auditLink.findingIds).toContain("finding-1");
+    expect(result.state.lifecycleArtifacts[0]?.auditLink.proposedActionIds).toContain("action-1");
+    expect(result.bundle.entries[0]?.summary).toBe("Produced a planning artifact");
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1,9 +1,10 @@
 import { buildAuditBundle, createAuditEntry } from "@h9-foundry/agentforge-audit";
-import { agentOutputSchema, toolResultSchema } from "@h9-foundry/agentforge-schemas";
+import { agentOutputSchema, lifecycleArtifactSchema, toolResultSchema } from "@h9-foundry/agentforge-schemas";
 import type {
   AuditComponent,
   AuditBundle,
   EffectivePolicySnapshot,
+  LifecycleArtifact,
   ToolRequest,
   ToolResult,
   WorkflowDefinition,
@@ -196,12 +197,41 @@ function sliceState(state: WorkflowStateEnvelope, sections: readonly string[]): 
   return slice;
 }
 
+function linkLifecycleArtifacts(
+  artifacts: readonly LifecycleArtifact[],
+  context: {
+    readonly runId: string;
+    readonly auditEntryId: string;
+    readonly bundlePath: string;
+    readonly findingIds: readonly string[];
+    readonly proposedActionIds: readonly string[];
+  }
+): LifecycleArtifact[] {
+  return artifacts.map((artifact) =>
+    lifecycleArtifactSchema.parse({
+      ...artifact,
+      source: {
+        ...artifact.source,
+        runId: artifact.source.sourceType === "workflow-run" ? context.runId : artifact.source.runId
+      },
+      auditLink: {
+        ...artifact.auditLink,
+        bundlePath: context.bundlePath,
+        entryIds: Array.from(new Set([...artifact.auditLink.entryIds, context.auditEntryId])),
+        findingIds: Array.from(new Set([...artifact.auditLink.findingIds, ...context.findingIds])),
+        proposedActionIds: Array.from(new Set([...artifact.auditLink.proposedActionIds, ...context.proposedActionIds]))
+      }
+    })
+  );
+}
+
 export async function runWorkflow(deps: WorkflowRunDependencies): Promise<{ state: WorkflowStateEnvelope; bundle: AuditBundle }> {
   const startedAt = new Date().toISOString();
   const state: WorkflowStateEnvelope = {
     ...deps.initialState,
     findings: [...(deps.initialState.findings ?? [])],
     proposedActions: [...(deps.initialState.proposedActions ?? [])],
+    lifecycleArtifacts: [...(deps.initialState.lifecycleArtifacts ?? [])],
     blockedPlugins: [...(deps.initialState.blockedPlugins ?? [])],
     agentResults: { ...(deps.initialState.agentResults ?? {}) },
     auditTrail: [...(deps.initialState.auditTrail ?? [])]
@@ -255,13 +285,26 @@ export async function runWorkflow(deps: WorkflowRunDependencies): Promise<{ stat
       )
     );
 
-    state.agentResults[node.id] = output;
+    const auditEntryId = `${state.runId}-${node.id}`;
+    const linkedLifecycleArtifacts = linkLifecycleArtifacts(output.lifecycleArtifacts, {
+      runId: state.runId,
+      auditEntryId,
+      bundlePath: deps.artifactJsonPath,
+      findingIds: output.findings.map((finding) => finding.id),
+      proposedActionIds: output.proposedActions.map((action) => action.id)
+    });
+
+    state.agentResults[node.id] = {
+      ...output,
+      lifecycleArtifacts: linkedLifecycleArtifacts
+    };
     state.findings.push(...output.findings);
     state.proposedActions.push(...output.proposedActions);
+    state.lifecycleArtifacts.push(...linkedLifecycleArtifacts);
 
     state.auditTrail.push(
       createAuditEntry({
-        id: `${state.runId}-${node.id}`,
+        id: auditEntryId,
         nodeId: node.id,
         nodeName: agent.manifest.name,
         kind: agent.manifest.runtime.kind,

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -139,6 +139,7 @@ export const agentOutputSchema = z.object({
   summary: z.string().min(1),
   findings: z.array(findingSchema).default([]),
   proposedActions: z.array(proposedActionSchema).default([]),
+  lifecycleArtifacts: z.array(z.lazy(() => lifecycleArtifactSchema)).default([]),
   requestedTools: z.array(toolRequestSchema).default([]),
   blockedActionFlags: z.array(z.string()).default([]),
   confidence: z.number().min(0).max(1).optional(),
@@ -305,6 +306,7 @@ export const workflowStateEnvelopeSchema = z.object({
   approvals: z.array(approvalCheckpointSchema).default([]),
   findings: z.array(findingSchema).default([]),
   proposedActions: z.array(proposedActionSchema).default([]),
+  lifecycleArtifacts: z.array(z.lazy(() => lifecycleArtifactSchema)).default([]),
   blockedPlugins: z.array(blockedPluginSchema).default([]),
   agentResults: z.record(z.string(), agentOutputSchema).default({}),
   auditTrail: z.array(auditEntrySchema).default([])
@@ -486,6 +488,14 @@ export const maintenanceArtifactSchema = lifecycleArtifactEnvelopeSchema.extend(
   payload: maintenanceArtifactPayloadSchema
 });
 
+export const lifecycleArtifactSchema = z.discriminatedUnion("artifactKind", [
+  planningArtifactSchema,
+  designArtifactSchema,
+  reviewArtifactSchema,
+  releaseArtifactSchema,
+  maintenanceArtifactSchema
+]);
+
 export const auditBundleSchema = z.object({
   version: z.string().min(1),
   runId: z.string().min(1),
@@ -536,6 +546,7 @@ export const schemaRegistry = {
   reviewArtifact: reviewArtifactSchema,
   releaseArtifact: releaseArtifactSchema,
   maintenanceArtifact: maintenanceArtifactSchema,
+  lifecycleArtifact: lifecycleArtifactSchema,
   agentOutput: agentOutputSchema,
   agentManifest: agentManifestSchema,
   agentPluginRegistration: agentPluginRegistrationSchema,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -10,6 +10,7 @@ import {
   auditBundleSchema,
   auditComponentSchema,
   lifecycleArtifactAuditLinkSchema,
+  lifecycleArtifactSchema,
   lifecycleArtifactEnvelopeSchema,
   lifecycleArtifactRepoReferenceSchema,
   lifecycleArtifactSourceReferenceSchema,
@@ -59,6 +60,7 @@ export type LifecycleArtifactSourceReference = Infer<typeof lifecycleArtifactSou
 export type LifecycleArtifactRepoReference = Infer<typeof lifecycleArtifactRepoReferenceSchema>;
 export type LifecycleArtifactAuditLink = Infer<typeof lifecycleArtifactAuditLinkSchema>;
 export type LifecycleArtifactEnvelope = Infer<typeof lifecycleArtifactEnvelopeSchema>;
+export type LifecycleArtifact = Infer<typeof lifecycleArtifactSchema>;
 export type PlanningArtifactPayload = Infer<typeof planningArtifactPayloadSchema>;
 export type PlanningArtifact = Infer<typeof planningArtifactSchema>;
 export type DesignArtifactOption = Infer<typeof designArtifactOptionSchema>;


### PR DESCRIPTION
## Summary
- add lifecycle artifact union support to the shared schema/type surface where the runtime needs it
- let agent outputs and workflow state carry lifecycle artifacts explicitly
- have the runtime append emitted lifecycle artifacts with audit entry and bundle linkage

Closes #93.

## Validation
- `pnpm exec vitest run packages/runtime/src/index.test.ts packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Usability impact
- preserves the current CLI-first newcomer path
- no CLI/help/output changes in this slice
- no README/quickstart/example refresh needed for this runtime-contract change