### PR TITLE
Version public AgentForge packages

### DIFF
--- a/.changeset/planning-design-workflows.md
+++ b/.changeset/planning-design-workflows.md
@@ -1,9 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
-"@h9-foundry/agentforge-audit": minor
-"@h9-foundry/agentforge-runtime": minor
----
-
-Ship official `planning-discovery` and `architecture-design-review` workflow wedges with validated request inputs, lifecycle artifact emission, and CLI-first evaluator docs.

--- a/agents/design-analyst/CHANGELOG.md
+++ b/agents/design-analyst/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @h9-foundry/agentforge-agent-design-analyst
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-schemas@0.5.0
+  - @h9-foundry/agentforge-shared-types@0.5.0
+  - @h9-foundry/agentforge-sdk@0.5.0

--- a/agents/design-analyst/package.json
+++ b/agents/design-analyst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-design-analyst",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/agents/planning-analyst/CHANGELOG.md
+++ b/agents/planning-analyst/CHANGELOG.md
@@ -1,0 +1,10 @@
+# @h9-foundry/agentforge-agent-planning-analyst
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-schemas@0.5.0
+  - @h9-foundry/agentforge-shared-types@0.5.0
+  - @h9-foundry/agentforge-sdk@0.5.0

--- a/agents/planning-analyst/package.json
+++ b/agents/planning-analyst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-planning-analyst",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @h9-foundry/agentforge-audit
 
+## 0.5.0
+
+### Minor Changes
+
+- b8a25bb: Ship official `planning-discovery` and `architecture-design-review` workflow wedges with validated request inputs, lifecycle artifact emission, and CLI-first evaluator docs.
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-shared-types@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-audit",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @h9-foundry/agentforge-cli
 
+## 0.5.0
+
+### Minor Changes
+
+- b8a25bb: Ship official `planning-discovery` and `architecture-design-review` workflow wedges with validated request inputs, lifecycle artifact emission, and CLI-first evaluator docs.
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-schemas@0.5.0
+  - @h9-foundry/agentforge-shared-types@0.5.0
+  - @h9-foundry/agentforge-audit@0.5.0
+  - @h9-foundry/agentforge-runtime@0.5.0
+  - @h9-foundry/agentforge-context-engine@0.5.0
+  - @h9-foundry/agentforge-policy-engine@0.5.0
+  - @h9-foundry/agentforge-sdk@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-cli",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/context-engine/CHANGELOG.md
+++ b/packages/context-engine/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @h9-foundry/agentforge-context-engine
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-schemas@0.5.0
+  - @h9-foundry/agentforge-shared-types@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Repository and execution context collection for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/policy-engine/CHANGELOG.md
+++ b/packages/policy-engine/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @h9-foundry/agentforge-policy-engine
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-schemas@0.5.0
+  - @h9-foundry/agentforge-shared-types@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @h9-foundry/agentforge-runtime
 
+## 0.5.0
+
+### Minor Changes
+
+- b8a25bb: Ship official `planning-discovery` and `architecture-design-review` workflow wedges with validated request inputs, lifecycle artifact emission, and CLI-first evaluator docs.
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-schemas@0.5.0
+  - @h9-foundry/agentforge-shared-types@0.5.0
+  - @h9-foundry/agentforge-audit@0.5.0
+  - @h9-foundry/agentforge-policy-engine@0.5.0
+  - @h9-foundry/agentforge-sdk@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @h9-foundry/agentforge-schemas
 
+## 0.5.0
+
+### Minor Changes
+
+- b8a25bb: Ship official `planning-discovery` and `architecture-design-review` workflow wedges with validated request inputs, lifecycle artifact emission, and CLI-first evaluator docs.
+
 ## 0.4.2
 
 ## 0.4.1

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @h9-foundry/agentforge-sdk
 
+## 0.5.0
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-shared-types@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @h9-foundry/agentforge-shared-types
 
+## 0.5.0
+
+### Minor Changes
+
+- b8a25bb: Ship official `planning-discovery` and `architecture-design-review` workflow wedges with validated request inputs, lifecycle artifact emission, and CLI-first evaluator docs.
+
+### Patch Changes
+
+- Updated dependencies [b8a25bb]
+  - @h9-foundry/agentforge-schemas@0.5.0
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
   "license": "MIT",
   "author": "H9 Foundry",


### PR DESCRIPTION
Human-owned replacement for blocked bot release PR #175.

This PR contains the standard Changesets version/changelog updates for the planning/design workflow release.

Supersedes #175 if the bot PR continues to remain blocked with no attached required checks.

## Validation

- generated via `pnpm release:version`
- no source/runtime behavior changes beyond version/changelog updates
- protected merge path should trigger the normal publish workflow after merge
