### PR TITLE
Add lifecycle artifact sanitization

### DIFF
--- a/.changeset/policy-artifact-redaction.md
+++ b/.changeset/policy-artifact-redaction.md
@@ -1,0 +1,6 @@
+---
+"@h9-foundry/agentforge-policy-engine": patch
+"@h9-foundry/agentforge-runtime": patch
+---
+
+Add lifecycle artifact sanitization and redaction handling.

--- a/packages/policy-engine/src/index.test.ts
+++ b/packages/policy-engine/src/index.test.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
 
+import { lifecycleArtifactSchema, schemaFixtures } from "@h9-foundry/agentforge-schemas";
+
 import { createPolicyEngine, loadPolicyDocument, resolvePolicy } from "./index.js";
 
 describe("policy engine", () => {
@@ -150,5 +152,60 @@ describe("policy engine", () => {
     expect(engine.evaluatePluginTrust("community-plugin", { tier: "community", source: "local", reviewed: true }).allowed).toBe(false);
     expect(engine.evaluatePluginTrust("remote-plugin", { tier: "verified", source: "third-party", reviewed: true }).allowed).toBe(false);
     expect(engine.evaluatePluginTrust("unreviewed-plugin", { tier: "verified", source: "local", reviewed: false }).allowed).toBe(false);
+  });
+
+  it("sanitizes lifecycle artifact summaries and nested payload strings", () => {
+    const engine = createPolicyEngine(
+      {
+        version: 1,
+        environment: "local",
+        resolvedAt: new Date().toISOString(),
+        defaults: {
+          executionMode: "inspect",
+          modelAccess: false,
+          network: "deny",
+          writes: "approval_required"
+        },
+        paths: {
+          allowedRead: ["**/*"],
+          allowedWrite: [".agentops/runs/**", "tests/**"],
+          blocked: [".env*", "secrets/**"]
+        },
+        plugins: {
+          allowedTiers: ["core", "verified"],
+          allowedSources: ["official", "local"],
+          requireReviewed: true
+        },
+        tools: {
+          "filesystem.read-file": { effect: "allow" }
+        }
+      },
+      "/repo"
+    );
+
+    const planningArtifact = lifecycleArtifactSchema.parse(JSON.parse(JSON.stringify(schemaFixtures.planningArtifact)));
+    expect(planningArtifact.artifactKind).toBe("planning-brief");
+    if (planningArtifact.artifactKind !== "planning-brief") {
+      throw new Error("Expected planning artifact fixture");
+    }
+
+    const sanitized = engine.sanitizeLifecycleArtifact({
+      ...planningArtifact,
+      summary: "summary token=ghp_1234567890ABCDE",
+      payload: {
+        ...planningArtifact.payload,
+        assumptions: ["password=hunter2"],
+        recommendedNextSteps: ["Call Bearer sk-abcdef123456"]
+      }
+    });
+
+    expect(sanitized.summary).toContain("[REDACTED_TOKEN]");
+    expect(sanitized.artifactKind).toBe("planning-brief");
+    if (sanitized.artifactKind !== "planning-brief") {
+      throw new Error("Expected sanitized planning artifact");
+    }
+    expect(sanitized.payload.assumptions[0]).toContain("[REDACTED_PASSWORD]");
+    expect(sanitized.payload.recommendedNextSteps[0]).toContain("[REDACTED_API_KEY]");
+    expect(sanitized.payload.linkedIssues).toEqual(planningArtifact.payload.linkedIssues);
   });
 });

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -4,10 +4,11 @@ import { isAbsolute, relative, resolve } from "node:path";
 import yaml from "js-yaml";
 import picomatch from "picomatch";
 
