### PR TITLE
Version public AgentForge packages

### DIFF
--- a/.changeset/lifecycle-artifact-envelope-schema.md
+++ b/.changeset/lifecycle-artifact-envelope-schema.md
@@ -1,6 +1,0 @@
----
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Add a shared lifecycle artifact envelope schema and inferred types for future SDLC artifact families.

--- a/.changeset/lifecycle-artifact-family-schemas.md
+++ b/.changeset/lifecycle-artifact-family-schemas.md
@@ -1,5 +1,0 @@
----
-"@h9-foundry/agentforge-schemas": patch
----
-
-Add the initial planning, design, review, release, and maintenance lifecycle artifact family schemas.

--- a/.changeset/lifecycle-artifact-family-type-exports.md
+++ b/.changeset/lifecycle-artifact-family-type-exports.md
@@ -1,5 +1,0 @@
----
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Export the initial lifecycle artifact family types from shared-types.

--- a/.changeset/lifecycle-artifact-fixtures-and-coverage.md
+++ b/.changeset/lifecycle-artifact-fixtures-and-coverage.md
@@ -1,5 +1,0 @@
----
-"@h9-foundry/agentforge-schemas": patch
----
-
-Add lifecycle artifact fixtures and focused schema coverage.

--- a/.changeset/policy-artifact-redaction.md
+++ b/.changeset/policy-artifact-redaction.md
@@ -1,6 +1,0 @@
----
-"@h9-foundry/agentforge-policy-engine": patch
-"@h9-foundry/agentforge-runtime": patch
----
-
-Add lifecycle artifact sanitization and redaction handling.

--- a/.changeset/runtime-lifecycle-artifact-linkage.md
+++ b/.changeset/runtime-lifecycle-artifact-linkage.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-runtime": patch
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Add runtime lifecycle artifact emission and audit linkage support.

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @h9-foundry/agentforge-audit
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [6bd74e6]
+- Updated dependencies [0c1af6b]
+- Updated dependencies [65eb7e0]
+  - @h9-foundry/agentforge-shared-types@0.4.1
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-audit",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @h9-foundry/agentforge-cli
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [6bd74e6]
+- Updated dependencies [86edea7]
+- Updated dependencies [0c1af6b]
+- Updated dependencies [b78fb05]
+- Updated dependencies [2772d1d]
+- Updated dependencies [65eb7e0]
+  - @h9-foundry/agentforge-schemas@0.4.1
+  - @h9-foundry/agentforge-shared-types@0.4.1
+  - @h9-foundry/agentforge-policy-engine@0.4.1
+  - @h9-foundry/agentforge-runtime@0.4.1
+  - @h9-foundry/agentforge-context-engine@0.4.1
+  - @h9-foundry/agentforge-audit@0.4.1
+  - @h9-foundry/agentforge-sdk@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-cli",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/context-engine/CHANGELOG.md
+++ b/packages/context-engine/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @h9-foundry/agentforge-context-engine
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [6bd74e6]
+- Updated dependencies [86edea7]
+- Updated dependencies [0c1af6b]
+- Updated dependencies [b78fb05]
+- Updated dependencies [65eb7e0]
+  - @h9-foundry/agentforge-schemas@0.4.1
+  - @h9-foundry/agentforge-shared-types@0.4.1
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Repository and execution context collection for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/policy-engine/CHANGELOG.md
+++ b/packages/policy-engine/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @h9-foundry/agentforge-policy-engine
 
+## 0.4.1
+
+### Patch Changes
+
+- 2772d1d: Add lifecycle artifact sanitization and redaction handling.
+- Updated dependencies [6bd74e6]
+- Updated dependencies [86edea7]
+- Updated dependencies [0c1af6b]
+- Updated dependencies [b78fb05]
+- Updated dependencies [65eb7e0]
+  - @h9-foundry/agentforge-schemas@0.4.1
+  - @h9-foundry/agentforge-shared-types@0.4.1
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @h9-foundry/agentforge-runtime
 
+## 0.4.1
+
+### Patch Changes
+
+- 2772d1d: Add lifecycle artifact sanitization and redaction handling.
+- 65eb7e0: Add runtime lifecycle artifact emission and audit linkage support.
+- Updated dependencies [6bd74e6]
+- Updated dependencies [86edea7]
+- Updated dependencies [0c1af6b]
+- Updated dependencies [b78fb05]
+- Updated dependencies [2772d1d]
+- Updated dependencies [65eb7e0]
+  - @h9-foundry/agentforge-schemas@0.4.1
+  - @h9-foundry/agentforge-shared-types@0.4.1
+  - @h9-foundry/agentforge-policy-engine@0.4.1
+  - @h9-foundry/agentforge-audit@0.4.1
+  - @h9-foundry/agentforge-sdk@0.4.1
+
 ## 0.4.0
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @h9-foundry/agentforge-schemas
 
+## 0.4.1
+
+### Patch Changes
+
+- 6bd74e6: Add a shared lifecycle artifact envelope schema and inferred types for future SDLC artifact families.
+- 86edea7: Add the initial planning, design, review, release, and maintenance lifecycle artifact family schemas.
+- b78fb05: Add lifecycle artifact fixtures and focused schema coverage.
+- 65eb7e0: Add runtime lifecycle artifact emission and audit linkage support.
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @h9-foundry/agentforge-sdk
 
+## 0.4.1
+
+### Patch Changes
+
+- Updated dependencies [6bd74e6]
+- Updated dependencies [0c1af6b]
+- Updated dependencies [65eb7e0]
+  - @h9-foundry/agentforge-shared-types@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @h9-foundry/agentforge-shared-types
 
+## 0.4.1
+
+### Patch Changes
+
+- 6bd74e6: Add a shared lifecycle artifact envelope schema and inferred types for future SDLC artifact families.
+- 0c1af6b: Export the initial lifecycle artifact family types from shared-types.
+- 65eb7e0: Add runtime lifecycle artifact emission and audit linkage support.
+- Updated dependencies [6bd74e6]
+- Updated dependencies [86edea7]
+- Updated dependencies [b78fb05]
+- Updated dependencies [65eb7e0]
+  - @h9-foundry/agentforge-schemas@0.4.1
+
 ## 0.4.0
 
 ### Minor Changes

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
   "license": "MIT",
   "author": "H9 Foundry",


### PR DESCRIPTION
Replacement for #96 so required checks can attach to a human-owned branch.

This PR contains the same 0.4.1 Changesets release content currently staged on `changeset-release/main` and is intended to publish the merged Phase 1 foundation/runtime/schema work plus the README onboarding improvement.

## Release summary
- `@h9-foundry/agentforge-schemas@0.4.1`
- `@h9-foundry/agentforge-shared-types@0.4.1`
- `@h9-foundry/agentforge-runtime@0.4.1`
- `@h9-foundry/agentforge-policy-engine@0.4.1`
- dependent curated public packages updated accordingly

## Notes
- bot PR #96 remains open but is stuck in GitHub's pending-without-contexts state after branch refreshes
- merge this PR instead once required checks pass so the release workflow can publish normally