### PR TITLE
Align sample repo evaluator path

### DIFF
--- a/examples/sample-repo/README.md
+++ b/examples/sample-repo/README.md
@@ -6,6 +6,8 @@ This example is a minimal standalone repository shape for trying the Phase 1 loc
 
 Copy this directory outside the AgentForge monorepo, initialize it as its own git repository, and then run the published CLI against it.
 
+This sample already includes `.agentops`, so you do not need to run `agentforge init` unless you want to regenerate the starter config yourself.
+
 Example:
 
 ```bash
@@ -14,7 +16,6 @@ cd /tmp/agentforge-sample
 git init
 git add .
 git commit -m "initial sample"
-npx @h9-foundry/agentforge-cli init
 npx @h9-foundry/agentforge-cli scan --json
 npx @h9-foundry/agentforge-cli run pr-review --json
 npx @h9-foundry/agentforge-cli explain last-run --json


### PR DESCRIPTION
Closes #116

## Summary
- remove the redundant `init` step from the sample repo evaluator flow
- explain that the copied sample already includes `.agentops`
- keep the blank-repo CLI quickstart as the default first-use path elsewhere in the docs

## Validation
- verified the sample repo commands exactly as written:
  - `npx @h9-foundry/agentforge-cli scan --json`
  - `npx @h9-foundry/agentforge-cli run pr-review --json`
  - `npx @h9-foundry/agentforge-cli explain last-run --json`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test` printed all suite results as passing, but the local Vitest process did not return a final exit before the tool session stalled

## Notes
- docs-only slice; no runtime or CLI behavior changed
- this keeps the sample repo aligned with its preconfigured `.agentops` state