### PR TITLE
Emit implementation-proposal artifacts

### DIFF
--- a/.agentops/workflows/implementation-proposal.yaml
+++ b/.agentops/workflows/implementation-proposal.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: implementation-intake
     outputs_to: agentResults.intake
+  - id: planning
+    kind: reasoning
+    agent: implementation-planner
+    outputs_to: agentResults.planning
   - id: report
     kind: report
     outputs_to: reports.final

--- a/.changeset/implementation-proposal-artifact.md
+++ b/.changeset/implementation-proposal-artifact.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add implementation-proposal artifact emission and the bounded implementation planner workflow node.

--- a/agents/implementation-planner/CHANGELOG.md
+++ b/agents/implementation-planner/CHANGELOG.md
@@ -1,0 +1,3 @@
+# @h9-foundry/agentforge-agent-implementation-planner
+
+Private starter agent package for the bounded `implementation-proposal` workflow wedge.

--- a/agents/implementation-planner/agent.manifest.json
+++ b/agents/implementation-planner/agent.manifest.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "name": "implementation-planner",
+  "displayName": "Implementation Planner",
+  "category": "implementation",
+  "runtime": {
+    "minVersion": "0.1.0",
+    "kind": "reasoning"
+  },
+  "permissions": {
+    "model": true,
+    "network": false,
+    "tools": [],
+    "readPaths": ["**/*"],
+    "writePaths": []
+  },
+  "inputs": ["workflowInputs", "repo", "changes", "agentResults"],
+  "outputs": ["lifecycleArtifacts"],
+  "contextPolicy": {
+    "sections": ["workflowInputs", "repo", "changes", "agentResults"],
+    "minimalContext": true
+  },
+  "catalog": {
+    "domain": "build",
+    "supportLevel": "official",
+    "maturity": "mvp",
+    "trustScope": "official-core-only"
+  },
+  "trust": {
+    "tier": "core",
+    "source": "official",
+    "reviewed": true
+  }
+}

--- a/agents/implementation-planner/package.json
+++ b/agents/implementation-planner/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@h9-foundry/agentforge-agent-implementation-planner",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "agent.manifest.json"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@h9-foundry/agentforge-schemas": "workspace:*",
+    "@h9-foundry/agentforge-sdk": "workspace:*",
+    "@h9-foundry/agentforge-shared-types": "workspace:*"
+  }
+}

--- a/agents/implementation-planner/src/index.test.ts
+++ b/agents/implementation-planner/src/index.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { implementationPlannerAgent } from "./index.js";
+
+describe("implementation planner agent", () => {
+  it("emits an implementation proposal artifact from validated inputs", async () => {
+    const output = await implementationPlannerAgent.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-3",
+        workflow: "implementation-proposal",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: ["packages"],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          implementationRequest: {
+            designRecordRef: ".agentops/runs/run-2/bundle.json",
+            implementationGoal: "Prepare the next bounded implementation proposal",
+            targetPaths: ["packages/cli", "packages/runtime"],
+            validationCommands: ["pnpm test"],
+            constraints: ["Keep the default path read-only"],
+            approvalMode: "proposal-only"
+          },
+          designRecord: {
+            schemaVersion: "1.0.0",
+            artifactKind: "design-record",
+            lifecycleDomain: "design",
+            workflow: {
+              name: "architecture-design-review",
+              displayName: "Architecture And Design Review"
+            },
+            source: {
+              sourceType: "workflow-run",
+              runId: "run-2",
+              inputRefs: [".agentops/requests/design.yaml", ".agentops/runs/run-1/bundle.json"],
+              issueRefs: ["#132"]
+            },
+            status: "complete",
+            generatedAt: new Date().toISOString(),
+            repo: {
+              root: "/repo",
+              name: "repo",
+              branch: "main"
+            },
+            provenance: {
+              generatedBy: "agentforge-runtime",
+              schemaVersion: "1.0.0",
+              executionEnvironment: "local",
+              repoRoot: "/repo"
+            },
+            redaction: {
+              applied: true,
+              strategyVersion: "1.0.0",
+              categories: ["secrets"]
+            },
+            auditLink: {
+              entryIds: [],
+              findingIds: [],
+              proposedActionIds: []
+            },
+            summary: "Design record ready.",
+            payload: {
+              decisionSummary: "Choose the implementation workflow shape.",
+              context: "Planning brief summary: Planning brief ready.",
+              optionsConsidered: [{ option: "single-workflow-pass", summary: "Keep the workflow narrow." }],
+              chosenApproach: "single-workflow-pass",
+              tradeOffs: [],
+              risks: [],
+              followUpWork: ["Turn the design record into a bounded implementation proposal."],
+              interfacesImpacted: ["packages/cli/src/index.ts"],
+              schemaChangesNeeded: ["packages/schemas/src/index.ts"],
+              policyChangesNeeded: [],
+              migrationNotes: [],
+              compatibilityNotes: []
+            }
+          },
+          requestFile: ".agentops/requests/implementation.yaml"
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.lifecycleArtifacts).toHaveLength(1);
+    expect(output.lifecycleArtifacts[0]?.artifactKind).toBe("implementation-proposal");
+  });
+});