-import { policyDocumentSchema } from "@h9-foundry/agentforge-schemas";
+import { lifecycleArtifactSchema, policyDocumentSchema } from "@h9-foundry/agentforge-schemas";
 import type {
   EffectivePolicySnapshot,
   ExecutionEnvironment,
+  LifecycleArtifact,
   PolicyDocument,
   TrustMetadata,
   ToolRequest
@@ -165,6 +166,24 @@ function matchesAny(pathValue: string, patterns: readonly string[]): boolean {
   return patterns.some((pattern) => picomatch(pattern)(pathValue));
 }
 
+function sanitizeUnknown(value: unknown, redactSecrets: (value: string) => string): unknown {
+  if (typeof value === "string") {
+    return redactSecrets(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeUnknown(entry, redactSecrets));
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [key, sanitizeUnknown(entry, redactSecrets)])
+    );
+  }
+
+  return value;
+}
+
 export function loadPolicyDocument(policyPath: string): PolicyDocument {
   const fileContents = readFileSync(policyPath, "utf8");
   const parsed = yaml.load(fileContents);
@@ -264,6 +283,10 @@ export function createPolicyEngine(policy: EffectivePolicySnapshot, repoRoot: st
       .replaceAll(/-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]+?-----END [A-Z ]*PRIVATE KEY-----/g, "[REDACTED_PRIVATE_KEY]");
   }
 
