### PR TITLE
Improve CLI first-run guidance

### DIFF
--- a/.changeset/cli-first-run-guidance.md
+++ b/.changeset/cli-first-run-guidance.md
@@ -1,0 +1,5 @@
+---
+"@h9-foundry/agentforge-cli": patch
+---
+
+Improve the plain-text `run pr-review` success output with clearer artifact and next-step guidance.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -58,6 +58,9 @@ program
     }
     console.log(`Completed run ${result.runId}`);
     console.log(`Artifacts: ${result.outputDir}`);
+    console.log(`Audit bundle: ${result.jsonPath}`);
+    console.log(`Summary: ${result.markdownPath}`);
+    console.log("Next: run `agentforge explain last-run` for a compact summary of this workflow run.");
     console.log(`Blocked plugins: ${result.blockedPlugins}`);
   });
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,7 +1,7 @@
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 
 import { describe, expect, it } from "vitest";
 
@@ -219,5 +219,28 @@ describe("cli smoke flows", () => {
     expect(explanation.findings).toBe(0);
     expect(explanation.blockedActions).toBe(0);
     expect(explanation.blockedPlugins).toBe(0);
+  });
+
+  it("prints first-run guidance for the current wedge in plain-text mode", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentops-cli-guidance-"));
+    execFileSync("git", ["init"], { cwd: root });
+    execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
+    execFileSync("git", ["config", "user.name", "AgentForge Test"], { cwd: root });
+    writeFileSync(join(root, "package.json"), '{"name":"fixture"}');
+    writeFileSync(join(root, "src.ts"), "export const value = 1;\n");
+    execFileSync("git", ["add", "."], { cwd: root });
+    execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "init"], { cwd: root });
+    writeFileSync(join(root, "src.ts"), "export const value = 2;\n");
+
+    const cliEntry = join(process.cwd(), "packages", "cli", "src", "bin.ts");
+    const run = spawnSync("pnpm", ["exec", "tsx", cliEntry, "run", "pr-review"], {
+      cwd: root,
+      encoding: "utf8"
+    });
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("Audit bundle:");
+    expect(run.stdout).toContain("Summary:");
+    expect(run.stdout).toContain("agentforge explain last-run");
   });
 });

--- a/packages/cli/src/release-preflight.test.ts
+++ b/packages/cli/src/release-preflight.test.ts
@@ -233,7 +233,7 @@ describe("release preflight", () => {
     expect(result.stdout).toContain("AgentForge npm bootstrap guide");
   });
 
-  it("renders workflow-first help for the current wedge", () => {
+  it("renders workflow-first help for the current wedge", { timeout: 15000 }, () => {
     const topLevel = spawnSync("pnpm", ["exec", "tsx", "packages/cli/src/bin.ts", "--help"], {
       cwd: process.cwd(),
       encoding: "utf8"


### PR DESCRIPTION
Closes #115

## Summary
- improve the non-JSON `run pr-review` success output with artifact and next-step guidance
- keep JSON output unchanged
- add focused CLI-process coverage for the plain-text guidance path
- carry forward the CLI help smoke-test timeout adjustment so the focused CLI suites remain stable

## Validation
- `pnpm exec vitest run packages/cli/src/index.test.ts packages/cli/src/release-preflight.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review`
- `node packages/cli/dist/bin.js explain last-run`
- `node packages/cli/dist/bin.js run pr-review --json`
- `pnpm test` printed the full passing suite output, but the local Vitest process did not return a final exit before the tool session stalled

## Notes
- impact on first-time usability: improves the plain-text success path without changing command shape or JSON contracts
- no doc changes were needed because the updated output now matches the existing CLI-first onboarding docs
- the local shutdown ambiguity remains tracked separately in #120