### PR TITLE
Design Phase 3 and 4 roadmap docs

### DIFF
--- a/docs/EVALS_BENCHMARKS_FRAMEWORK.md
+++ b/docs/EVALS_BENCHMARKS_FRAMEWORK.md
@@ -1,0 +1,123 @@
+# Evals And Benchmarks Framework
+
+This document defines the design target for issue [#63](https://github.com/H9-Foundry/AgentForge/issues/63).
+
+It describes how AgentForge should measure workflow quality, safety, and regression over time.
+
+It does **not** claim that a first-class eval runner or benchmark harness is implemented today.
+
+## Why This Exists
+
+The repository already has:
+
+- unit and integration tests
+- CLI smoke tests
+- release verification
+- local dogfooding against the current wedge
+
+But those checks are not a dedicated evaluation framework for workflow quality and safety.
+
+## Design Goal
+
+The first eval/benchmark roadmap should:
+
+- separate deterministic regression checks from model-dependent evaluations
+- define shared artifacts for eval specs, eval runs, and benchmark summaries
+- keep provider-specific concerns out of the core contract
+- make workflow quality measurable as the catalog expands
+
+## Current Baseline
+
+Available now:
+
+- schema fixtures and runtime tests
+- release verification
+- local dogfooding for `pr-review`
+- support matrix and roadmap framing
+
+Not yet available:
+
+- eval spec schema
+- benchmark dataset or fixture corpus
+- workflow-scoring contracts
+- repeatable regression comparison across workflow versions
+
+## Framework Layers
+
+### Layer 1: Deterministic Eval Specs
+
+Define a contract for:
+
+- workflow input fixtures
+- expected deterministic outputs
+- redaction and policy expectations
+- baseline regression assertions
+
+This layer should be provider-agnostic and CI-friendly.
+
+### Layer 2: Model-Dependent Eval Runs
+
+Define a contract for:
+
+- model or agent under test
+- fixture inputs
+- scored outputs and rubric criteria
+- safety and quality dimensions
+
+This layer should keep scoring explicit and comparable, not magical.
+
+### Layer 3: Benchmarks And Trend Reporting
+
+Define how AgentForge should compare:
+
+- workflow versions
+- agent variants
+- quality and safety regressions
+- provider differences when relevant
+
+This layer should consume the earlier artifacts rather than invent its own ad hoc output.
+
+## Non-Goals
+
+This roadmap should not:
+
+- claim evaluation guarantees before infrastructure exists
+- tie evals to one model provider prematurely
+- conflate product telemetry with workflow evaluation
+- turn benchmarks into public marketing claims before they are stable
+
+## Trust And Policy Boundaries
+
+- eval fixtures must remain local and explicit by default
+- model-dependent runs must preserve redaction and policy posture
+- benchmark comparisons must distinguish deterministic facts from rubric judgments
+- external eval providers or hosted services remain future-facing and explicit
+
+## Required Artifacts And Contracts
+
+The roadmap should eventually introduce:
+
+- `eval-spec`
+- `eval-result`
+- `benchmark-summary`
+
+The first phase should define these as schema and reporting targets before implementation.
+
+## Relationship To Workflow Growth
+
+Evals should grow with the workflow catalog:
+
+- first for `pr-review`
+- then for planning/design workflows
+- then for build, QA, security, release, maintenance, and operations workflows
+
+The eval framework should never assume a broader workflow surface than the support matrix currently claims.
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. eval-spec schema and deterministic fixture corpus for core workflows
+2. local eval runner with score normalization and artifact emission
+3. benchmark comparison and regression-reporting surface for workflow and agent variants
+

--- a/docs/PLUGIN_REGISTRY_ROADMAP.md
+++ b/docs/PLUGIN_REGISTRY_ROADMAP.md
@@ -1,0 +1,123 @@
+# Plugin And Registry Roadmap
+
+This document defines the design target for issue [#62](https://github.com/H9-Foundry/AgentForge/issues/62).
+
+It describes how AgentForge should evolve from local/manual plugin trust into a broader plugin and registry roadmap without overstating current support.
+
+It does **not** claim that a remote registry, third-party install flow, or plugin marketplace is implemented today.
+
+## Why This Exists
+
+AgentForge already has a real local plugin trust baseline:
+
+- local workspace agent plugins can be loaded manually
+- plugin trust metadata is evaluated before execution
+- blocked plugins are recorded in the audit bundle
+
+But the broader ecosystem story is still undefined.
+
+## Design Goal
+
+The roadmap should:
+
+- preserve the current local/manual plugin trust baseline
+- define how workflow, agent, and adapter plugins could expand safely
+- separate read-only registry discovery from install or activation behavior
+- keep registry-facing work downstream of schema, policy, and trust contracts
+
+## Current Baseline
+
+Available now:
+
+- local/manual agent plugins only
+- trust-tier, trust-source, and reviewed-state enforcement
+- blocked-plugin reporting in audit output
+- internal `packages/registry-client` placeholder package
+
+Not yet available:
+
+- remote plugin discovery
+- registry metadata schema
+- signed third-party plugin distribution
+- adapter/provider plugin loading
+- install or update flows
+
+## Roadmap Wedges
+
+### Wedge 1: Registry Metadata Contract
+
+Define the registry-facing metadata needed to describe:
+
+- plugin identity
+- plugin type
+- version and compatibility range
+- trust tier and verification evidence
+- supported workflow domains and maturity
+
+This wedge should remain read-only and catalog-oriented.
+
+### Wedge 2: Read-Only Registry Discovery
+
+Define a bounded registry client surface that can:
+
+- fetch or cache plugin metadata
+- validate metadata against trust and compatibility contracts
+- expose install candidates without activating them
+
+This wedge should not install anything automatically.
+
+### Wedge 3: Verified Plugin Activation
+
+Define the eventual path for:
+
+- verified third-party plugin acquisition
+- signature or provenance checks
+- explicit maintainer approval before activation
+- policy-aware activation and rollback
+
+This wedge remains future-facing until the earlier two wedges exist.
+
+## Non-Goals
+
+This roadmap should not:
+
+- launch a plugin marketplace now
+- imply that `packages/registry-client` is a public production surface today
+- weaken local plugin trust requirements for convenience
+- introduce network-backed plugin loading into the default workflow path
+
+## Trust And Policy Boundaries
+
+- local/manual plugin loading remains the current supported baseline
+- registry reads must remain explicit and bounded
+- plugin activation must remain separate from plugin discovery
+- third-party plugin activation must remain approval-gated and policy-aware
+- trust metadata continues to be evaluated before workflow execution
+
+## Required Artifacts And Contracts
+
+The roadmap should eventually introduce:
+
+- registry plugin metadata schema
+- plugin compatibility contract
+- verification or provenance record for registry entries
+- activation decision record linked to audit output
+
+## Relationship To The Current Support Matrix
+
+Current truthful state:
+
+- local/manual plugin trust is real
+- registry integrations are planned
+- `packages/registry-client` remains internal
+
+The roadmap should keep those statements true until later implementation lands.
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. registry metadata schema and plugin-catalog contract
+2. read-only registry-client discovery and compatibility verification surface
+3. verified third-party plugin activation flow with explicit approval and trust checks
+

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -40,7 +40,7 @@ Rules:
 
 Current active lane:
 
-1. [#53](https://github.com/H9-Foundry/AgentForge/issues/53) build and implementation workflow support
+1. [#62](https://github.com/H9-Foundry/AgentForge/issues/62) plugin and registry roadmap
 
 ### Ready Lane
 
@@ -48,14 +48,12 @@ Work that is explicitly designed or queued next, but should not start until the 
 
 Current ready lane:
 
-2. [#54](https://github.com/H9-Foundry/AgentForge/issues/54) test and QA workflow expansion
-3. [#55](https://github.com/H9-Foundry/AgentForge/issues/55) security and DevSecOps workflow expansion
-4. [#56](https://github.com/H9-Foundry/AgentForge/issues/56) GitHub integration maturity
-5. [#59](https://github.com/H9-Foundry/AgentForge/issues/59) release and CI-CD workflow expansion
-6. [#60](https://github.com/H9-Foundry/AgentForge/issues/60) operations and incident workflow expansion
-7. [#61](https://github.com/H9-Foundry/AgentForge/issues/61) maintenance, dependency, and docs workflow expansion
-8. planning/discovery implementation follow-ons under [#127](https://github.com/H9-Foundry/AgentForge/issues/127), [#128](https://github.com/H9-Foundry/AgentForge/issues/128), [#129](https://github.com/H9-Foundry/AgentForge/issues/129), and [#130](https://github.com/H9-Foundry/AgentForge/issues/130)
-9. architecture/design implementation follow-ons under [#132](https://github.com/H9-Foundry/AgentForge/issues/132), [#133](https://github.com/H9-Foundry/AgentForge/issues/133), [#134](https://github.com/H9-Foundry/AgentForge/issues/134), [#136](https://github.com/H9-Foundry/AgentForge/issues/136), and [#135](https://github.com/H9-Foundry/AgentForge/issues/135)
+2. [#63](https://github.com/H9-Foundry/AgentForge/issues/63) evals and benchmarks framework
+3. [#64](https://github.com/H9-Foundry/AgentForge/issues/64) additional SCM and CI integrations roadmap
+4. [#65](https://github.com/H9-Foundry/AgentForge/issues/65) supply-chain and release trust hardening
+5. planning/discovery implementation follow-ons under [#127](https://github.com/H9-Foundry/AgentForge/issues/127), [#128](https://github.com/H9-Foundry/AgentForge/issues/128), [#129](https://github.com/H9-Foundry/AgentForge/issues/129), and [#130](https://github.com/H9-Foundry/AgentForge/issues/130)
+6. architecture/design implementation follow-ons under [#132](https://github.com/H9-Foundry/AgentForge/issues/132), [#133](https://github.com/H9-Foundry/AgentForge/issues/133), [#134](https://github.com/H9-Foundry/AgentForge/issues/134), [#136](https://github.com/H9-Foundry/AgentForge/issues/136), and [#135](https://github.com/H9-Foundry/AgentForge/issues/135)
+7. Phase 2 workflow implementation follow-ons under [#139](https://github.com/H9-Foundry/AgentForge/issues/139) through [#159](https://github.com/H9-Foundry/AgentForge/issues/159)
 
 ### Parallel Safe Lane
 
@@ -87,10 +85,7 @@ Work that is part of the roadmap and ordered relative to dependencies, but not y
 
 Current mapped lane:
 
-10. [#62](https://github.com/H9-Foundry/AgentForge/issues/62) plugin and registry roadmap
-11. [#63](https://github.com/H9-Foundry/AgentForge/issues/63) evals and benchmarks framework
-12. [#64](https://github.com/H9-Foundry/AgentForge/issues/64) additional SCM and CI integrations roadmap
-13. [#65](https://github.com/H9-Foundry/AgentForge/issues/65) supply-chain and release trust hardening
+- no additional mapped items beyond the current active and ready lanes yet
 
 ### Deferred Lane
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -175,6 +175,21 @@ Open a new bounded issue for any future newcomer-facing follow-up rather than re
 - evals and benchmarks
 - compatibility and support matrix expansion
 
+### Current Ecosystem Design Work
+
+- [docs/PLUGIN_REGISTRY_ROADMAP.md](PLUGIN_REGISTRY_ROADMAP.md)
+  - local/manual plugin trust baseline versus broader registry intent
+  - registry metadata, discovery, and verified activation wedges
+  - follow-on slices for metadata, discovery, and activation hardening
+- [docs/EVALS_BENCHMARKS_FRAMEWORK.md](EVALS_BENCHMARKS_FRAMEWORK.md)
+  - deterministic eval specs versus model-dependent eval runs
+  - benchmark-summary direction and regression tracking
+  - follow-on slices for eval specs, runner, and benchmark reporting
+- [docs/SCM_CI_INTEGRATIONS_ROADMAP.md](SCM_CI_INTEGRATIONS_ROADMAP.md)
+  - host-agnostic SCM/CI contracts before new host additions
+  - GitLab as the first additional concrete host pair
+  - follow-on slices for contracts, GitLab wedge, and generic CI evidence
+
 ## Phase 4: Enterprise / Governance / Scale
 
 ### Target Outcomes
@@ -188,6 +203,13 @@ Open a new bounded issue for any future newcomer-facing follow-up rather than re
 - governance and scale controls
 - compatibility commitments
 - observability and operational maturity
+
+### Current Governance / Trust Design Work
+
+- [docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md](SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md)
+  - dependency-integrity, attestation-verification, and consumer-trust gaps beyond the current trusted release baseline
+  - explicit downstream relationship to security, release, plugin, and integration work
+  - follow-on slices for dependency integrity, attestation verification, and registry/plugin distribution hardening
 
 ## Major Risks
 

--- a/docs/SCM_CI_INTEGRATIONS_ROADMAP.md
+++ b/docs/SCM_CI_INTEGRATIONS_ROADMAP.md
@@ -1,0 +1,106 @@
+# Additional SCM And CI Integrations Roadmap
+
+This document defines the design target for issue [#64](https://github.com/H9-Foundry/AgentForge/issues/64).
+
+It describes how AgentForge should expand beyond the current GitHub-centric baseline without promising broad integration support prematurely.
+
+It does **not** claim that additional SCM or CI integrations are implemented today.
+
+## Why This Exists
+
+The current repo is strongest in local execution plus GitHub-backed planning and release workflows.
+
+Broader SCM and CI support is part of the product direction, but there is no explicit sequence for it yet.
+
+## Design Goal
+
+The roadmap should:
+
+- define a host-agnostic contract for SCM and CI references
+- prioritize the next adapters rather than implying all hosts are equal
+- keep policy, trust, and artifact contracts ahead of new integrations
+- maintain an honest support matrix while new hosts remain planned
+
+## Current Baseline
+
+Available now:
+
+- local git context collection
+- narrow GitHub integration for planning/release/process work
+- GitHub-hosted validation and release automation
+
+Not yet available:
+
+- additional SCM host adapters
+- additional CI evidence adapters
+- host-agnostic workflow surfaces across multiple providers
+
+## Recommended Priority Order
+
+### Priority 1: Host-Agnostic Reference Contracts
+
+Before adding more hosts, define:
+
+- SCM reference model
+- CI run/check evidence model
+- host capability classification
+
+This keeps future adapters from inventing incompatible contracts.
+
+### Priority 2: One Additional SCM/CI Pair
+
+The first additional target should validate the host-agnostic model with one concrete ecosystem, likely:
+
+- GitLab SCM plus GitLab CI
+
+This provides a meaningful contrast to GitHub without exploding scope.
+
+### Priority 3: Additional Generic CI Evidence
+
+After the first new host pair:
+
+- expand to generic CI evidence adapters
+- consider Buildkite, Jenkins, or similar systems where bounded evidence ingestion makes sense
+
+## Non-Goals
+
+This roadmap should not:
+
+- promise every SCM and CI host equally
+- create hidden network dependencies in default local flows
+- make host-specific behavior the new core contract
+
+## Trust And Policy Boundaries
+
+- local execution must remain viable without any host integration
+- external host reads remain explicit and adapter-mediated
+- host writes or state changes must remain approval-gated
+- imported host content remains untrusted input
+
+## Required Artifacts And Contracts
+
+The roadmap should eventually introduce:
+
+- host-agnostic SCM reference schema
+- host-agnostic CI evidence schema
+- adapter capability metadata
+- host-handoff summary rendering compatible with lifecycle artifacts
+
+## Relationship To GitHub Maturity
+
+GitHub remains the first mature integration target.
+
+Additional SCM/CI work should:
+
+- build on the GitHub maturity contracts from `docs/GITHUB_INTEGRATION_MATURITY.md`
+- reuse lifecycle artifact handoff and evidence normalization patterns
+- keep GitHub-specific and host-agnostic layers separate
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. host-agnostic SCM and CI reference contracts plus adapter capability metadata
+2. GitLab issue/MR and CI evidence integration wedge as the first additional concrete host
+3. generic CI evidence adapter surface for bounded pipeline status and artifact ingestion
+

--- a/docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md
+++ b/docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md
@@ -1,0 +1,122 @@
+# Supply-Chain And Release Trust Hardening
+
+This document defines the design target for issue [#65](https://github.com/H9-Foundry/AgentForge/issues/65).
+
+It describes the remaining supply-chain and release-trust work beyond the current trusted publishing baseline.
+
+It does **not** claim that all hardening work is implemented today.
+
+## Why This Exists
+
+AgentForge already has a strong release-trust baseline:
+
+- curated public packages
+- trusted publishing
+- release verification
+- build provenance
+- signed maintainer commits
+
+But that baseline is not the end of the supply-chain story.
+
+## Design Goal
+
+The next hardening roadmap should:
+
+- preserve and extend the current trusted release posture
+- define remaining gaps across dependency integrity, artifact verification, and consumer trust
+- connect release-trust work to security, release, plugin, and compatibility roadmaps
+- keep public claims aligned with implemented protections
+
+## Current Baseline
+
+Available now:
+
+- trusted publishing through GitHub Actions
+- release verification and publish gating
+- provenance attestation for build artifacts
+- signed maintainer workflow and protected `main`
+
+Not yet available:
+
+- consumer-facing verification guidance beyond the current release tooling
+- broader dependency-integrity and SBOM workflow support
+- registry/plugin distribution trust hardening beyond local plugin trust
+- cross-host supply-chain evidence normalization
+
+## Remaining Hardening Areas
+
+### 1. Dependency Integrity
+
+Define how AgentForge should verify and report:
+
+- lockfile integrity expectations
+- dependency source and update provenance
+- SBOM or inventory outputs where appropriate
+
+### 2. Artifact And Attestation Verification
+
+Define how workflows should consume:
+
+- provenance attestations
+- package verification results
+- trusted-publishing posture checks
+
+This should extend the current release-readiness direction without replacing it.
+
+### 3. Plugin And Registry Trust Expansion
+
+Define how future plugin and registry work must incorporate:
+
+- verification records
+- signature or attestation checks
+- explicit activation approval
+
+### 4. Consumer And Maintainer Guidance
+
+Define what additional guidance and reporting is needed so maintainers and consumers can understand:
+
+- what is verified today
+- what is not yet verified
+- how to interpret release-trust signals
+
+## Non-Goals
+
+This roadmap should not:
+
+- weaken current release posture for convenience
+- claim full enterprise supply-chain coverage before it exists
+- replace the existing trusted release path during design
+
+## Trust And Policy Boundaries
+
+- current trusted publishing remains mandatory for official publishes
+- new hardening work should narrow trust gaps rather than widening capabilities
+- verification and attestation evidence remain explicit and auditable
+- maintainer convenience must not override release trust boundaries
+
+## Required Artifacts And Contracts
+
+The roadmap should eventually introduce:
+
+- supply-chain verification artifact or report extensions
+- dependency-integrity evidence contract
+- attestation verification result contract
+- consumer-facing trust-summary outputs derived from release artifacts
+
+## Relationship To Other Workstreams
+
+This roadmap is downstream of:
+
+- security and DevSecOps workflow expansion
+- release and CI-CD workflow expansion
+- plugin and registry roadmap
+- additional SCM/CI integration work where host evidence is relevant
+
+## Follow-On Implementation Slices
+
+This epic should be decomposed into at least:
+
+1. dependency-integrity and SBOM-oriented verification/reporting surface
+2. attestation verification and trust-summary integration for release workflows
+3. plugin and registry distribution hardening requirements aligned to verified activation and consumer trust signals
+


### PR DESCRIPTION
Closes #62
Closes #63
Closes #64
Closes #65

## Summary
- add decision-complete roadmap docs for plugins/registry, evals/benchmarks, additional SCM/CI integrations, and supply-chain hardening
- update the roadmap and queue execution flow so the remaining open work is represented as bounded follow-on implementation issues rather than implied platform support
- decompose each Phase 3/4 epic into bounded child implementation issues

## Child Issues Opened
- #161 through #172

## Validation
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`
- `node packages/cli/dist/bin.js run pr-review --json`

## Notes
- this PR is docs and backlog decomposition only; it does not add new plugin, registry, eval, SCM/CI, or supply-chain runtime capability
- the queue tracker remains the live source of truth for active versus ready work