### PR TITLE
Clarify CLI wedge help text

### DIFF
--- a/.changeset/cli-help-wedge-wording.md
+++ b/.changeset/cli-help-wedge-wording.md
@@ -1,0 +1,5 @@
+---
+"@h9-foundry/agentforge-cli": patch
+---
+
+Clarify top-level CLI help and the supported Phase 1 wedge values for `run` and `explain`.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -13,7 +13,10 @@ import {
 
 const program = new Command();
 
-program.name("agentforge").description("Secure-by-default workflow runner for engineering agents.").version("0.1.0");
+program
+  .name("agentforge")
+  .description("Secure-by-default workflow runner for repository-aware SDLC workflows.")
+  .version("0.1.0");
 
 program
   .command("init")
@@ -44,8 +47,8 @@ program
 
 program
   .command("run")
-  .description("Run a starter workflow locally in safe mode.")
-  .argument("<workflow>", "Workflow name, for example pr-review")
+  .description("Run the current starter workflow wedge locally in safe mode.")
+  .argument("<workflow>", "Workflow name. Phase 1 currently supports: pr-review")
   .option("--json", "Print machine-readable JSON output.")
   .action(async (workflow, options: { json?: boolean }) => {
     const result = await runLocalWorkflow(workflow);
@@ -60,8 +63,8 @@ program
 
 program
   .command("explain")
-  .description("Explain the latest workflow run.")
-  .argument("<target>", "Currently only supports last-run")
+  .description("Explain the latest run from the current starter workflow wedge.")
+  .argument("<target>", "Target to explain. Phase 1 currently supports: last-run")
   .option("--json", "Print machine-readable JSON output.")
   .action((target, options: { json?: boolean }) => {
     if (target !== "last-run") {

--- a/packages/cli/src/release-preflight.test.ts
+++ b/packages/cli/src/release-preflight.test.ts
@@ -233,6 +233,28 @@ describe("release preflight", () => {
     expect(result.stdout).toContain("AgentForge npm bootstrap guide");
   });
 
+  it("renders workflow-first help for the current wedge", () => {
+    const topLevel = spawnSync("pnpm", ["exec", "tsx", "packages/cli/src/bin.ts", "--help"], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+    const runHelp = spawnSync("pnpm", ["exec", "tsx", "packages/cli/src/bin.ts", "run", "--help"], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+    const explainHelp = spawnSync("pnpm", ["exec", "tsx", "packages/cli/src/bin.ts", "explain", "--help"], {
+      cwd: process.cwd(),
+      encoding: "utf8"
+    });
+
+    expect(topLevel.status).toBe(0);
+    expect(topLevel.stdout).toContain("repository-aware SDLC workflows");
+    expect(runHelp.status).toBe(0);
+    expect(runHelp.stdout).toContain("Phase 1 currently supports: pr-review");
+    expect(explainHelp.status).toBe(0);
+    expect(explainHelp.stdout).toContain("Phase 1 currently supports: last-run");
+  });
+
   it("exposes the release check command from the CLI", () => {
     const home = mkdtempSync(join(tmpdir(), "agentforge-home-"));
     const result = spawnSync("pnpm", ["exec", "tsx", "packages/cli/src/bin.ts", "release", "check"], {


### PR DESCRIPTION
Closes #114

## Summary
- update the top-level CLI description to match the current workflow-first SDLC wedge
- make the currently supported Phase 1 values explicit in `run --help` and `explain --help`
- add focused CLI-process coverage for the updated help output

## Validation
- `pnpm exec vitest run packages/cli/src/release-preflight.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js --help`
- `node packages/cli/dist/bin.js run --help`
- `node packages/cli/dist/bin.js explain --help`
- `pnpm test` printed the full passing suite output, but the local Vitest process did not return a final exit before the tool session stalled

## Notes
- impact on first-time usability: improves it by making the current wedge clearer without changing command shape or flags
- no doc changes were needed because the updated help wording now matches the existing CLI-first docs
- the local shutdown ambiguity remains tracked separately in #120