### PR TITLE
Version public AgentForge packages (human-owned)

### DIFF
--- a/.changeset/cli-first-run-guidance.md
+++ b/.changeset/cli-first-run-guidance.md
@@ -1,5 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
----
-
-Improve the plain-text `run pr-review` success output with clearer artifact and next-step guidance.

--- a/.changeset/cli-help-wedge-wording.md
+++ b/.changeset/cli-help-wedge-wording.md
@@ -1,5 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
----
-
-Clarify top-level CLI help and the supported Phase 1 wedge values for `run` and `explain`.

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @h9-foundry/agentforge-audit
 
+## 0.4.2
+
+### Patch Changes
+
+- @h9-foundry/agentforge-shared-types@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-audit",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @h9-foundry/agentforge-cli
 
+## 0.4.2
+
+### Patch Changes
+
+- 509464f: Improve the plain-text `run pr-review` success output with clearer artifact and next-step guidance.
+- 073c07a: Clarify top-level CLI help and the supported Phase 1 wedge values for `run` and `explain`.
+  - @h9-foundry/agentforge-schemas@0.4.2
+  - @h9-foundry/agentforge-shared-types@0.4.2
+  - @h9-foundry/agentforge-sdk@0.4.2
+  - @h9-foundry/agentforge-context-engine@0.4.2
+  - @h9-foundry/agentforge-policy-engine@0.4.2
+  - @h9-foundry/agentforge-runtime@0.4.2
+  - @h9-foundry/agentforge-audit@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-cli",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/context-engine/CHANGELOG.md
+++ b/packages/context-engine/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @h9-foundry/agentforge-context-engine
 
+## 0.4.2
+
+### Patch Changes
+
+- @h9-foundry/agentforge-schemas@0.4.2
+- @h9-foundry/agentforge-shared-types@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Repository and execution context collection for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/policy-engine/CHANGELOG.md
+++ b/packages/policy-engine/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @h9-foundry/agentforge-policy-engine
 
+## 0.4.2
+
+### Patch Changes
+
+- @h9-foundry/agentforge-schemas@0.4.2
+- @h9-foundry/agentforge-shared-types@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @h9-foundry/agentforge-runtime
 
+## 0.4.2
+
+### Patch Changes
+
+- @h9-foundry/agentforge-schemas@0.4.2
+- @h9-foundry/agentforge-shared-types@0.4.2
+- @h9-foundry/agentforge-sdk@0.4.2
+- @h9-foundry/agentforge-policy-engine@0.4.2
+- @h9-foundry/agentforge-audit@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,7 @@
 # @h9-foundry/agentforge-schemas
 
+## 0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @h9-foundry/agentforge-sdk
 
+## 0.4.2
+
+### Patch Changes
+
+- @h9-foundry/agentforge-shared-types@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @h9-foundry/agentforge-shared-types
 
+## 0.4.2
+
+### Patch Changes
+
+- @h9-foundry/agentforge-schemas@0.4.2
+
 ## 0.4.1
 
 ### Patch Changes

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
   "license": "MIT",
   "author": "H9 Foundry",


### PR DESCRIPTION
Supersedes #123.

## Summary
- carry forward the Changesets-generated 0.4.2 version/changelog bump on a human-owned branch so required checks can attach normally
- keep the release contents identical to the bot branch
- use this PR as the gated merge path if it goes green

## Validation
- changeset-generated version/changelog diff inspected from `changeset-release/main`
- branch recreated directly from the bot release branch without additional functional edits

## Notes
- if this PR goes green, it replaces #123 as the release path
- if it merges, the normal release workflow should publish 0.4.2