### PR TITLE
Design Phase 2 workflow expansion docs

### DIFF
--- a/docs/BUILD_IMPLEMENTATION_WORKFLOW.md
+++ b/docs/BUILD_IMPLEMENTATION_WORKFLOW.md
@@ -1,0 +1,284 @@
+# Build And Implementation Workflow MVP
+
+This document defines the design target for issue [#53](https://github.com/H9-Foundry/AgentForge/issues/53).
+
+It describes the first build/implementation workflow wedge AgentForge should add after planning/discovery and architecture/design.
+
+It does **not** claim that this workflow is implemented or officially shipped today.
+
+## Why This Exists
+
+AgentForge can now define what to build and how the repository should change, but it still stops before controlled implementation work begins.
+
+Without an explicit build/implementation workflow:
+
+- implementation requests remain informal and hard to audit
+- write-intent boundaries are not captured as workflow policy
+- deterministic preflight checks are not separated cleanly from agentic proposal work
+- build/test readiness cannot be tied to implementation artifacts explicitly
+
+## MVP Goal
+
+The MVP should let a maintainer take a design record and produce one bounded implementation proposal that:
+
+- identifies the intended repository edits
+- records deterministic preflight checks and blocked conditions
+- distinguishes proposal generation from side-effectful apply/build steps
+- captures approval-gated next actions for patch application and validation
+
+The workflow should remain:
+
+- workflow-first, not chat-first
+- read-only by default
+- explicit about where approval-gated side effects begin
+- auditable through the existing runtime and lifecycle artifact model
+
+## User Jobs
+
+The first workflow wedge should solve these jobs:
+
+1. turn a design record into a bounded implementation proposal
+2. identify the exact packages, files, and interfaces expected to change
+3. separate deterministic repository/build checks from agentic implementation reasoning
+4. prepare approval-gated apply/build steps without executing them by default
+
+The MVP should optimize first for:
+
+- maintainers turning a design decision into bounded implementation work
+- contributors who need a controlled implementation plan before editing
+- local repository execution on the current CLI surface
+
+## Non-Goals
+
+This MVP should not:
+
+- provide unrestricted autonomous code writing
+- apply patches or run write-heavy build steps automatically on the default path
+- replace standard developer review before merge
+- broaden network or filesystem side-effect permissions
+
+## Current Baseline
+
+Available now:
+
+- planning and design workflow design targets
+- lifecycle artifact envelopes and family schemas
+- lifecycle artifact sanitization and audit linkage
+- runtime/policy contracts for capability envelopes and side-effect classes
+- one official `pr-review` workflow and release/readiness tooling
+
+Not yet available:
+
+- an official build/implementation workflow asset
+- an implementation proposal artifact emitted by the runtime
+- approval-class wiring for proposal versus apply/build execution
+- deterministic build-target inventory as workflow output
+
+## Recommended MVP Wedge
+
+### Workflow Identity
+
+- workflow name: `implementation-proposal`
+- trigger: `manual`
+- primary lifecycle domain: `build`
+- support level at first implementation: `official`
+- maturity at first implementation: `mvp`
+
+### Entry Model
+
+The first evaluator path should stay CLI-first without expanding the command surface.
+
+Recommended input model:
+
+- keep `agentforge run <workflow>` as the invocation shape
+- add a repo-local request document under `.agentops/requests/implementation.yaml`
+- require that request document to reference a prior design record artifact
+
+### Implementation Request Contract
+
+The request document should include:
+
+- `designRecordRef` as required
+- `implementationGoal` as required
+- `targetPaths` as optional list
+- `validationCommands` as optional allowlisted list
+- `constraints` as optional list
+- `approvalMode` as required enum describing whether the run is proposal-only or apply-capable
+
+The MVP should reject a request without a valid design record or explicit approval mode before any reasoning node runs.
+
+## Workflow Stages
+
+The MVP should use five stages.
+
+### 1. Implementation Intake Normalization
+
+Type:
+
+- deterministic
+
+Responsibilities:
+
+- load `.agentops/requests/implementation.yaml`
+- validate required fields
+- load and validate the referenced design record artifact
+- normalize target paths and validation commands
+
+Outputs:
+
+- normalized implementation request
+- validated design record input
+- deterministic findings if blocked
+
+### 2. Repository And Build Discovery
+
+Type:
+
+- deterministic
+
+Responsibilities:
+
+- assemble bounded repository context for the implementation target
+- identify affected packages and entrypoints
+- identify known build/test scripts and validation surfaces
+- reject unsafe or disallowed requested commands
+
+Outputs:
+
+- implementation context slice
+- deterministic affected-surface inventory
+- allowed validation command set
+
+### 3. Implementation Analysis
+
+Type:
+
+- reasoning
+
+Responsibilities:
+
+- translate the design record into a bounded implementation proposal
+- describe expected edits, risks, and unknowns
+- propose an execution order for edits and validation
+
+Preferred starter agent:
+
+- new `implementation-planner`
+
+Outputs:
+
+- `implementation-proposal` lifecycle artifact
+
+### 4. Approval-Gated Apply Planning
+
+Type:
+
+- deterministic plus policy
+
+Responsibilities:
+
+- classify which follow-on actions would be read-only versus side-effectful
+- map apply/build/test steps to approval classes
+- preserve the default path as proposal-only
+
+Outputs:
+
+- gated action plan
+- explicit approval requirements
+
+### 5. Report
+
+Type:
+
+- report
+
+Responsibilities:
+
+- render a compact markdown summary from the implementation proposal
+- preserve the audit bundle as the execution trace
+
+Outputs:
+
+- audit bundle
+- markdown summary
+- implementation proposal artifact persisted in workflow state and audit linkage
+
+## Deterministic Vs Agentic Boundaries
+
+Deterministic responsibilities:
+
+- request loading and validation
+- design-record reference validation
+- path filtering and context budgeting
+- package/build/test inventory collection
+- command allowlisting
+- action-plan approval classification
+- artifact persistence and audit linkage
+
+Reasoning responsibilities:
+
+- proposed edit plan
+- sequencing recommendations
+- implementation risk synthesis
+- uncertainty and rollback considerations
+
+## Trust And Policy Boundaries
+
+The MVP must keep the current security posture intact:
+
+- proposal generation is read-only by default
+- any patch application, build write, or network side effect remains approval-gated
+- requested commands must be allowlisted before they can be surfaced as candidate validation steps
+- policy overrides the workflow request, starter agent defaults, and any proposed apply step
+
+## Required Artifacts
+
+Primary lifecycle artifact:
+
+- `implementation-proposal`
+
+The payload should minimally include:
+
+- `designRecordRef`
+- `implementationGoal`
+- `affectedPaths`
+- `proposedChanges`
+- `validationPlan`
+- `approvalRequiredSteps`
+- `risks`
+- `openQuestions`
+
+Follow-on implementation should also add a deterministic companion inventory artifact or embedded section for:
+
+- package impacts
+- allowed validation commands
+- blocked side-effect classes
+
+## Required Deterministic Nodes, Agents, And Adapters
+
+Deterministic needs:
+
+- implementation-request validator
+- affected-surface collector
+- allowlisted command inventory
+- approval-class mapper
+
+Starter agent need:
+
+- `implementation-planner`
+
+Adapter expectations:
+
+- filesystem and shell adapters remain tightly policy-gated
+- no unrestricted shell execution
+- no new unrestricted write path
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. implementation request schema and official `implementation-proposal` workflow asset
+2. `implementation-planner` starter agent and `implementation-proposal` artifact emission
+3. deterministic affected-surface and allowlisted validation-command inventory
+4. approval-gated apply/build execution mediation that preserves read-only defaults
+

--- a/docs/GITHUB_INTEGRATION_MATURITY.md
+++ b/docs/GITHUB_INTEGRATION_MATURITY.md
@@ -1,0 +1,107 @@
+# GitHub Integration Maturity
+
+This document defines the design target for issue [#56](https://github.com/H9-Foundry/AgentForge/issues/56).
+
+It describes how GitHub should mature as an SDLC integration surface without turning AgentForge into a GitHub-only product.
+
+It does **not** claim that broader GitHub integration is implemented or officially shipped today.
+
+## Why This Exists
+
+GitHub is already part of the current execution story:
+
+- issue planning is tracked in GitHub
+- release and validation automation run in GitHub Actions
+- PR review is the current official workflow wedge
+
+But the platform does not yet define what "mature GitHub support" actually means.
+
+## Design Goal
+
+The first maturity pass should:
+
+- document current GitHub support honestly
+- define the near-term GitHub surfaces worth formalizing
+- keep GitHub support explicitly downstream of the core workflow/runtime model
+- avoid coupling the overall product identity to one host platform
+
+## Current Baseline
+
+Available now:
+
+- GitHub issues and milestones as planning source of truth
+- GitHub Actions for validation and release automation
+- GitHub-centric release hardening
+- narrow PR-review integration and release/version PR handling
+
+Not yet available:
+
+- official GitHub-backed workflow adapters beyond the current narrow paths
+- explicit project/status-sync workflow surfaces
+- formalized issue/PR handoff artifacts for the broader SDLC lifecycle
+
+## Near-Term Maturity Wedge
+
+Phase 2 should focus on these GitHub surfaces:
+
+1. issue and PR reference normalization across workflows
+2. bounded issue/PR comment/report handoff for planning, design, QA, and release outputs
+3. GitHub Actions evidence ingestion for QA and release workflows
+4. queue/status synchronization that remains subordinate to local workflow truth
+
+## Non-Goals
+
+This maturity pass should not:
+
+- assume GitHub is the only supported SCM/CI target forever
+- create hidden network dependencies in local workflows
+- promise GitHub Projects or enterprise admin integrations before design and trust controls exist
+
+## Trust And Policy Boundaries
+
+- local workflow execution must stay viable without GitHub access on the default path
+- any GitHub write side effect must remain adapter-mediated and approval-gated where appropriate
+- imported GitHub text remains untrusted input
+- GitHub status should reflect workflow state, not override local policy/runtime decisions
+
+## Required Artifacts And Contracts
+
+GitHub maturity work should align with these artifact needs:
+
+- normalized issue and PR references in planning/design/build/QA artifacts
+- optional GitHub handoff summaries derived from lifecycle artifacts
+- explicit execution-status mapping between local workflow state and GitHub reporting
+
+## Required Adapters And Deterministic Nodes
+
+Deterministic needs:
+
+- GitHub reference normalizer
+- PR and issue metadata collector
+- Actions/check-run status normalizer
+- artifact-to-GitHub summary renderer
+
+Adapter expectations:
+
+- GitHub issue/PR reads remain explicit
+- comment/status writes stay clearly bounded and policy-aware
+
+## Relationship To Broader SCM/CI Support
+
+GitHub is the first mature integration target because it already anchors planning and release.
+
+It should remain:
+
+- the best-supported near-term host integration
+- a reference design for future SCM/CI adapters
+- explicitly narrower than the broader cross-platform roadmap
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. GitHub issue/PR reference and status normalization shared across lifecycle workflows
+2. bounded GitHub handoff/comment/report surfaces for planning, design, QA, and release artifacts
+3. GitHub Actions evidence ingestion for QA and release workflows
+4. support-matrix and policy guidance for GitHub-specific versus host-agnostic behavior
+

--- a/docs/MAINTENANCE_WORKFLOWS.md
+++ b/docs/MAINTENANCE_WORKFLOWS.md
@@ -1,0 +1,165 @@
+# Maintenance, Dependency, And Docs Workflow Expansion
+
+This document defines the design target for issue [#61](https://github.com/H9-Foundry/AgentForge/issues/61).
+
+It describes how AgentForge should support routine maintenance work as a lifecycle domain separate from review and release.
+
+It does **not** claim that these workflows are implemented or officially shipped today.
+
+## Why This Exists
+
+The repository already has strong release hygiene and structured planning, but routine maintenance work still relies on ad hoc process:
+
+- dependency upgrades
+- documentation refreshes
+- maintenance triage
+- recurring hygiene review
+
+Without a maintenance workflow family:
+
+- maintenance work is overloaded onto `pr-review`
+- dependency and docs stewardship do not produce lifecycle-specific artifacts
+- release and GitHub automation do not feed into a bounded maintenance model
+
+## Design Goal
+
+The first maintenance expansion should define one bounded workflow wedge that:
+
+- normalizes maintenance requests
+- gathers deterministic maintenance evidence
+- emits one structured maintenance report
+- provides a safe handoff into implementation, QA, and release workflows
+
+## Current Baseline
+
+Available now:
+
+- release/readiness automation
+- GitHub issue planning and queue tracking
+- newcomer and contributor docs/process scaffolding
+- lifecycle artifact and audit infrastructure
+
+Not yet available:
+
+- official maintenance workflow assets
+- dedicated maintenance artifacts in runtime use
+- explicit dependency/docs-hygiene workflow boundaries
+
+## Recommended Initial Workflow Family
+
+Phase 2 should define one first official wedge:
+
+- `maintenance-triage`
+
+Later planned variants can include:
+
+- `dependency-upgrade-review`
+- `docs-hygiene-review`
+- `maintenance-backlog-refresh`
+
+Only `maintenance-triage` should be targeted for first implementation planning.
+
+## User Jobs
+
+The first maintenance wedge should solve these jobs:
+
+1. turn a maintenance request or recurring hygiene task into a bounded maintenance brief
+2. collect deterministic dependency/docs/release signals relevant to the request
+3. recommend whether the next step is implementation, QA, security, or release work
+4. keep maintenance expectations explicit for contributors and maintainers
+
+## Non-Goals
+
+This expansion should not:
+
+- treat dependency bots alone as full maintenance support
+- merge all maintenance work into release or PR review forever
+- create write-heavy recurring automation by default
+
+## Workflow Shape
+
+### Workflow Identity
+
+- workflow name: `maintenance-triage`
+- trigger: `manual` first, with recurring use only after explicit later work
+- primary lifecycle domain: `maintain`
+- support level at first implementation: `official`
+- maturity at first implementation: `mvp`
+
+### Entry Model
+
+Recommended input model:
+
+- keep `agentforge run <workflow>`
+- add `.agentops/requests/maintenance.yaml`
+- allow references to dependency alerts, docs tasks, release reports, or backlog issues
+
+### Workflow Stages
+
+1. intake normalization
+2. deterministic maintenance evidence collection
+3. maintenance analysis
+4. report and artifact emission
+
+## Deterministic Vs Agentic Boundaries
+
+Deterministic responsibilities:
+
+- request validation
+- dependency/docs/release signal collection
+- issue and package reference normalization
+- artifact persistence and audit linkage
+
+Reasoning responsibilities:
+
+- maintenance prioritization
+- recommended next-workflow routing
+- contributor-facing triage guidance
+
+## Trust And Policy Boundaries
+
+- maintenance review remains read-only by default
+- any follow-on dependency update or docs edit remains explicit downstream implementation work
+- network-backed maintenance signals must remain adapter-mediated and policy-aware
+
+## Required Artifacts
+
+Primary lifecycle artifact:
+
+- `maintenance-report`
+
+The payload should minimally include:
+
+- `maintenanceGoal`
+- `evidenceSources`
+- `affectedPackagesOrDocs`
+- `recommendedActions`
+- `routingRecommendation`
+- `risks`
+
+## Required Deterministic Nodes, Agents, And Adapters
+
+Deterministic needs:
+
+- maintenance request validator
+- dependency/docs/release signal collector
+- routing classifier
+
+Starter agent need:
+
+- `maintenance-analyst`
+
+Adapter expectations:
+
+- GitHub and dependency-alert ingestion must remain explicit and bounded
+- recurring automation stays downstream of manual workflow design
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. maintenance request schema and official `maintenance-triage` workflow asset
+2. `maintenance-analyst` starter agent and `maintenance-report` artifact emission
+3. deterministic dependency/docs/release signal collection and routing classification
+4. GitHub and release/readiness handoff wiring for maintenance follow-up work
+

--- a/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
+++ b/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
@@ -1,0 +1,163 @@
+# Operations And Incident Workflow Expansion
+
+This document defines the design target for issue [#60](https://github.com/H9-Foundry/AgentForge/issues/60).
+
+It describes how AgentForge should support operational handoff and incident response workflows without pretending to be a hosted observability platform.
+
+It does **not** claim that these workflows are implemented or officially shipped today.
+
+## Why This Exists
+
+The current platform stops at build, review, and release-oriented repository work.
+
+Without an explicit operations/incident workflow family:
+
+- production-facing handoff remains out of model
+- observability evidence has no bounded ingestion contract
+- incident follow-up work cannot be tied cleanly back to design, implementation, QA, or release artifacts
+
+## Design Goal
+
+The first operations expansion should define one bounded incident-handoff wedge that:
+
+- ingests explicitly provided operational evidence
+- normalizes that evidence deterministically
+- emits one incident-oriented artifact for follow-up planning and maintenance
+- keeps runtime and policy boundaries tighter than a hosted ops platform would require
+
+## Current Baseline
+
+Available now:
+
+- context, policy, artifact, and audit infrastructure
+- planning and design workflow design targets
+- release/readiness tooling
+
+Not yet available:
+
+- official operations or incident workflow assets
+- explicit observability evidence adapters
+- incident-oriented lifecycle artifacts in runtime use
+
+## Recommended Initial Workflow Family
+
+Phase 2 should define one first official wedge:
+
+- `incident-handoff`
+
+Later planned variants can include:
+
+- `postmortem-review`
+- `alert-triage`
+- `operational-readiness-review`
+
+Only `incident-handoff` should be targeted for first implementation planning.
+
+## User Jobs
+
+The first incident wedge should solve these jobs:
+
+1. capture bounded operational evidence for an incident or production issue
+2. summarize likely impacted repository areas and follow-up work
+3. hand off incident findings into planning, maintenance, or security workflows
+4. keep sensitive operational data policy-aware and auditable
+
+## Non-Goals
+
+This expansion should not:
+
+- build a hosted monitoring or paging product
+- claim deep live-system integration before explicit adapters exist
+- allow arbitrary remote-system access from the default workflow
+
+## Workflow Shape
+
+### Workflow Identity
+
+- workflow name: `incident-handoff`
+- trigger: `manual`
+- primary lifecycle domain: `operate`
+- support level at first implementation: `official`
+- maturity at first implementation: `mvp`
+
+### Entry Model
+
+Recommended input model:
+
+- keep `agentforge run <workflow>`
+- add `.agentops/requests/incident.yaml`
+- allow references to logs, alert summaries, release reports, or external incident notes that have been staged locally
+
+### Workflow Stages
+
+1. intake normalization
+2. deterministic evidence staging and normalization
+3. incident analysis
+4. report and artifact emission
+
+## Deterministic Vs Agentic Boundaries
+
+Deterministic responsibilities:
+
+- request validation
+- local evidence staging and schema validation
+- timestamp/source normalization
+- path and artifact linkage
+- redaction and audit linkage
+
+Reasoning responsibilities:
+
+- likely impact synthesis
+- follow-up workflow recommendation
+- incident severity framing
+- open-question identification
+
+## Trust And Policy Boundaries
+
+- operations evidence must be staged explicitly rather than fetched implicitly
+- sensitive logs and notes remain subject to strict redaction
+- no default live-system access
+- any future network-backed observability adapter must stay explicit and approval-aware
+
+## Required Artifacts
+
+Primary lifecycle artifact:
+
+- `incident-brief`
+
+The payload should minimally include:
+
+- `incidentSummary`
+- `evidenceSources`
+- `timelineSummary`
+- `likelyImpactedAreas`
+- `followUpWorkflowRefs`
+- `openQuestions`
+
+## Required Deterministic Nodes, Agents, And Adapters
+
+Deterministic needs:
+
+- incident request validator
+- staged evidence normalizer
+- timestamp/source normalizer
+- redaction-aware incident evidence collector
+
+Starter agent need:
+
+- `incident-analyst`
+
+Adapter expectations:
+
+- local staged-evidence adapters first
+- observability/log adapters later and only with explicit trust boundaries
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. incident request schema and official `incident-handoff` workflow asset
+2. `incident-analyst` starter agent and `incident-brief` artifact emission
+3. deterministic staged incident-evidence normalization and source provenance capture
+4. redaction/policy wiring for sensitive operational evidence and follow-up routing
+

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -40,7 +40,7 @@ Rules:
 
 Current active lane:
 
-1. [#79](https://github.com/H9-Foundry/AgentForge/issues/79) architecture/design workflow MVP
+1. [#53](https://github.com/H9-Foundry/AgentForge/issues/53) build and implementation workflow support
 
 ### Ready Lane
 
@@ -48,8 +48,14 @@ Work that is explicitly designed or queued next, but should not start until the 
 
 Current ready lane:
 
-2. validation-hygiene investigation under [#120](https://github.com/H9-Foundry/AgentForge/issues/120)
-3. planning/discovery implementation follow-ons under [#127](https://github.com/H9-Foundry/AgentForge/issues/127), [#128](https://github.com/H9-Foundry/AgentForge/issues/128), [#129](https://github.com/H9-Foundry/AgentForge/issues/129), and [#130](https://github.com/H9-Foundry/AgentForge/issues/130)
+2. [#54](https://github.com/H9-Foundry/AgentForge/issues/54) test and QA workflow expansion
+3. [#55](https://github.com/H9-Foundry/AgentForge/issues/55) security and DevSecOps workflow expansion
+4. [#56](https://github.com/H9-Foundry/AgentForge/issues/56) GitHub integration maturity
+5. [#59](https://github.com/H9-Foundry/AgentForge/issues/59) release and CI-CD workflow expansion
+6. [#60](https://github.com/H9-Foundry/AgentForge/issues/60) operations and incident workflow expansion
+7. [#61](https://github.com/H9-Foundry/AgentForge/issues/61) maintenance, dependency, and docs workflow expansion
+8. planning/discovery implementation follow-ons under [#127](https://github.com/H9-Foundry/AgentForge/issues/127), [#128](https://github.com/H9-Foundry/AgentForge/issues/128), [#129](https://github.com/H9-Foundry/AgentForge/issues/129), and [#130](https://github.com/H9-Foundry/AgentForge/issues/130)
+9. architecture/design implementation follow-ons under [#132](https://github.com/H9-Foundry/AgentForge/issues/132), [#133](https://github.com/H9-Foundry/AgentForge/issues/133), [#134](https://github.com/H9-Foundry/AgentForge/issues/134), [#136](https://github.com/H9-Foundry/AgentForge/issues/136), and [#135](https://github.com/H9-Foundry/AgentForge/issues/135)
 
 ### Parallel Safe Lane
 
@@ -81,12 +87,10 @@ Work that is part of the roadmap and ordered relative to dependencies, but not y
 
 Current mapped lane:
 
-7. [#53](https://github.com/H9-Foundry/AgentForge/issues/53) build/implementation workflow support
-8. [#54](https://github.com/H9-Foundry/AgentForge/issues/54) test/QA workflow expansion
-9. [#55](https://github.com/H9-Foundry/AgentForge/issues/55) security/DevSecOps workflow expansion
-10. [#59](https://github.com/H9-Foundry/AgentForge/issues/59) release/CI-CD workflow expansion
-11. [#61](https://github.com/H9-Foundry/AgentForge/issues/61) maintenance/dependency/docs workflow expansion
-12. [#60](https://github.com/H9-Foundry/AgentForge/issues/60) operations/incident workflow expansion
+10. [#62](https://github.com/H9-Foundry/AgentForge/issues/62) plugin and registry roadmap
+11. [#63](https://github.com/H9-Foundry/AgentForge/issues/63) evals and benchmarks framework
+12. [#64](https://github.com/H9-Foundry/AgentForge/issues/64) additional SCM and CI integrations roadmap
+13. [#65](https://github.com/H9-Foundry/AgentForge/issues/65) supply-chain and release trust hardening
 
 ### Deferred Lane
 
@@ -94,10 +98,7 @@ Work that remains part of the roadmap but should not be pulled forward until ear
 
 Current deferred lane:
 
-- [#62](https://github.com/H9-Foundry/AgentForge/issues/62) plugin and registry roadmap
-- [#63](https://github.com/H9-Foundry/AgentForge/issues/63) evals and benchmarks framework
-- [#64](https://github.com/H9-Foundry/AgentForge/issues/64) additional SCM and CI integrations roadmap
-- [#65](https://github.com/H9-Foundry/AgentForge/issues/65) supply-chain and release trust hardening
+- no additional deferred lane items beyond the mapped Phase 3 and 4 design epics yet
 
 ## Do-Not-Start-Before Rules
 

--- a/docs/RELEASE_CICD_WORKFLOWS.md
+++ b/docs/RELEASE_CICD_WORKFLOWS.md
@@ -1,0 +1,167 @@
+# Release And CI-CD Workflow Expansion
+
+This document defines the design target for issue [#59](https://github.com/H9-Foundry/AgentForge/issues/59).
+
+It describes how AgentForge should grow from the current release/readiness tooling into a broader release and CI/CD workflow family.
+
+It does **not** claim that a broader CI/CD workflow family is implemented or officially shipped today.
+
+## Why This Exists
+
+AgentForge already has real release automation:
+
+- `release guide`
+- `release check`
+- `release verify`
+- trusted publishing through GitHub Actions
+
+But those capabilities are still narrow tooling rather than an explicit lifecycle workflow family.
+
+## Design Goal
+
+The first release/CI-CD expansion should:
+
+- preserve the current trusted release posture
+- formalize a first release-oriented workflow wedge around release evidence and gating
+- define where broader CI evidence ingestion belongs
+- keep GitHub-specific behavior separate from general pipeline support
+
+## Current Baseline
+
+Available now:
+
+- release readiness CLI commands
+- release validation and publish automation
+- package/version verification
+- audit and lifecycle artifact infrastructure
+
+Not yet available:
+
+- an official release workflow asset
+- a release-candidate lifecycle artifact emitted by the runtime
+- explicit CI evidence ingestion into a release workflow
+- support for broader host-agnostic pipeline orchestration
+
+## Recommended Initial Workflow Family
+
+Phase 2 should define one first official wedge:
+
+- `release-readiness`
+
+Later planned variants can include:
+
+- `pipeline-evidence-review`
+- `deployment-gate-review`
+- `promotion-approval`
+
+Only `release-readiness` should be targeted for first implementation planning.
+
+## User Jobs
+
+The first release wedge should solve these jobs:
+
+1. collect deterministic release evidence for a candidate version or merge state
+2. summarize publish blockers and follow-up actions
+3. normalize local and CI evidence into one release artifact
+4. preserve approval boundaries between readiness review and actual publish/promote steps
+
+## Non-Goals
+
+This expansion should not:
+
+- replace the existing release workflow immediately
+- promise deep integration with every CI provider
+- auto-promote or publish without explicit trusted controls
+- collapse release review and deployment into one opaque step
+
+## Workflow Shape
+
+### Workflow Identity
+
+- workflow name: `release-readiness`
+- trigger: `manual`
+- primary lifecycle domain: `release`
+- support level at first implementation: `official`
+- maturity at first implementation: `mvp`
+
+### Entry Model
+
+Recommended input model:
+
+- keep `agentforge run <workflow>`
+- add `.agentops/requests/release.yaml`
+- allow references to QA reports, security reports, and version targets
+
+### Workflow Stages
+
+1. intake normalization
+2. deterministic release evidence collection
+3. release analysis
+4. report and artifact emission
+
+## Deterministic Vs Agentic Boundaries
+
+Deterministic responsibilities:
+
+- request validation
+- package/version and tag inspection
+- local and CI status normalization
+- trusted-publishing configuration checks
+- artifact persistence and audit linkage
+
+Reasoning responsibilities:
+
+- release blocker synthesis
+- readiness judgment
+- recommended mitigation sequencing
+
+## Trust And Policy Boundaries
+
+- the release-readiness workflow remains read-only by default
+- publish, tag, or promote actions stay outside the default path
+- CI evidence ingestion must be adapter-mediated and policy-aware
+- trusted publishing remains mandatory for official publish automation
+
+## Required Artifacts
+
+Primary lifecycle artifact:
+
+- `release-report`
+
+The payload should minimally include:
+
+- `targetVersion`
+- `packageSet`
+- `evidenceSources`
+- `blockers`
+- `readinessStatus`
+- `requiredApprovals`
+- `recommendedNextSteps`
+
+## Required Deterministic Nodes, Agents, And Adapters
+
+Deterministic needs:
+
+- release request validator
+- package/version and tag collector
+- CI/check-run status normalizer
+- trusted-publishing posture verifier
+
+Starter agent need:
+
+- `release-analyst`
+
+Adapter expectations:
+
+- CI evidence adapters remain explicit
+- publish orchestration stays approval-gated and separate from readiness review
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. release request schema and official `release-readiness` workflow asset
+2. `release-analyst` starter agent and `release-report` artifact emission
+3. deterministic CI evidence ingestion and release-state normalization
+4. approval-gated publish/promotion orchestration aligned to release-trust controls
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -131,6 +131,34 @@ Open a new bounded issue for any future newcomer-facing follow-up rather than re
   - design record artifact and workflow stages
   - deterministic interface discovery versus design reasoning
   - follow-on implementation slices
+- [docs/BUILD_IMPLEMENTATION_WORKFLOW.md](BUILD_IMPLEMENTATION_WORKFLOW.md)
+  - implementation proposal workflow identity and approval-gated apply boundary
+  - deterministic build inventory versus implementation reasoning
+  - implementation-proposal artifact and follow-on slices
+- [docs/TEST_QA_WORKFLOWS.md](TEST_QA_WORKFLOWS.md)
+  - dedicated QA workflow family separate from `pr-review`
+  - QA evidence normalization and `qa-report` artifact target
+  - follow-on slices for workflow, agent, evidence collection, and policy wiring
+- [docs/SECURITY_DEVSECOPS_WORKFLOWS.md](SECURITY_DEVSECOPS_WORKFLOWS.md)
+  - security-review workflow wedge and security artifact target
+  - deterministic security evidence versus security analysis boundaries
+  - follow-on slices for workflow, agent, evidence, and policy wiring
+- [docs/GITHUB_INTEGRATION_MATURITY.md](GITHUB_INTEGRATION_MATURITY.md)
+  - current GitHub baseline versus broader host-agnostic goals
+  - bounded GitHub handoff and evidence-ingestion surface
+  - follow-on slices for normalization, handoff, and policy guidance
+- [docs/RELEASE_CICD_WORKFLOWS.md](RELEASE_CICD_WORKFLOWS.md)
+  - release-readiness workflow wedge and `release-report` artifact target
+  - separation between current release tooling and broader CI/CD workflow intent
+  - follow-on slices for workflow, agent, CI evidence, and gated publish orchestration
+- [docs/OPERATIONS_INCIDENT_WORKFLOWS.md](OPERATIONS_INCIDENT_WORKFLOWS.md)
+  - incident-handoff workflow wedge and staged operational evidence posture
+  - `incident-brief` artifact target and redaction boundaries
+  - follow-on slices for workflow, agent, evidence normalization, and policy wiring
+- [docs/MAINTENANCE_WORKFLOWS.md](MAINTENANCE_WORKFLOWS.md)
+  - maintenance-triage workflow wedge and `maintenance-report` artifact target
+  - dependency/docs/release signal collection and routing boundaries
+  - follow-on slices for workflow, agent, routing, and GitHub/release handoff
 
 ## Phase 3: Ecosystem And Plugins
 

--- a/docs/SECURITY_DEVSECOPS_WORKFLOWS.md
+++ b/docs/SECURITY_DEVSECOPS_WORKFLOWS.md
@@ -1,0 +1,167 @@
+# Security And DevSecOps Workflow Expansion
+
+This document defines the design target for issue [#55](https://github.com/H9-Foundry/AgentForge/issues/55).
+
+It describes how AgentForge should grow security workflows beyond the current security posture and starter audit behavior.
+
+It does **not** claim that these workflows are implemented or officially shipped today.
+
+## Why This Exists
+
+AgentForge already has strong policy, redaction, and release-trust controls, but it does not yet expose a first-class security workflow family.
+
+Without explicit security workflows:
+
+- security review intent is mixed into generic review paths
+- compliance and DevSecOps use cases have no bounded workflow wedge
+- security-specific evidence and findings are not normalized separately
+- future supply-chain and release-hardening work lacks a clear upstream workflow model
+
+## Design Goal
+
+The first security expansion should define a workflow family that:
+
+- keeps the current security posture as a hard baseline
+- adds explicit workflows for bounded security review and evidence collection
+- separates deterministic security evidence gathering from model reasoning
+- feeds release-trust and maintenance work without overstating compliance claims
+
+## Current Baseline
+
+Available now:
+
+- policy engine with lifecycle overlays and redaction
+- lifecycle artifact sanitization and audit linkage
+- starter `security-audit` agent
+- release verification and trusted publishing
+
+Not yet available:
+
+- official security workflow assets
+- dedicated security lifecycle artifacts beyond design targets
+- explicit DevSecOps evidence adapters or compliance-oriented workflows
+
+## Recommended Initial Workflow Family
+
+Phase 2 should define one first official wedge:
+
+- `security-review`
+
+Later planned variants can include:
+
+- `dependency-risk-review`
+- `compliance-evidence-assembly`
+- `supply-chain-verification`
+
+Only `security-review` should be targeted for first implementation planning.
+
+## User Jobs
+
+The first security wedge should solve these jobs:
+
+1. gather bounded security-relevant evidence for a repository change or release candidate
+2. separate deterministic evidence from risk judgment
+3. emit one structured security report for downstream use
+4. provide an explicit handoff to release-trust and maintenance workflows
+
+## Non-Goals
+
+This expansion should not:
+
+- weaken current trust or redaction controls
+- claim compliance certifications or enterprise controls that do not exist
+- provide unrestricted external scanner execution
+- turn AgentForge into a hosted security platform
+
+## Workflow Shape
+
+### Workflow Identity
+
+- workflow name: `security-review`
+- trigger: `manual`
+- primary lifecycle domain: `security`
+- support level at first implementation: `official`
+- maturity at first implementation: `mvp`
+
+### Entry Model
+
+Recommended input model:
+
+- keep `agentforge run <workflow>`
+- add `.agentops/requests/security.yaml`
+- allow references to design records, implementation proposals, QA reports, or release artifacts
+
+### Workflow Stages
+
+1. intake normalization
+2. deterministic evidence collection
+3. security analysis
+4. report and artifact emission
+
+## Deterministic Vs Agentic Boundaries
+
+Deterministic responsibilities:
+
+- request validation
+- path and evidence scoping
+- local/static security evidence collection
+- dependency and release-trust signal normalization
+- artifact persistence and audit linkage
+
+Reasoning responsibilities:
+
+- risk prioritization
+- exploitability or severity framing
+- recommended mitigations
+- release or maintenance impact synthesis
+
+## Trust And Policy Boundaries
+
+- security workflows must remain more restrictive than generic review by default
+- sensitive findings and payloads remain subject to policy redaction
+- external scanners or network evidence sources must be explicit adapters, not implicit behavior
+- any remediation side effect remains outside the default security-review path
+
+## Required Artifacts
+
+Primary lifecycle artifact:
+
+- `security-report`
+
+The payload should minimally include:
+
+- `targetRef`
+- `evidenceSources`
+- `findings`
+- `severitySummary`
+- `mitigations`
+- `releaseImpact`
+- `followUpWork`
+
+## Required Deterministic Nodes, Agents, And Adapters
+
+Deterministic needs:
+
+- security request validator
+- local/static evidence collector
+- severity normalization
+- sensitive-payload sanitizer
+
+Starter agent need:
+
+- `security-analyst`
+
+Adapter expectations:
+
+- dependency and advisory ingestion must remain explicit and policy-aware
+- future compliance evidence adapters must preserve redaction and auditability
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. security request schema and official `security-review` workflow asset
+2. `security-analyst` starter agent and `security-report` artifact emission
+3. deterministic local security evidence collection and normalization
+4. security-domain policy wiring for evidence visibility, redaction, and escalation posture
+

--- a/docs/TEST_QA_WORKFLOWS.md
+++ b/docs/TEST_QA_WORKFLOWS.md
@@ -1,0 +1,165 @@
+# Test And QA Workflow Expansion
+
+This document defines the design target for issue [#54](https://github.com/H9-Foundry/AgentForge/issues/54).
+
+It describes the first dedicated QA workflow family AgentForge should add beyond the current `pr-review` wedge.
+
+It does **not** claim that these workflows are implemented or officially shipped today.
+
+## Why This Exists
+
+`pr-review` already touches tests and QA implicitly, but QA remains embedded inside review rather than represented as its own workflow family.
+
+Without dedicated QA workflows:
+
+- validation intent is mixed with code-review intent
+- test evidence is not normalized into lifecycle-specific artifacts
+- deterministic test/result handling is harder to separate from model reasoning
+- later release and maintenance workflows have no stable QA handoff
+
+## Design Goal
+
+The first QA expansion should define a workflow family that:
+
+- accepts a bounded QA request or implementation/design artifact input
+- gathers deterministic test and evidence context
+- emits one structured QA artifact
+- keeps execution support explicit and narrow at each stage
+
+## Current Baseline
+
+Available now:
+
+- one official `pr-review` workflow
+- starter `test-generation` agent
+- audit bundle and lifecycle artifact infrastructure
+- release verification and package checks
+
+Not yet available:
+
+- a dedicated QA workflow asset
+- a dedicated QA artifact family implementation beyond the design contract
+- deterministic normalization of test evidence into QA-specific outputs
+
+## Recommended Initial Workflow Family
+
+Phase 2 should treat QA as a family with one initial official wedge:
+
+- `qa-review`
+
+Later planned variants can include:
+
+- `test-generation-review`
+- `regression-triage`
+- `release-readiness-qa`
+
+Only `qa-review` should be targeted for first implementation planning.
+
+## User Jobs
+
+The first QA wedge should solve these jobs:
+
+1. gather deterministic evidence about validation surfaces for a bounded change
+2. summarize test gaps, risks, and recommended next checks
+3. separate QA outcomes from code review comments
+4. provide a clean handoff to release and maintenance workflows
+
+## Non-Goals
+
+This expansion should not:
+
+- imply broad arbitrary test execution support on day one
+- replace dedicated CI systems
+- merge every QA function into `pr-review`
+- promise flaky-test management or hosted lab execution
+
+## Workflow Shape
+
+### Workflow Identity
+
+- workflow name: `qa-review`
+- trigger: `manual`
+- primary lifecycle domain: `qa`
+- support level at first implementation: `official`
+- maturity at first implementation: `mvp`
+
+### Entry Model
+
+Recommended input model:
+
+- keep `agentforge run <workflow>`
+- add `.agentops/requests/qa.yaml`
+- allow references to design records, implementation proposals, or local validation outputs
+
+### Workflow Stages
+
+1. intake normalization
+2. deterministic evidence collection
+3. QA analysis
+4. report and artifact emission
+
+## Deterministic Vs Agentic Boundaries
+
+Deterministic responsibilities:
+
+- request validation
+- evidence collection from allowlisted local sources
+- normalization of known test outputs
+- artifact persistence and audit linkage
+
+Reasoning responsibilities:
+
+- QA risk framing
+- test-gap synthesis
+- prioritization of recommended follow-up checks
+
+## Trust And Policy Boundaries
+
+- read-only by default
+- test execution support must remain explicit and allowlisted
+- external CI ingestion must stay adapter- and policy-bounded
+- any write or network side effect remains approval-gated
+
+## Required Artifacts
+
+Primary lifecycle artifact:
+
+- `qa-report`
+
+The payload should minimally include:
+
+- `targetRef`
+- `evidenceSources`
+- `executedChecks`
+- `findings`
+- `coverageGaps`
+- `recommendedNextChecks`
+- `releaseImpact`
+
+## Required Deterministic Nodes, Agents, And Adapters
+
+Deterministic needs:
+
+- QA request validator
+- test-output normalizer
+- check inventory collector
+- release-impact classifier
+
+Starter agent need:
+
+- `qa-analyst`
+
+Adapter expectations:
+
+- local filesystem and shell evidence remain policy-bounded
+- future CI/test-result adapters must normalize into one QA evidence contract
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. QA request schema and official `qa-review` workflow asset
+2. `qa-analyst` starter agent and `qa-report` artifact emission
+3. deterministic test-output normalization and QA evidence ingestion
+4. policy/runtime wiring for QA-specific validation commands and evidence visibility
+


### PR DESCRIPTION
Closes #53
Closes #54
Closes #55
Closes #56
Closes #59
Closes #60
Closes #61

## Summary
- add decision-complete Phase 2 design docs for build/implementation, QA, security, GitHub maturity, release/CI-CD, operations/incident, and maintenance workflows
- update the roadmap and queue execution flow so the remaining roadmap work is sequenced honestly after planning/design and validation-hygiene completion
- decompose each Phase 2 epic into bounded child implementation issues instead of implying that the workflows already exist

## Child Issues Opened
- #139 through #159

## Validation
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`
- `node packages/cli/dist/bin.js run pr-review --json`

## Notes
- this PR is docs and backlog decomposition only; it does not add new official workflow assets or widen runtime capabilities
- the queue tracker remains the live source of truth for active versus ready work