--- a/agents/implementation-planner/src/index.ts
+++ b/agents/implementation-planner/src/index.ts
@@ -1,0 +1,191 @@
+import { agentManifestSchema, agentOutputSchema, implementationArtifactSchema } from "@h9-foundry/agentforge-schemas";
+import type { DesignArtifact, ImplementationRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: string): T | undefined {
+  if (!isRecord(stateSlice.workflowInputs)) {
+    return undefined;
+  }
+
+  return stateSlice.workflowInputs[key] as T | undefined;
+}
+
+function buildArtifactEnvelopeBase(state: WorkflowStateEnvelope, summary: string, inputRefs: readonly string[], issueRefs: readonly string[]) {
+  return {
+    schemaVersion: state.version,
+    workflow: {
+      name: state.workflow,
+      displayName: "Implementation Proposal"
+    },
+    source: {
+      sourceType: "workflow-run" as const,
+      runId: state.runId,
+      inputRefs: [...inputRefs],
+      issueRefs: [...issueRefs]
+    },
+    status: "complete" as const,
+    generatedAt: new Date().toISOString(),
+    repo: {
+      root: state.repo.root,
+      name: state.repo.name,
+      branch: state.repo.branch
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" as const : "local" as const,
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
+    },
+    auditLink: {
+      entryIds: [],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary
+  };
+}
+
+export const manifest = agentManifestSchema.parse({
+  version: 1,
+  name: "implementation-planner",
+  displayName: "Implementation Planner",
+  category: "implementation",
+  runtime: {
+    minVersion: "0.1.0",
+    kind: "reasoning"
+  },
+  permissions: {
+    model: true,
+    network: false,
+    tools: [],
+    readPaths: ["**/*"],
+    writePaths: []
+  },
+  inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+  outputs: ["lifecycleArtifacts"],
+  contextPolicy: {
+    sections: ["workflowInputs", "repo", "changes", "agentResults"],
+    minimalContext: true
+  },
+  catalog: {
+    domain: "build",
+    supportLevel: "official",
+    maturity: "mvp",
+    trustScope: "official-core-only"
+  },
+  trust: {
+    tier: "core",
+    source: "official",
+    reviewed: true
+  }
+});
+
+export const implementationPlannerAgent: RuntimeAgent = {
+  manifest,
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const implementationRequest = getWorkflowInput<ImplementationRequest>(stateSlice, "implementationRequest");
+    const designRecord = getWorkflowInput<DesignArtifact>(stateSlice, "designRecord");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!implementationRequest || !designRecord) {
+      throw new Error("implementation-proposal requires validated implementation inputs before proposal analysis.");
+    }
+
+    const affectedPaths = [
+      ...new Set([
+        ...implementationRequest.targetPaths,
+        ...designRecord.payload.interfacesImpacted,
+        ...designRecord.payload.schemaChangesNeeded,
+        ...designRecord.payload.policyChangesNeeded
+      ])
+    ];
+    const normalizedAffectedPaths =
+      affectedPaths.length > 0 ? affectedPaths : ["Repository paths still need deterministic build-surface confirmation."];
+    const proposedChanges = [
+      `Prepare a bounded implementation plan for ${implementationRequest.implementationGoal}.`,
+      ...normalizedAffectedPaths.slice(0, 5).map((pathValue) => `Plan targeted edits for ${pathValue}.`)
+    ];
+    const validationPlan =
+      implementationRequest.validationCommands.length > 0
+        ? implementationRequest.validationCommands.map(
+            (command) => `Review allowlist suitability for \`${command}\` before any future execution.`
+          )
+        : ["Confirm allowlisted validation commands in the next deterministic implementation slice before execution."];
+    const approvalRequiredSteps =
+      implementationRequest.approvalMode === "apply-capable"
+        ? [
+            "Any future patch application requires explicit approval before execution.",
+            "Any future build or validation execution requires approval after allowlist review."
+          ]
+        : ["The default path remains proposal-only; any patch or build execution requires a separate approved workflow."];
+    const risks = [
+      ...(implementationRequest.targetPaths.length === 0
+        ? ["Target paths were not supplied, so affected surfaces may still broaden after deterministic discovery."]
+        : []),
+      ...(implementationRequest.validationCommands.length === 0
+        ? ["Validation commands are not yet specified and will need deterministic allowlist confirmation later."]
+        : [])
+    ];
+    const openQuestions = [
+      ...(implementationRequest.constraints.length === 0
+        ? ["Which additional implementation constraints should be captured before execution work begins?"]
+        : []),
+      ...(designRecord.payload.policyChangesNeeded.length > 0
+        ? ["Do the policy surfaces identified in the design record require a separate approval review?"]
+        : [])
+    ];
+    const summary = `Implementation proposal prepared for ${implementationRequest.implementationGoal}.`;
+    const implementationProposal = implementationArtifactSchema.parse({
+      ...buildArtifactEnvelopeBase(
+        state,
+        summary,
+        [requestFile ?? ".agentops/requests/implementation.yaml", implementationRequest.designRecordRef],
+        designRecord.source.issueRefs
+      ),
+      artifactKind: "implementation-proposal",
+      lifecycleDomain: "build",
+      payload: {
+        designRecordRef: implementationRequest.designRecordRef,
+        implementationGoal: implementationRequest.implementationGoal,
+        affectedPaths: normalizedAffectedPaths,
+        proposedChanges,
+        validationPlan,
+        approvalRequiredSteps,
+        risks,
+        openQuestions
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [implementationProposal],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.76,
+      metadata: {
+        deterministicInputs: {
+          targetPaths: implementationRequest.targetPaths,
+          validationCommands: implementationRequest.validationCommands,
+          constraints: implementationRequest.constraints,
+          designInterfaces: designRecord.payload.interfacesImpacted
+        },
+        synthesizedProposal: {
+          affectedPaths: normalizedAffectedPaths,
+          approvalRequiredSteps,
+          openQuestions
+        }
+      }
+    });
+  }
+};

