### PR TITLE
Increase release guide test timeout

### DIFF
--- a/packages/cli/src/release-preflight.test.ts
+++ b/packages/cli/src/release-preflight.test.ts
@@ -223,7 +223,7 @@ describe("release preflight", () => {
     expect(guide).toContain("https://www.npmjs.com/org/create");
   });
 
-  it("exposes the release guide command from the CLI", () => {
+  it("exposes the release guide command from the CLI", { timeout: 15000 }, () => {
     const result = spawnSync("pnpm", ["exec", "tsx", "packages/cli/src/bin.ts", "release", "guide"], {
       cwd: process.cwd(),
       encoding: "utf8"


### PR DESCRIPTION
## Summary
- increase the timeout on the `release guide` CLI smoke test
- keep the fix scoped to local validation only

## Validation
- `pnpm exec vitest run packages/cli/src/release-preflight.test.ts`
- focused suite now passes, including `release guide`
- local `pnpm test` previously exposed this timeout specifically while the release/version work was being prepared

## Notes
- this is a validation fix so the open release PR can sit on a clean base again