### PR TITLE
Implement implementation-proposal request intake

### DIFF
--- a/.agentops/workflows/implementation-proposal.yaml
+++ b/.agentops/workflows/implementation-proposal.yaml
@@ -1,0 +1,17 @@
+version: 1
+name: implementation-proposal
+description: Validate a bounded implementation request and prepare it for later proposal stages.
+trigger: manual
+catalog:
+  domain: build
+  supportLevel: official
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: implementation-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final

--- a/.changeset/implementation-proposal-request.md
+++ b/.changeset/implementation-proposal-request.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add the implementation request schema and local workflow intake path for `implementation-proposal`.

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -359,4 +359,136 @@ describe("cli smoke flows", () => {
     expect(bundle.workflow).toBe("architecture-design-review");
     expect(bundle.lifecycleArtifacts.some((artifact) => artifact.artifactKind === "design-record")).toBe(true);
   });
+
+  it("fails implementation-proposal before reasoning when the request is missing", async () => {
+    const root = createGitFixture("agentops-cli-implementation-missing-");
+    initProject(root);
+
+    await expect(runLocalWorkflow("implementation-proposal", root)).rejects.toThrow("Missing implementation request");
+  });
+
+  it("requires a valid design bundle reference for implementation-proposal", async () => {
+    const root = createGitFixture("agentops-cli-implementation-invalid-ref-");
+    initProject(root);
+    mkdirSync(join(root, ".agentops", "requests"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        "designRecordRef: .agentops/runs/missing/bundle.json",
+        "implementationGoal: Prepare the next bounded implementation proposal",
+        "approvalMode: proposal-only"
+      ].join("\n")
+    );
+
+    await expect(runLocalWorkflow("implementation-proposal", root)).rejects.toThrow("Referenced design bundle not found");
+  });
+
+  it("requires a design-record artifact for implementation-proposal", async () => {
+    const root = createGitFixture("agentops-cli-implementation-invalid-artifact-");
+    initProject(root);
+    mkdirSync(join(root, ".agentops", "requests"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Plan the first workflow wedge",
+        "goals:",
+        "  - Produce a planning brief",
+        "constraints:",
+        "  - Keep the workflow local-first",
+        "issueRefs:",
+        "  - '#127'",
+        "pathHints:",
+        "  - packages/runtime"
+      ].join("\n")
+    );
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        `designRecordRef: .agentops/runs/${planningRun.runId}/bundle.json`,
+        "implementationGoal: Prepare the next bounded implementation proposal",
+        "approvalMode: proposal-only"
+      ].join("\n")
+    );
+
+    await expect(runLocalWorkflow("implementation-proposal", root)).rejects.toThrow(
+      "Referenced bundle does not contain a design-record artifact"
+    );
+  });
+
+  it("requires approvalMode for implementation-proposal requests", async () => {
+    const root = createGitFixture("agentops-cli-implementation-missing-approval-");
+    initProject(root);
+    mkdirSync(join(root, ".agentops", "requests"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        "designRecordRef: .agentops/runs/run-456/bundle.json",
+        "implementationGoal: Prepare the next bounded implementation proposal"
+      ].join("\n")
+    );
+
+    await expect(runLocalWorkflow("implementation-proposal", root)).rejects.toThrow();
+  });
+
+  it("runs implementation-proposal after a valid design-record handoff", async () => {
+    const root = createGitFixture("agentops-cli-implementation-");
+    initProject(root);
+    mkdirSync(join(root, ".agentops", "requests"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Plan the first workflow wedge",
+        "goals:",
+        "  - Produce a planning brief",
+        "constraints:",
+        "  - Keep the workflow local-first",
+        "issueRefs:",
+        "  - '#127'",
+        "pathHints:",
+        "  - packages/runtime",
+        "  - packages/schemas"
+      ].join("\n")
+    );
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "design.yaml"),
+      [
+        `planningBriefRef: .agentops/runs/${planningRun.runId}/bundle.json`,
+        "decisionTarget: Choose the first design workflow implementation shape",
+        "pathHints:",
+        "  - packages/runtime",
+        "  - packages/schemas",
+        "alternatives:",
+        "  - single-workflow-pass"
+      ].join("\n")
+    );
+    const designRun = await runLocalWorkflow("architecture-design-review", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        `designRecordRef: .agentops/runs/${designRun.runId}/bundle.json`,
+        "implementationGoal: Prepare the next bounded implementation proposal",
+        "approvalMode: proposal-only",
+        "targetPaths:",
+        "  - packages/cli",
+        "  - packages/runtime",
+        "validationCommands:",
+        "  - pnpm test",
+        "constraints:",
+        "  - Keep the default path read-only"
+      ].join("\n")
+    );
+
+    const implementationRun = await runLocalWorkflow("implementation-proposal", root);
+    expect(implementationRun.status).toBe("success");
+    expect(implementationRun.artifactKinds).toEqual([]);
+
+    const bundle = JSON.parse(readFileSync(implementationRun.jsonPath, "utf8")) as {
+      workflow: string;
+      lifecycleArtifacts: { artifactKind: string }[];
+    };
+    expect(bundle.workflow).toBe("implementation-proposal");
+    expect(bundle.lifecycleArtifacts).toEqual([]);
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,9 @@ import { runWorkflow } from "@h9-foundry/agentforge-runtime";
 import {
   agentforgeConfigSchema,
   auditBundleSchema,
+  designArtifactSchema,
   designRequestSchema,
+  implementationRequestSchema,
   planningArtifactSchema,
   planningRequestSchema,
   workflowDefinitionSchema
@@ -19,7 +21,9 @@ import type {
   AgentForgeConfig,
   AgentPluginRegistration,
   BlockedPlugin,
+  DesignArtifact,
   DesignRequest,
+  ImplementationRequest,
   PlanningArtifact,
   PlanningRequest,
   WorkflowDefinition
@@ -187,6 +191,25 @@ nodes:
     outputs_to: reports.final
 `;
 
+const implementationWorkflowTemplate = `version: 1
+name: implementation-proposal
+description: Validate a bounded implementation request and prepare it for later proposal stages.
+trigger: manual
+catalog:
+  domain: build
+  supportLevel: official
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: implementation-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final
+`;
+
 function loadYaml(filePath: string): unknown {
   return yaml.load(readFileSync(filePath, "utf8"));
 }
@@ -240,7 +263,7 @@ function validateWorkflowLifecyclePosture(
   policyEngine: ReturnType<typeof createPolicyEngine>
 ): void {
   const domain = workflow.catalog?.domain;
-  if (domain !== "plan" && domain !== "design") {
+  if (domain !== "plan" && domain !== "design" && domain !== "build") {
     return;
   }
 
@@ -269,6 +292,24 @@ function loadPlanningBundleArtifact(root: string, planningBriefRef: string): Pla
   }
 
   return planningArtifactSchema.parse(planningArtifact);
+}
+
+function loadDesignBundleArtifact(root: string, designRecordRef: string): DesignArtifact {
+  const bundlePath = join(root, designRecordRef);
+  if (!existsSync(bundlePath)) {
+    throw new Error(`Referenced design bundle not found: ${designRecordRef}`);
+  }
+
+  const bundle = auditBundleSchema.parse(JSON.parse(readFileSync(bundlePath, "utf8")) as unknown);
+  const designArtifact = bundle.lifecycleArtifacts.find(
+    (artifact): artifact is DesignArtifact => artifact.artifactKind === "design-record"
+  );
+
+  if (!designArtifact) {
+    throw new Error(`Referenced bundle does not contain a design-record artifact: ${designRecordRef}`);
+  }
+
+  return designArtifactSchema.parse(designArtifact);
 }
 
 function prepareWorkflowInputs(
@@ -302,6 +343,20 @@ function prepareWorkflowInputs(
     return {
       designRequest: designRequest satisfies DesignRequest,
       planningBrief,
+      requestFile: requestPath
+    };
+  }
+
+  if (workflow.name === "implementation-proposal") {
+    const requestPath = ".agentops/requests/implementation.yaml";
+    ensureReadablePath(policyEngine, requestPath, "implementation request");
+    const implementationRequest = readYamlFile(join(root, requestPath), implementationRequestSchema, "implementation request");
+    ensureReadablePath(policyEngine, implementationRequest.designRecordRef, "design record reference");
+    const designRecord = loadDesignBundleArtifact(root, implementationRequest.designRecordRef);
+
+    return {
+      implementationRequest: implementationRequest satisfies ImplementationRequest,
+      designRecord,
       requestFile: requestPath
     };
   }
@@ -465,6 +520,10 @@ function ensureInitFiles(root: string): string[] {
     {
       path: join(workflowsDir, "architecture-design-review.yaml"),
       contents: designWorkflowTemplate
+    },
+    {
+      path: join(workflowsDir, "implementation-proposal.yaml"),
+      contents: implementationWorkflowTemplate
     }
   ];
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -3,7 +3,14 @@ import { join } from "node:path";
 
 import { agentManifestSchema, agentOutputSchema, designArtifactSchema, planningArtifactSchema } from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
-import type { DesignRequest, PlanningArtifact, PlanningRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type {
+  DesignArtifact,
+  DesignRequest,
+  ImplementationRequest,
+  PlanningArtifact,
+  PlanningRequest,
+  WorkflowStateEnvelope
+} from "@h9-foundry/agentforge-shared-types";
 
 const contextCollectorAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
@@ -480,6 +487,72 @@ const designInventoryAgent: RuntimeAgent = {
   }
 };
 
+const implementationIntakeAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "implementation-intake",
+    displayName: "Implementation Intake",
+    category: "implementation",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "context"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "build",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const implementationRequest = getWorkflowInput<ImplementationRequest>(stateSlice, "implementationRequest");
+    const designRecord = getWorkflowInput<DesignArtifact>(stateSlice, "designRecord");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!implementationRequest || !designRecord) {
+      throw new Error(
+        "implementation-proposal requires a validated implementation request and design record before runtime execution."
+      );
+    }
+
+    return agentOutputSchema.parse({
+      summary: `Loaded implementation request from ${requestFile ?? ".agentops/requests/implementation.yaml"} with design record ${implementationRequest.designRecordRef}.`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: {
+        requestFile,
+        designRecordRef: implementationRequest.designRecordRef,
+        implementationGoal: implementationRequest.implementationGoal,
+        approvalMode: implementationRequest.approvalMode,
+        targetPaths: implementationRequest.targetPaths,
+        validationCommands: implementationRequest.validationCommands,
+        designDecisionSummary: designRecord.payload.decisionSummary
+      }
+    });
+  }
+};
+
 const designAnalystAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -860,6 +933,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["planning-analyst", planningAnalystAgent],
     ["design-intake", designIntakeAgent],
     ["design-inventory", designInventoryAgent],
+    ["implementation-intake", implementationIntakeAgent],
     ["design-analyst", designAnalystAgent],
     ["code-review", codeReviewAgent],
     ["security-audit", securityAuditAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   designArtifactSchema,
   designRequestSchema,
   getJsonSchemas,
+  implementationRequestSchema,
   lifecycleArtifactEnvelopeSchema,
   maintenanceArtifactSchema,
   policyDocumentSchema,
@@ -24,6 +25,7 @@ describe("schema fixtures", () => {
     expect(() => workflowDefinitionSchema.parse(schemaFixtures.workflowDefinition)).not.toThrow();
     expect(() => planningRequestSchema.parse(schemaFixtures.planningRequest)).not.toThrow();
     expect(() => designRequestSchema.parse(schemaFixtures.designRequest)).not.toThrow();
+    expect(() => implementationRequestSchema.parse(schemaFixtures.implementationRequest)).not.toThrow();
   });
 
   it("rejects invalid manifests", () => {
@@ -42,6 +44,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.workflowDefinition).toBeDefined();
     expect(jsonSchemas.planningRequest).toBeDefined();
     expect(jsonSchemas.designRequest).toBeDefined();
+    expect(jsonSchemas.implementationRequest).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
     expect(jsonSchemas.planningArtifact).toBeDefined();
     expect(jsonSchemas.designArtifact).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -304,6 +304,15 @@ export const designRequestSchema = z.object({
   questions: z.array(z.string().min(1)).default([])
 });
 
+export const implementationRequestSchema = z.object({
+  designRecordRef: z.string().min(1),
+  implementationGoal: z.string().min(1),
+  targetPaths: z.array(z.string().min(1)).default([]),
+  validationCommands: z.array(z.string().min(1)).default([]),
+  constraints: z.array(z.string().min(1)).default([]),
+  approvalMode: z.enum(["proposal-only", "apply-capable"])
+});
+
 export const repoMetadataSchema = z.object({
   root: z.string().min(1),
   name: z.string().min(1),
@@ -604,6 +613,7 @@ export const schemaRegistry = {
   agentforgeConfig: agentforgeConfigSchema,
   planningRequest: planningRequestSchema,
   designRequest: designRequestSchema,
+  implementationRequest: implementationRequestSchema,
   policyDocument: policyDocumentSchema,
   effectivePolicySnapshot: effectivePolicySnapshotSchema,
   workflowDefinition: workflowDefinitionSchema,
@@ -771,6 +781,15 @@ const invalidReviewArtifactFixture = {
   lifecycleDomain: "release"
 } as const;
 
+const implementationRequestFixture = {
+  designRecordRef: ".agentops/runs/run-456/bundle.json",
+  implementationGoal: "Prepare a bounded implementation proposal for the next workflow wedge.",
+  targetPaths: ["packages/cli", "packages/runtime"],
+  validationCommands: ["pnpm test", "pnpm typecheck"],
+  constraints: ["Keep the default path read-only"],
+  approvalMode: "proposal-only"
+} as const;
+
 export const schemaFixtures = {
   finding: {
     id: "finding-1",
@@ -875,6 +894,7 @@ export const schemaFixtures = {
     alternatives: ["single-agent workflow", "deterministic intake plus reasoning"],
     questions: ["How should planning artifacts be referenced downstream?"]
   },
+  implementationRequest: implementationRequestFixture,
   lifecycleArtifactEnvelope: planningArtifactFixture,
   planningArtifact: planningArtifactFixture,
   designArtifact: designArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -4,6 +4,7 @@ import type {
   DesignArtifact,
   DesignArtifactOption,
   DesignRequest,
+  ImplementationRequest,
   MaintenanceArtifact,
   PlanningArtifact,
   PlanningRequest,
@@ -36,5 +37,7 @@ describe("shared lifecycle artifact types", () => {
   it("exports workflow request helper types", () => {
     expectTypeOf<PlanningRequest["problemStatement"]>().toEqualTypeOf<string>();
     expectTypeOf<DesignRequest["planningBriefRef"]>().toEqualTypeOf<string>();
+    expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
+    expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
   });
 });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -25,6 +25,7 @@ import {
   designRequestSchema,
   effectivePolicySnapshotSchema,
   findingSchema,
+  implementationRequestSchema,
   maintenanceArtifactPayloadSchema,
   maintenanceArtifactSchema,
   policyDocumentSchema,
@@ -70,6 +71,7 @@ export type DesignArtifactOption = Infer<typeof designArtifactOptionSchema>;
 export type DesignArtifactPayload = Infer<typeof designArtifactPayloadSchema>;
 export type DesignArtifact = Infer<typeof designArtifactSchema>;
 export type DesignRequest = Infer<typeof designRequestSchema>;
+export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
 export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
 export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;
 export type ReleaseVerificationCheck = Infer<typeof releaseVerificationCheckSchema>;


### PR DESCRIPTION
## Summary
- add the implementation request schema and shared type
- add the official local `implementation-proposal` workflow asset and init scaffolding
- add deterministic pre-validation for implementation requests and design-record bundle references
- add the internal `implementation-intake` builtin agent and focused CLI/schema/shared-type tests

## Issue
Closes #139

## Scope Boundaries
- no implementation planner agent yet
- no `implementation-proposal` lifecycle artifact emission yet
- no deterministic build-surface inventory or validation-command normalization yet
- no README or support-matrix promotion yet

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/index.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo evaluator flow through `planning-discovery` -> `architecture-design-review` -> `implementation-proposal`

## Usability Impact
This preserves the current evaluator path for the existing official workflows while adding a new bounded local workflow intake surface. The new workflow is not promoted to official public docs yet; that remains gated on `#146` and `#153`.