### PR TITLE
Document first-run output and external evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,34 @@ That path creates `.agentops/` locally and writes run artifacts under `.agentops
 
 If you want to develop AgentForge itself, use the contributor/source-build path in [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/quickstart.md](docs/quickstart.md).
 
+## What Success Looks Like
+
+After a clean `pr-review` run, the CLI returns a compact JSON summary like this:
+
+```json
+{
+  "runId": "1773758683225-4271ed",
+  "status": "success",
+  "findings": 0,
+  "blockedActions": 0,
+  "blockedPlugins": 0,
+  "jsonPath": ".agentops/runs/1773758683225-4271ed/bundle.json",
+  "markdownPath": ".agentops/runs/1773758683225-4271ed/summary.md"
+}
+```
+
+Inspect these two artifacts next:
+
+- `bundle.json`: structured audit bundle for tools, automation, or deeper review
+- `summary.md`: human-readable run summary with workflow status and audit trail
+
+For a small clean repository, the markdown summary will usually show:
+
+- workflow `pr-review`
+- `status: success`
+- zero findings, blocked actions, and blocked plugins
+- an audit trail for `context-collector`, `security-audit`, `code-review`, `test-generation`, and `final-report`
+
 ## Project Definition
 
 AgentForge provides the runtime, policy, context, audit, and packaging foundation for software engineering workflows that need to reason over a repository without abandoning deterministic controls. The current product wedge is a local, repo-first `pr-review` workflow that demonstrates the model end to end.
@@ -151,6 +179,11 @@ npx @h9-foundry/agentforge-cli scan --json
 npx @h9-foundry/agentforge-cli run pr-review --json
 npx @h9-foundry/agentforge-cli explain last-run --json
 ```
+
+The last command should point you to:
+
+- `.agentops/runs/<run-id>/bundle.json`
+- `.agentops/runs/<run-id>/summary.md`
 
 ### Contributor And Source-Build Path
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,7 +2,39 @@
 
 This quickstart walks through the current official AgentForge wedge: secure local repository review with auditable outputs.
 
-## Install And Build
+## Fastest Evaluator Path
+
+Use the published CLI if you want to try the current wedge without cloning the monorepo.
+
+```bash
+mkdir agentforge-demo
+cd agentforge-demo
+git init
+npx @h9-foundry/agentforge-cli init
+npx @h9-foundry/agentforge-cli scan --json
+npx @h9-foundry/agentforge-cli run pr-review --json
+npx @h9-foundry/agentforge-cli explain last-run --json
+```
+
+That flow creates `.agentops/` locally and writes run artifacts under `.agentops/runs/<run-id>/`.
+
+## What To Inspect After The First Run
+
+- `.agentops/runs/<run-id>/bundle.json`
+  - structured audit bundle with workflow metadata, findings, proposed actions, redaction state, and audit entries
+- `.agentops/runs/<run-id>/summary.md`
+  - human-readable summary of workflow status and the audit trail
+
+For a small clean repository, a successful run should report:
+
+- workflow `pr-review`
+- `status: success`
+- zero findings, blocked actions, and blocked plugins
+- completed audit steps for `context-collector`, `security-audit`, `code-review`, `test-generation`, and `final-report`
+
+## Contributor And Source-Build Path
+
+If you want to work on AgentForge itself, build the monorepo locally:
 
 ```bash
 pnpm install

--- a/examples/sample-repo/README.md
+++ b/examples/sample-repo/README.md
@@ -4,7 +4,7 @@ This example is a minimal standalone repository shape for trying the Phase 1 loc
 
 ## Intended Use
 
-Copy this directory outside the AgentForge monorepo, initialize it as its own git repository, and then run the built CLI against it.
+Copy this directory outside the AgentForge monorepo, initialize it as its own git repository, and then run the published CLI against it.
 
 Example:
 
@@ -14,9 +14,15 @@ cd /tmp/agentforge-sample
 git init
 git add .
 git commit -m "initial sample"
-node /path/to/AgentForge/.build/packages/cli/src/bin.js init
-node /path/to/AgentForge/.build/packages/cli/src/bin.js scan --json
-node /path/to/AgentForge/.build/packages/cli/src/bin.js run pr-review --json
+npx @h9-foundry/agentforge-cli init
+npx @h9-foundry/agentforge-cli scan --json
+npx @h9-foundry/agentforge-cli run pr-review --json
+npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
-The sample code is intentionally small so the audit output is easy to inspect.
+Inspect the generated artifacts under `.agentops/runs/<run-id>/`:
+
+- `bundle.json` for the structured audit bundle
+- `summary.md` for the human-readable run summary
+
+The sample code is intentionally small so the first-run output is easy to inspect.


### PR DESCRIPTION
Closes #99
Closes #100

## Summary
- add a compact successful `pr-review` output example to the README
- explain where `bundle.json` and `summary.md` land after a run
- rewrite quickstart and sample repo docs around the published CLI evaluator path
- keep contributor/source-build guidance available, but secondary

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- verified the documented external-evaluation commands exactly as written against the published `0.4.1` CLI:
  - `npx @h9-foundry/agentforge-cli init`
  - `npx @h9-foundry/agentforge-cli scan --json`
  - `npx @h9-foundry/agentforge-cli run pr-review --json`
  - `npx @h9-foundry/agentforge-cli explain last-run --json`

## Notes
- this is a docs-only slice; no runtime or CLI behavior changed
- the sample repo flow now uses the published CLI instead of a monorepo-internal built path