+  function sanitizeLifecycleArtifact(artifact: LifecycleArtifact): LifecycleArtifact {
+    return lifecycleArtifactSchema.parse(sanitizeUnknown(artifact, redactSecrets));
+  }
+
   return {
     snapshot: policy,
     canReadPath(pathValue: string): PolicyDecision {
@@ -277,6 +300,7 @@ export function createPolicyEngine(policy: EffectivePolicySnapshot, repoRoot: st
     filterBlockedPaths(paths: readonly string[]): string[] {
       return paths.filter((pathValue) => evaluatePath(pathValue, "read").allowed);
     },
-    redactSecrets
+    redactSecrets,
+    sanitizeLifecycleArtifact
   };
 }

--- a/packages/runtime/src/index.test.ts
+++ b/packages/runtime/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import { agentOutputSchema, lifecycleArtifactSchema, schemaFixtures } from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
-import type { Finding, LifecycleArtifact, ProposedAction, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type { Finding, ProposedAction, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
 
 import { runWorkflow } from "./index.js";
 
@@ -116,7 +116,8 @@ describe("runtime", () => {
         canReadPath: () => ({ allowed: true, effect: "allow", requiresApproval: false }),
         canWritePath: () => ({ allowed: false, effect: "approval_required", requiresApproval: true, reason: "Write requires approval." }),
         evaluateToolRequest: () => ({ allowed: false, effect: "deny", requiresApproval: false }),
-        redactSecrets: (value) => value
+        redactSecrets: (value) => value,
+        sanitizeLifecycleArtifact: (artifact) => artifact
       },
       artifactJsonPath: ".agentops/runs/run-1/bundle.json",
       artifactMarkdownPath: ".agentops/runs/run-1/summary.md"
@@ -197,7 +198,8 @@ describe("runtime", () => {
           requiresApproval: true,
           reason: "Tool requires approval: filesystem.write-file"
         }),
-        redactSecrets: (value) => value
+        redactSecrets: (value) => value,
+        sanitizeLifecycleArtifact: (artifact) => artifact
       },
       artifactJsonPath: ".agentops/runs/run-1/bundle.json",
       artifactMarkdownPath: ".agentops/runs/run-1/summary.md"
@@ -227,15 +229,28 @@ describe("runtime", () => {
           targetPaths: [],
           approvalRequired: true
         };
-        const lifecycleArtifact: LifecycleArtifact = lifecycleArtifactSchema.parse(
+        const lifecycleArtifact = lifecycleArtifactSchema.parse(
           JSON.parse(JSON.stringify(schemaFixtures.planningArtifact))
         );
+        expect(lifecycleArtifact.artifactKind).toBe("planning-brief");
+        if (lifecycleArtifact.artifactKind !== "planning-brief") {
+          throw new Error("Expected planning artifact fixture");
+        }
 
         return {
-          summary: "Produced a planning artifact",
+          summary: "Produced a planning artifact token=ghp_1234567890ABCDE",
           findings: [finding],
           proposedActions: [proposedAction],
-          lifecycleArtifacts: [lifecycleArtifact],
+          lifecycleArtifacts: [
+            {
+              ...lifecycleArtifact,
+              summary: "Artifact password=hunter2",
+              payload: {
+                ...lifecycleArtifact.payload,
+                assumptions: ["Bearer sk-abcdef123456"]
+              }
+            }
+          ],
           requestedTools: [],
           blockedActionFlags: [],
           metadata: {}
@@ -261,7 +276,24 @@ describe("runtime", () => {
         canReadPath: () => ({ allowed: true, effect: "allow", requiresApproval: false }),
         canWritePath: () => ({ allowed: false, effect: "approval_required", requiresApproval: true, reason: "Write requires approval." }),
         evaluateToolRequest: () => ({ allowed: false, effect: "deny", requiresApproval: false }),
-        redactSecrets: (value) => value
+        redactSecrets: (value) =>
+          value
+            .replaceAll("ghp_1234567890ABCDE", "[REDACTED_GITHUB_TOKEN]")
+            .replaceAll("hunter2", "[REDACTED_PASSWORD]")
+            .replaceAll("sk-abcdef123456", "[REDACTED_API_KEY]"),
+        sanitizeLifecycleArtifact: (artifact) =>
+          artifact.artifactKind === "planning-brief"
+            ? lifecycleArtifactSchema.parse({
+                ...artifact,
+                summary: artifact.summary.replaceAll("password=hunter2", "password=[REDACTED_PASSWORD]"),
+                payload: {
+                  ...artifact.payload,
+                  assumptions: artifact.payload.assumptions.map((value: string) =>
+                    value.replaceAll("Bearer sk-abcdef123456", "Bearer [REDACTED_API_KEY]")
+                  )
+                }
+              })
+            : artifact
       },
       artifactJsonPath: ".agentops/runs/run-1/bundle.json",
       artifactMarkdownPath: ".agentops/runs/run-1/summary.md"
@@ -273,6 +305,13 @@ describe("runtime", () => {
     expect(result.state.lifecycleArtifacts[0]?.auditLink.entryIds).toContain("run-1-plan");
     expect(result.state.lifecycleArtifacts[0]?.auditLink.findingIds).toContain("finding-1");
     expect(result.state.lifecycleArtifacts[0]?.auditLink.proposedActionIds).toContain("action-1");
-    expect(result.bundle.entries[0]?.summary).toBe("Produced a planning artifact");
+    expect(result.state.lifecycleArtifacts[0]?.summary).toContain("[REDACTED_PASSWORD]");
+    const emittedArtifact = result.state.lifecycleArtifacts[0];
+    expect(emittedArtifact?.artifactKind).toBe("planning-brief");
+    if (!emittedArtifact || emittedArtifact.artifactKind !== "planning-brief") {
+      throw new Error("Expected emitted planning artifact");
+    }
+    expect(emittedArtifact.payload.assumptions[0]).toContain("[REDACTED_API_KEY]");
+    expect(result.bundle.entries[0]?.summary).toContain("[REDACTED_GITHUB_TOKEN]");
   });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -33,6 +33,7 @@ export interface PolicyEngineLike {
     reason?: string;
   };
   redactSecrets(value: string): string;
+  sanitizeLifecycleArtifact(artifact: LifecycleArtifact): LifecycleArtifact;
 }
 
 export interface WorkflowRunDependencies {
@@ -292,7 +293,7 @@ export async function runWorkflow(deps: WorkflowRunDependencies): Promise<{ stat
       bundlePath: deps.artifactJsonPath,
       findingIds: output.findings.map((finding) => finding.id),
       proposedActionIds: output.proposedActions.map((action) => action.id)
-    });
+    }).map((artifact) => deps.policyEngine.sanitizeLifecycleArtifact(artifact));
 
     state.agentResults[node.id] = {
       ...output,


### PR DESCRIPTION
Closes #94

## Summary
- add policy-engine lifecycle artifact sanitization and redaction helpers
- sanitize emitted lifecycle artifacts in the runtime before persistence
- cover nested payload redaction and structure preservation in focused tests

## Validation
- `pnpm exec vitest run packages/policy-engine/src/index.test.ts packages/runtime/src/index.test.ts packages/schemas/src/index.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- `pnpm test` showed all suites passing in tool output, but the capture session did not return a final summary line before stalling

## Usability impact
- preserves the current first-time evaluator path
- no CLI commands or onboarding docs changed in this slice
- no README/quickstart refresh needed for this policy/runtime-only change