--- a/agents/implementation-planner/tsconfig.json
+++ b/agents/implementation-planner/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../../packages/schemas" }, { "path": "../../packages/sdk" }, { "path": "../../packages/shared-types" }]
+}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -482,13 +482,16 @@ describe("cli smoke flows", () => {
 
     const implementationRun = await runLocalWorkflow("implementation-proposal", root);
     expect(implementationRun.status).toBe("success");
-    expect(implementationRun.artifactKinds).toEqual([]);
+    expect(implementationRun.artifactKinds).toContain("implementation-proposal");
 
     const bundle = JSON.parse(readFileSync(implementationRun.jsonPath, "utf8")) as {
       workflow: string;
       lifecycleArtifacts: { artifactKind: string }[];
     };
     expect(bundle.workflow).toBe("implementation-proposal");
-    expect(bundle.lifecycleArtifacts).toEqual([]);
+    expect(bundle.lifecycleArtifacts.some((artifact) => artifact.artifactKind === "implementation-proposal")).toBe(true);
+
+    const explanation = explainLastRun(root);
+    expect(explanation.artifactKinds).toContain("implementation-proposal");
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -205,6 +205,10 @@ nodes:
     kind: deterministic
     agent: implementation-intake
     outputs_to: agentResults.intake
+  - id: planning
+    kind: reasoning
+    agent: implementation-planner
+    outputs_to: agentResults.planning
   - id: report
     kind: report
     outputs_to: reports.final

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -1,11 +1,18 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 
-import { agentManifestSchema, agentOutputSchema, designArtifactSchema, planningArtifactSchema } from "@h9-foundry/agentforge-schemas";
+import {
+  agentManifestSchema,
+  agentOutputSchema,
+  designArtifactSchema,
+  implementationArtifactSchema,
+  planningArtifactSchema
+} from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 import type {
   DesignArtifact,
   DesignRequest,
+  ImplementationArtifact,
   ImplementationRequest,
   PlanningArtifact,
   PlanningRequest,
@@ -553,6 +560,144 @@ const implementationIntakeAgent: RuntimeAgent = {
   }
 };
 
+const implementationPlannerAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "implementation-planner",
+    displayName: "Implementation Planner",
+    category: "implementation",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "reasoning"
+    },
+    permissions: {
+      model: true,
+      network: false,
+      tools: [],
+      readPaths: ["**/*"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+    outputs: ["lifecycleArtifacts"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "changes", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "build",
+      supportLevel: "official",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const implementationRequest = getWorkflowInput<ImplementationRequest>(stateSlice, "implementationRequest");
+    const designRecord = getWorkflowInput<DesignArtifact>(stateSlice, "designRecord");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!implementationRequest || !designRecord) {
+      throw new Error("implementation-proposal requires validated implementation inputs before proposal analysis.");
+    }
+
+    const affectedPaths = [
+      ...new Set([
+        ...implementationRequest.targetPaths,
+        ...designRecord.payload.interfacesImpacted,
+        ...designRecord.payload.schemaChangesNeeded,
+        ...designRecord.payload.policyChangesNeeded
+      ])
+    ];
+    const normalizedAffectedPaths =
+      affectedPaths.length > 0 ? affectedPaths : ["Repository paths still need deterministic build-surface confirmation."];
+    const proposedChanges = [
+      `Prepare a bounded implementation plan for ${implementationRequest.implementationGoal}.`,
+      ...normalizedAffectedPaths.slice(0, 5).map((pathValue) => `Plan targeted edits for ${pathValue}.`)
+    ];
+    const validationPlan =
+      implementationRequest.validationCommands.length > 0
+        ? implementationRequest.validationCommands.map(
+            (command) => `Review allowlist suitability for \`${command}\` before any future execution.`
+          )
+        : ["Confirm allowlisted validation commands in the next deterministic implementation slice before execution."];
+    const approvalRequiredSteps =
+      implementationRequest.approvalMode === "apply-capable"
+        ? [
+            "Any future patch application requires explicit approval before execution.",
+            "Any future build or validation execution requires approval after allowlist review."
+          ]
+        : ["The default path remains proposal-only; any patch or build execution requires a separate approved workflow."];
+    const risks = [
+      ...(implementationRequest.targetPaths.length === 0
+        ? ["Target paths were not supplied, so affected surfaces may still broaden after deterministic discovery."]
+        : []),
+      ...(implementationRequest.validationCommands.length === 0
+        ? ["Validation commands are not yet specified and will need deterministic allowlist confirmation later."]
+        : [])
+    ];
+    const openQuestions = [
+      ...(implementationRequest.constraints.length === 0
+        ? ["Which additional implementation constraints should be captured before execution work begins?"]
+        : []),
+      ...(designRecord.payload.policyChangesNeeded.length > 0
+        ? ["Do the policy surfaces identified in the design record require a separate approval review?"]
+        : [])
+    ];
+    const summary = `Implementation proposal prepared for ${implementationRequest.implementationGoal}.`;
+    const implementationProposal = implementationArtifactSchema.parse({
+      ...buildArtifactEnvelopeBase(
+        state,
+        summary,
+        [requestFile ?? ".agentops/requests/implementation.yaml", implementationRequest.designRecordRef],
+        designRecord.source.issueRefs
+      ),
+      artifactKind: "implementation-proposal",
+      lifecycleDomain: "build",
+      workflow: {
+        name: state.workflow,
+        displayName: "Implementation Proposal"
+      },
+      payload: {
+        designRecordRef: implementationRequest.designRecordRef,
+        implementationGoal: implementationRequest.implementationGoal,
+        affectedPaths: normalizedAffectedPaths,
+        proposedChanges,
+        validationPlan,
+        approvalRequiredSteps,
+        risks,
+        openQuestions
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [implementationProposal satisfies ImplementationArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.76,
+      metadata: {
+        deterministicInputs: {
+          targetPaths: implementationRequest.targetPaths,
+          validationCommands: implementationRequest.validationCommands,
+          constraints: implementationRequest.constraints,
+          designInterfaces: designRecord.payload.interfacesImpacted
+        },
+        synthesizedProposal: {
+          affectedPaths: normalizedAffectedPaths,
+          approvalRequiredSteps,
+          openQuestions
+        }
+      }
+    });
+  }
+};
+
 const designAnalystAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -934,6 +1079,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["design-intake", designIntakeAgent],
     ["design-inventory", designInventoryAgent],
     ["implementation-intake", implementationIntakeAgent],
+    ["implementation-planner", implementationPlannerAgent],
     ["design-analyst", designAnalystAgent],
     ["code-review", codeReviewAgent],
     ["security-audit", securityAuditAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -6,6 +6,7 @@ import {
   designArtifactSchema,
   designRequestSchema,
   getJsonSchemas,
+  implementationArtifactSchema,
   implementationRequestSchema,
   lifecycleArtifactEnvelopeSchema,
   maintenanceArtifactSchema,
@@ -48,6 +49,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
     expect(jsonSchemas.planningArtifact).toBeDefined();
     expect(jsonSchemas.designArtifact).toBeDefined();
+    expect(jsonSchemas.implementationArtifact).toBeDefined();
     expect(jsonSchemas.reviewArtifact).toBeDefined();
     expect(jsonSchemas.releaseArtifact).toBeDefined();
     expect(jsonSchemas.maintenanceArtifact).toBeDefined();
@@ -133,6 +135,7 @@ describe("schema fixtures", () => {
   it("validates the initial lifecycle artifact family schemas", () => {
     expect(() => planningArtifactSchema.parse(schemaFixtures.planningArtifact)).not.toThrow();
     expect(() => designArtifactSchema.parse(schemaFixtures.designArtifact)).not.toThrow();
+    expect(() => implementationArtifactSchema.parse(schemaFixtures.implementationArtifact)).not.toThrow();
     expect(() => reviewArtifactSchema.parse(schemaFixtures.reviewArtifact)).not.toThrow();
     expect(() => releaseArtifactSchema.parse(schemaFixtures.releaseArtifact)).not.toThrow();
     expect(() => maintenanceArtifactSchema.parse(schemaFixtures.maintenanceArtifact)).not.toThrow();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -16,11 +16,12 @@ export const trustSourceSchema = z.enum(["official", "local", "third-party"]);
 export const lifecycleArtifactKindSchema = z.enum([
   "planning-brief",
   "design-record",
+  "implementation-proposal",
   "review-report",
   "release-report",
   "maintenance-report"
 ]);
-export const lifecycleDomainSchema = z.enum(["plan", "design", "review", "release", "maintain"]);
+export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "review", "release", "maintain"]);
 export const lifecycleArtifactSourceTypeSchema = z.enum(["workflow-run", "manual-input", "imported"]);
 export const lifecycleArtifactStatusSchema = z.enum(["draft", "complete", "superseded", "cancelled"]);
 export const catalogDomainSchema = z.enum([
@@ -480,6 +481,17 @@ export const reviewArtifactPayloadSchema = z.object({
   approvalRecommendations: z.array(z.string().min(1)).default([])
 });
 
+export const implementationArtifactPayloadSchema = z.object({
+  designRecordRef: z.string().min(1),
+  implementationGoal: z.string().min(1),
+  affectedPaths: z.array(z.string().min(1)).default([]),
+  proposedChanges: z.array(z.string().min(1)).default([]),
+  validationPlan: z.array(z.string().min(1)).default([]),
+  approvalRequiredSteps: z.array(z.string().min(1)).default([]),
+  risks: z.array(z.string().min(1)).default([]),
+  openQuestions: z.array(z.string().min(1)).default([])
+});
+
 export const releaseVerificationCheckSchema = z.object({
   name: z.string().min(1),
   status: z.enum(["passed", "failed", "skipped"]),
@@ -528,6 +540,12 @@ export const designArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   payload: designArtifactPayloadSchema
 });
 
+export const implementationArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("implementation-proposal"),
+  lifecycleDomain: z.literal("build"),
+  payload: implementationArtifactPayloadSchema
+});
+
 export const reviewArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   artifactKind: z.literal("review-report"),
   lifecycleDomain: z.literal("review"),
@@ -549,6 +567,7 @@ export const maintenanceArtifactSchema = lifecycleArtifactEnvelopeSchema.extend(
 export const lifecycleArtifactSchema = z.discriminatedUnion("artifactKind", [
   planningArtifactSchema,
   designArtifactSchema,
+  implementationArtifactSchema,
   reviewArtifactSchema,
   releaseArtifactSchema,
   maintenanceArtifactSchema
@@ -596,6 +615,7 @@ export const schemaRegistry = {
   planningArtifactPayload: planningArtifactPayloadSchema,
   designArtifactOption: designArtifactOptionSchema,
   designArtifactPayload: designArtifactPayloadSchema,
+  implementationArtifactPayload: implementationArtifactPayloadSchema,
   reviewArtifactPayload: reviewArtifactPayloadSchema,
   releaseVerificationCheck: releaseVerificationCheckSchema,
   releaseVersionTarget: releaseVersionTargetSchema,
@@ -603,6 +623,7 @@ export const schemaRegistry = {
   maintenanceArtifactPayload: maintenanceArtifactPayloadSchema,
   planningArtifact: planningArtifactSchema,
   designArtifact: designArtifactSchema,
+  implementationArtifact: implementationArtifactSchema,
   reviewArtifact: reviewArtifactSchema,
   releaseArtifact: releaseArtifactSchema,
   maintenanceArtifact: maintenanceArtifactSchema,
@@ -704,6 +725,29 @@ const designArtifactFixture = {
     tradeOffs: ["More schema surface to maintain"],
     risks: ["Design records could drift from implementation"],
     followUpWork: ["Implement runtime emission later"]
+  }
+} as const;
+
+const implementationArtifactFixture = {
+  ...lifecycleArtifactFixtureBase,
+  artifactKind: "implementation-proposal",
+  lifecycleDomain: "build",
+  summary: "Implementation proposal for the next bounded workflow slice.",
+  payload: {
+    designRecordRef: ".agentops/runs/run-456/bundle.json",
+    implementationGoal: "Prepare the next bounded implementation proposal",
+    affectedPaths: ["packages/cli", "packages/runtime"],
+    proposedChanges: [
+      "Add the implementation planner starter agent.",
+      "Emit an implementation-proposal artifact through the runtime."
+    ],
+    validationPlan: ["Review requested validation commands before execution."],
+    approvalRequiredSteps: [
+      "Any future patch application requires explicit approval.",
+      "Any future build or validation execution requires approval after allowlist review."
+    ],
+    risks: ["Affected repository surfaces may widen once deterministic inventory lands."],
+    openQuestions: ["Which validation commands should become allowlisted in the next slice?"]
   }
 } as const;
 
@@ -898,6 +942,7 @@ export const schemaFixtures = {
   lifecycleArtifactEnvelope: planningArtifactFixture,
   planningArtifact: planningArtifactFixture,
   designArtifact: designArtifactFixture,
+  implementationArtifact: implementationArtifactFixture,
   reviewArtifact: reviewArtifactFixture,
   releaseArtifact: releaseArtifactFixture,
   maintenanceArtifact: maintenanceArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -4,6 +4,7 @@ import type {
   DesignArtifact,
   DesignArtifactOption,
   DesignRequest,
+  ImplementationArtifact,
   ImplementationRequest,
   MaintenanceArtifact,
   PlanningArtifact,
@@ -20,6 +21,8 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<PlanningArtifact["lifecycleDomain"]>().toEqualTypeOf<"plan">();
     expectTypeOf<DesignArtifact["artifactKind"]>().toEqualTypeOf<"design-record">();
     expectTypeOf<DesignArtifact["lifecycleDomain"]>().toEqualTypeOf<"design">();
+    expectTypeOf<ImplementationArtifact["artifactKind"]>().toEqualTypeOf<"implementation-proposal">();
+    expectTypeOf<ImplementationArtifact["lifecycleDomain"]>().toEqualTypeOf<"build">();
     expectTypeOf<ReviewArtifact["artifactKind"]>().toEqualTypeOf<"review-report">();
     expectTypeOf<ReviewArtifact["lifecycleDomain"]>().toEqualTypeOf<"review">();
     expectTypeOf<ReleaseArtifact["artifactKind"]>().toEqualTypeOf<"release-report">();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -25,6 +25,8 @@ import {
   designRequestSchema,
   effectivePolicySnapshotSchema,
   findingSchema,
+  implementationArtifactPayloadSchema,
+  implementationArtifactSchema,
   implementationRequestSchema,
   maintenanceArtifactPayloadSchema,
   maintenanceArtifactSchema,
@@ -71,6 +73,8 @@ export type DesignArtifactOption = Infer<typeof designArtifactOptionSchema>;
 export type DesignArtifactPayload = Infer<typeof designArtifactPayloadSchema>;
 export type DesignArtifact = Infer<typeof designArtifactSchema>;
 export type DesignRequest = Infer<typeof designRequestSchema>;
+export type ImplementationArtifactPayload = Infer<typeof implementationArtifactPayloadSchema>;
+export type ImplementationArtifact = Infer<typeof implementationArtifactSchema>;
 export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
 export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
 export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-types
 
+  agents/implementation-planner:
+    dependencies:
+      '@h9-foundry/agentforge-schemas':
+        specifier: workspace:*
+        version: link:../../packages/schemas
+      '@h9-foundry/agentforge-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@h9-foundry/agentforge-shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
+
   agents/planning-analyst:
     dependencies:
       '@h9-foundry/agentforge-schemas':


### PR DESCRIPTION
## Summary
- add the implementation-proposal lifecycle artifact family and shared type exports
- add the `implementation-planner` builtin agent and matching starter-agent package
- update the `implementation-proposal` workflow asset to include the planner node
- extend CLI and agent tests to assert real artifact emission from the implementation flow

## Issue
Closes #146

## Scope Boundaries
- no deterministic build-surface inventory yet
- no validation-command allowlist normalization yet
- no README, quickstart, or support-matrix promotion yet
- no patch or build execution in the default path

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/index.test.ts agents/implementation-planner/src/index.test.ts`
- `pnpm lint`
- `pnpm test`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo evaluator flow through `planning-discovery` -> `architecture-design-review` -> `implementation-proposal`

## Usability Impact
This keeps public docs conservative while making the implementation workflow emit a real lifecycle artifact end to end. Public promotion remains gated on `#153` plus evaluator-doc updates.