### PR TITLE
Add deterministic implementation inventory discovery

### DIFF
--- a/.agentops/workflows/implementation-proposal.yaml
+++ b/.agentops/workflows/implementation-proposal.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: implementation-intake
     outputs_to: agentResults.intake
+  - id: inventory
+    kind: deterministic
+    agent: implementation-inventory
+    outputs_to: agentResults.inventory
   - id: planning
     kind: reasoning
     agent: implementation-planner

--- a/.changeset/implementation-inventory.md
+++ b/.changeset/implementation-inventory.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add deterministic implementation inventory metadata and allowlisted validation command normalization for the implementation-proposal workflow.

--- a/agents/implementation-planner/src/index.test.ts
+++ b/agents/implementation-planner/src/index.test.ts
@@ -107,6 +107,26 @@ describe("implementation planner agent", () => {
             }
           },
           requestFile: ".agentops/requests/implementation.yaml"
+        },
+        agentResults: {
+          inventory: {
+            metadata: {
+              requestedTargetPaths: ["packages/cli", "packages/runtime"],
+              resolvedAffectedPaths: ["packages/runtime/src/index.ts", "packages/schemas/src/index.ts"],
+              affectedPackages: ["packages/runtime", "packages/schemas"],
+              entrypoints: ["packages/runtime/src/index.ts"],
+              schemaSurfaces: ["packages/schemas/src/index.ts"],
+              policySurfaces: [],
+              discoveredValidationCommands: [
+                {
+                  command: "pnpm test",
+                  source: "request",
+                  classification: "approval_required",
+                  reason: "Requested command matches a discovered allowlisted validation script."
+                }
+              ]
+            }
+          }
         }
       } as never,
       policy: {} as never,
@@ -114,6 +134,16 @@ describe("implementation planner agent", () => {
     });
 
     expect(output.lifecycleArtifacts).toHaveLength(1);
-    expect(output.lifecycleArtifacts[0]?.artifactKind).toBe("implementation-proposal");
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("implementation-proposal");
+    expect(artifact && artifact.artifactKind === "implementation-proposal").toBe(true);
+    if (!artifact || artifact.artifactKind !== "implementation-proposal") {
+      throw new Error("Expected implementation-proposal artifact.");
+    }
+
+    expect(artifact.payload.affectedPaths).toContain("packages/runtime/src/index.ts");
+    expect(artifact.payload.validationPlan).toContain(
+      "Command `pnpm test` is available but approval-required before execution."
+    );
   });
 });

--- a/agents/implementation-planner/src/index.ts
+++ b/agents/implementation-planner/src/index.ts
@@ -1,5 +1,15 @@
-import { agentManifestSchema, agentOutputSchema, implementationArtifactSchema } from "@h9-foundry/agentforge-schemas";
-import type { DesignArtifact, ImplementationRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import {
+  agentManifestSchema,
+  agentOutputSchema,
+  implementationArtifactSchema,
+  implementationInventorySchema
+} from "@h9-foundry/agentforge-schemas";
+import type {
+  DesignArtifact,
+  ImplementationInventory,
+  ImplementationRequest,
+  WorkflowStateEnvelope
+} from "@h9-foundry/agentforge-shared-types";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -100,25 +110,37 @@ export const implementationPlannerAgent: RuntimeAgent = {
       throw new Error("implementation-proposal requires validated implementation inputs before proposal analysis.");
     }
 
-    const affectedPaths = [
-      ...new Set([
-        ...implementationRequest.targetPaths,
-        ...designRecord.payload.interfacesImpacted,
-        ...designRecord.payload.schemaChangesNeeded,
-        ...designRecord.payload.policyChangesNeeded
-      ])
-    ];
+    const inventoryMetadata = implementationInventorySchema.safeParse(stateSlice.agentResults?.inventory?.metadata);
+    const inventory = inventoryMetadata.success ? inventoryMetadata.data : undefined;
     const normalizedAffectedPaths =
-      affectedPaths.length > 0 ? affectedPaths : ["Repository paths still need deterministic build-surface confirmation."];
+      inventory && inventory.resolvedAffectedPaths.length > 0
+        ? inventory.resolvedAffectedPaths
+        : [
+            ...new Set([
+              ...implementationRequest.targetPaths,
+              ...designRecord.payload.interfacesImpacted,
+              ...designRecord.payload.schemaChangesNeeded,
+              ...designRecord.payload.policyChangesNeeded
+            ])
+          ];
+    const finalAffectedPaths =
+      normalizedAffectedPaths.length > 0
+        ? normalizedAffectedPaths
+        : ["Repository paths still need deterministic build-surface confirmation."];
     const proposedChanges = [
       `Prepare a bounded implementation plan for ${implementationRequest.implementationGoal}.`,
-      ...normalizedAffectedPaths.slice(0, 5).map((pathValue) => `Plan targeted edits for ${pathValue}.`)
+      ...finalAffectedPaths.slice(0, 5).map((pathValue) => `Plan targeted edits for ${pathValue}.`)
     ];
+    const selectedCommands = inventory
+      ? inventory.discoveredValidationCommands.filter(
+          (entry) =>
+            entry.classification === "approval_required" &&
+            (implementationRequest.validationCommands.length === 0 || entry.source === "request")
+        )
+      : [];
     const validationPlan =
-      implementationRequest.validationCommands.length > 0
-        ? implementationRequest.validationCommands.map(
-            (command) => `Review allowlist suitability for \`${command}\` before any future execution.`
-          )
+      selectedCommands.length > 0
+        ? selectedCommands.map((entry) => `Command \`${entry.command}\` is available but approval-required before execution.`)
         : ["Confirm allowlisted validation commands in the next deterministic implementation slice before execution."];
     const approvalRequiredSteps =
       implementationRequest.approvalMode === "apply-capable"
@@ -156,7 +178,7 @@ export const implementationPlannerAgent: RuntimeAgent = {
       payload: {
         designRecordRef: implementationRequest.designRecordRef,
         implementationGoal: implementationRequest.implementationGoal,
-        affectedPaths: normalizedAffectedPaths,
+        affectedPaths: finalAffectedPaths,
         proposedChanges,
         validationPlan,
         approvalRequiredSteps,
@@ -178,10 +200,11 @@ export const implementationPlannerAgent: RuntimeAgent = {
           targetPaths: implementationRequest.targetPaths,
           validationCommands: implementationRequest.validationCommands,
           constraints: implementationRequest.constraints,
-          designInterfaces: designRecord.payload.interfacesImpacted
+          designInterfaces: designRecord.payload.interfacesImpacted,
+          inventory: (inventory ?? null) satisfies ImplementationInventory | null
         },
         synthesizedProposal: {
-          affectedPaths: normalizedAffectedPaths,
+          affectedPaths: finalAffectedPaths,
           approvalRequiredSteps,
           openQuestions
         }

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -12,7 +12,22 @@ function createGitFixture(prefix: string): string {
   execFileSync("git", ["init"], { cwd: root });
   execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
   execFileSync("git", ["config", "user.name", "AgentForge Test"], { cwd: root });
-  writeFileSync(join(root, "package.json"), '{"name":"fixture"}');
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify(
+      {
+        name: "fixture",
+        scripts: {
+          test: "echo test",
+          lint: "echo lint",
+          typecheck: "echo typecheck"
+        }
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
   writeFileSync(join(root, "src.ts"), "export const value = 1;\n");
   execFileSync("git", ["add", "."], { cwd: root });
   execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "init"], { cwd: root });
@@ -431,6 +446,55 @@ describe("cli smoke flows", () => {
     await expect(runLocalWorkflow("implementation-proposal", root)).rejects.toThrow();
   });
 
+  it("rejects non-allowlisted validation commands for implementation-proposal before reasoning", async () => {
+    const root = createGitFixture("agentops-cli-implementation-invalid-command-");
+    initProject(root);
+    mkdirSync(join(root, ".agentops", "requests"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Plan the first workflow wedge",
+        "goals:",
+        "  - Produce a planning brief",
+        "constraints:",
+        "  - Keep the workflow local-first",
+        "issueRefs:",
+        "  - '#127'",
+        "pathHints:",
+        "  - packages/runtime",
+        "  - packages/schemas"
+      ].join("\n")
+    );
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "design.yaml"),
+      [
+        `planningBriefRef: .agentops/runs/${planningRun.runId}/bundle.json`,
+        "decisionTarget: Choose the first design workflow implementation shape",
+        "pathHints:",
+        "  - packages/runtime",
+        "  - packages/schemas",
+        "alternatives:",
+        "  - single-workflow-pass"
+      ].join("\n")
+    );
+    const designRun = await runLocalWorkflow("architecture-design-review", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        `designRecordRef: .agentops/runs/${designRun.runId}/bundle.json`,
+        "implementationGoal: Prepare the next bounded implementation proposal",
+        "approvalMode: proposal-only",
+        "validationCommands:",
+        "  - rm -rf ."
+      ].join("\n")
+    );
+
+    await expect(runLocalWorkflow("implementation-proposal", root)).rejects.toThrow(
+      "Implementation request contains non-allowlisted validation command: rm -rf ."
+    );
+  });
+
   it("runs implementation-proposal after a valid design-record handoff", async () => {
     const root = createGitFixture("agentops-cli-implementation-");
     initProject(root);
@@ -486,10 +550,23 @@ describe("cli smoke flows", () => {
 
     const bundle = JSON.parse(readFileSync(implementationRun.jsonPath, "utf8")) as {
       workflow: string;
-      lifecycleArtifacts: { artifactKind: string }[];
+      lifecycleArtifacts: {
+        artifactKind: string;
+        payload: {
+          affectedPaths: string[];
+          validationPlan: string[];
+        };
+      }[];
     };
     expect(bundle.workflow).toBe("implementation-proposal");
     expect(bundle.lifecycleArtifacts.some((artifact) => artifact.artifactKind === "implementation-proposal")).toBe(true);
+    const implementationArtifact = bundle.lifecycleArtifacts.find((artifact) => artifact.artifactKind === "implementation-proposal");
+    expect(implementationArtifact?.payload.affectedPaths).toEqual(
+      expect.arrayContaining([".agentops/agentops.yaml", ".agentops/policy.yaml"])
+    );
+    expect(implementationArtifact?.payload.validationPlan).toEqual(
+      expect.arrayContaining(["Command `pnpm test` is available but approval-required before execution."])
+    );
 
     const explanation = explainLastRun(root);
     expect(explanation.artifactKinds).toContain("implementation-proposal");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -205,6 +205,10 @@ nodes:
     kind: deterministic
     agent: implementation-intake
     outputs_to: agentResults.intake
+  - id: inventory
+    kind: deterministic
+    agent: implementation-inventory
+    outputs_to: agentResults.inventory
   - id: planning
     kind: reasoning
     agent: implementation-planner

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -1,0 +1,140 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { createBuiltinAgentRegistry } from "./builtin-agents.js";
+
+describe("builtin implementation inventory agent", () => {
+  it("collects deterministic inventory and allowlisted validation commands", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentforge-inventory-"));
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify(
+        {
+          name: "fixture-root",
+          scripts: {
+            test: "vitest run",
+            "release:publish": "changeset publish"
+          }
+        },
+        null,
+        2
+      )
+    );
+    mkdirSync(join(root, "packages", "app", "src"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "app", "package.json"),
+      JSON.stringify(
+        {
+          name: "@fixture/app",
+          scripts: {
+            build: "tsc -p tsconfig.json",
+            test: "vitest run"
+          }
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(root, "packages", "app", "src", "index.ts"), "export const value = 1;\n");
+    writeFileSync(join(root, "packages", "app", "agent.manifest.json"), "{\"name\":\"fixture\"}\n");
+
+    const agent = createBuiltinAgentRegistry().get("implementation-inventory");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        repo: {
+          root,
+          name: "fixture-root",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        workflowInputs: {
+          implementationRequest: {
+            designRecordRef: ".agentops/runs/run-2/bundle.json",
+            implementationGoal: "Prepare the next bounded implementation proposal",
+            targetPaths: ["packages/app", "packages/missing"],
+            validationCommands: ["pnpm test"],
+            constraints: [],
+            approvalMode: "proposal-only"
+          },
+          designRecord: {
+            schemaVersion: "1.0.0",
+            artifactKind: "design-record",
+            lifecycleDomain: "design",
+            workflow: {
+              name: "architecture-design-review",
+              displayName: "Architecture And Design Review"
+            },
+            source: {
+              sourceType: "workflow-run",
+              runId: "run-2",
+              inputRefs: [".agentops/requests/design.yaml"],
+              issueRefs: ["#132"]
+            },
+            status: "complete",
+            generatedAt: new Date().toISOString(),
+            repo: {
+              root,
+              name: "fixture-root",
+              branch: "main"
+            },
+            provenance: {
+              generatedBy: "agentforge-runtime",
+              schemaVersion: "1.0.0",
+              executionEnvironment: "local",
+              repoRoot: root
+            },
+            redaction: {
+              applied: true,
+              strategyVersion: "1.0.0",
+              categories: ["secrets"]
+            },
+            auditLink: {
+              entryIds: [],
+              findingIds: [],
+              proposedActionIds: []
+            },
+            summary: "Design record ready.",
+            payload: {
+              decisionSummary: "Choose the implementation workflow shape.",
+              context: "Planning brief summary: Planning brief ready.",
+              optionsConsidered: [{ option: "single-workflow-pass", summary: "Keep the workflow narrow." }],
+              chosenApproach: "single-workflow-pass",
+              tradeOffs: [],
+              risks: [],
+              followUpWork: [],
+              interfacesImpacted: ["packages/app/src/index.ts"],
+              schemaChangesNeeded: [],
+              policyChangesNeeded: [],
+              migrationNotes: [],
+              compatibilityNotes: []
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.metadata?.resolvedAffectedPaths).toContain("packages/app");
+    expect(output.metadata?.resolvedAffectedPaths).toContain("packages/app/src/index.ts");
+    expect(output.metadata?.resolvedAffectedPaths).not.toContain("packages/missing");
+    expect(output.metadata?.affectedPackages).toContain("packages/app");
+    expect(output.metadata?.entrypoints).toContain("packages/app/src/index.ts");
+    expect(output.metadata?.discoveredValidationCommands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ command: "pnpm test", source: "request", classification: "approval_required" }),
+        expect.objectContaining({ command: "pnpm release:publish", classification: "deny" }),
+        expect.objectContaining({ command: "pnpm --filter @fixture/app test", classification: "approval_required" })
+      ])
+    );
+  });
+});

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -6,6 +6,7 @@ import {
   agentOutputSchema,
   designArtifactSchema,
   implementationArtifactSchema,
+  implementationInventorySchema,
   planningArtifactSchema
 } from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
@@ -13,7 +14,9 @@ import type {
   DesignArtifact,
   DesignRequest,
   ImplementationArtifact,
+  ImplementationInventory,
   ImplementationRequest,
+  NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
   WorkflowStateEnvelope
@@ -83,6 +86,53 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function asStringArray(value: unknown): string[] {
   return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function parsePackageScripts(packageJsonPath: string): Record<string, string> {
+  if (!existsSync(packageJsonPath)) {
+    return {};
+  }
+
+  const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
+  if (!isRecord(parsed) || !isRecord(parsed.scripts)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(parsed.scripts).filter((entry): entry is [string, string] => typeof entry[1] === "string")
+  );
+}
+
+const allowedValidationScriptNames = new Set(["test", "lint", "typecheck", "build", "build:packages", "release:verify"]);
+
+function normalizeRequestedCommand(command: string): string {
+  return command.trim().replace(/\s+/g, " ");
+}
+
+function buildValidationCommand(
+  packageManager: string,
+  scriptName: string,
+  packageName?: string
+): string {
+  if (packageName) {
+    return `${packageManager} --filter ${packageName} ${scriptName}`;
+  }
+
+  return `${packageManager} ${scriptName}`;
+}
+
+function derivePackageScope(pathValue: string): string | undefined {
+  const segments = pathValue.split("/").filter(Boolean);
+  if (segments.length < 2) {
+    return undefined;
+  }
+
+  const [topLevel, scope] = segments;
+  if (topLevel === "packages" || topLevel === "agents" || topLevel === "adapters") {
+    return `${topLevel}/${scope}`;
+  }
+
+  return undefined;
 }
 
 function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: string): T | undefined {
@@ -560,6 +610,158 @@ const implementationIntakeAgent: RuntimeAgent = {
   }
 };
 
+const implementationInventoryAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "implementation-inventory",
+    displayName: "Implementation Inventory",
+    category: "implementation",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: ["**/*"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "changes"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "changes"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "build",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const implementationRequest = getWorkflowInput<ImplementationRequest>(stateSlice, "implementationRequest");
+    const designRecord = getWorkflowInput<DesignArtifact>(stateSlice, "designRecord");
+    if (!implementationRequest || !designRecord) {
+      throw new Error("implementation-proposal requires deterministic inventory inputs before proposal analysis.");
+    }
+
+    const repoRoot = stateSlice.repo?.root;
+    const packageManager = stateSlice.repo?.packageManager || "pnpm";
+    const candidatePaths = [
+      ...new Set([
+        ...implementationRequest.targetPaths,
+        ...designRecord.payload.interfacesImpacted,
+        ...designRecord.payload.schemaChangesNeeded,
+        ...designRecord.payload.policyChangesNeeded
+      ])
+    ];
+    const resolvedAffectedPaths = candidatePaths.filter((pathValue) => {
+      if (!pathValue) {
+        return false;
+      }
+
+      if (!repoRoot) {
+        return true;
+      }
+
+      return existsSync(join(repoRoot, pathValue));
+    });
+    const affectedPackages = [...new Set(resolvedAffectedPaths.map(derivePackageScope).filter((value): value is string => Boolean(value)))];
+    const entrypoints = [
+      ...new Set(
+        resolvedAffectedPaths.filter(
+          (pathValue) =>
+            pathValue.endsWith("src/index.ts") || pathValue.endsWith("package.json") || pathValue.endsWith("agent.manifest.json")
+        )
+      )
+    ];
+    const schemaSurfaces = [...new Set(resolvedAffectedPaths.filter((pathValue) => pathValue.includes("schema")))];
+    const policySurfaces = [
+      ...new Set(
+        resolvedAffectedPaths.filter(
+          (pathValue) => pathValue.includes("policy") || pathValue.includes(".agentops/policy.yaml")
+        )
+      )
+    ];
+    const discoveredValidationCommands: NormalizedValidationCommand[] = [];
+    const registerScripts = (packageJsonPath: string, source: "package-script" | "workspace-script", packageName?: string) => {
+      const scripts = parsePackageScripts(packageJsonPath);
+      for (const scriptName of Object.keys(scripts)) {
+        const command = buildValidationCommand(packageManager, scriptName, packageName);
+        discoveredValidationCommands.push({
+          command,
+          source,
+          classification: allowedValidationScriptNames.has(scriptName) ? "approval_required" : "deny",
+          reason: allowedValidationScriptNames.has(scriptName)
+            ? "Discovered from a bounded repository script; execution would still require approval."
+            : "Command is not in the bounded allowlist for implementation validation."
+        });
+      }
+    };
+
+    if (repoRoot) {
+      registerScripts(join(repoRoot, "package.json"), "package-script");
+      for (const packageScope of affectedPackages) {
+        const packageJsonPath = join(repoRoot, packageScope, "package.json");
+        if (!existsSync(packageJsonPath)) {
+          continue;
+        }
+
+        const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
+        const packageName = isRecord(parsed) && typeof parsed.name === "string" ? parsed.name : packageScope;
+        registerScripts(packageJsonPath, "workspace-script", packageName);
+      }
+    }
+
+    const normalizedRequestedCommands = implementationRequest.validationCommands.map(normalizeRequestedCommand);
+    const allowlistedCommands = new Set(
+      discoveredValidationCommands
+        .filter((entry) => entry.classification === "approval_required")
+        .map((entry) => entry.command)
+    );
+    for (const requestedCommand of normalizedRequestedCommands) {
+      if (!allowlistedCommands.has(requestedCommand)) {
+        throw new Error(`Implementation request contains non-allowlisted validation command: ${requestedCommand}`);
+      }
+
+      discoveredValidationCommands.push({
+        command: requestedCommand,
+        source: "request",
+        classification: "approval_required",
+        reason: "Requested command matches a discovered allowlisted validation script."
+      });
+    }
+
+    const inventory = implementationInventorySchema.parse({
+      requestedTargetPaths: implementationRequest.targetPaths,
+      resolvedAffectedPaths,
+      affectedPackages,
+      entrypoints,
+      schemaSurfaces,
+      policySurfaces,
+      discoveredValidationCommands
+    });
+
+    return agentOutputSchema.parse({
+      summary: `Collected deterministic implementation inventory across ${inventory.resolvedAffectedPaths.length} path(s) and ${inventory.discoveredValidationCommands.length} validation command(s).`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: inventory satisfies ImplementationInventory
+    });
+  }
+};
+
 const implementationPlannerAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -604,25 +806,37 @@ const implementationPlannerAgent: RuntimeAgent = {
       throw new Error("implementation-proposal requires validated implementation inputs before proposal analysis.");
     }
 
-    const affectedPaths = [
-      ...new Set([
-        ...implementationRequest.targetPaths,
-        ...designRecord.payload.interfacesImpacted,
-        ...designRecord.payload.schemaChangesNeeded,
-        ...designRecord.payload.policyChangesNeeded
-      ])
-    ];
+    const inventoryMetadata = implementationInventorySchema.safeParse(stateSlice.agentResults?.inventory?.metadata);
+    const inventory = inventoryMetadata.success ? inventoryMetadata.data : undefined;
     const normalizedAffectedPaths =
-      affectedPaths.length > 0 ? affectedPaths : ["Repository paths still need deterministic build-surface confirmation."];
+      inventory && inventory.resolvedAffectedPaths.length > 0
+        ? inventory.resolvedAffectedPaths
+        : [
+            ...new Set([
+              ...implementationRequest.targetPaths,
+              ...designRecord.payload.interfacesImpacted,
+              ...designRecord.payload.schemaChangesNeeded,
+              ...designRecord.payload.policyChangesNeeded
+            ])
+          ];
+    const finalAffectedPaths =
+      normalizedAffectedPaths.length > 0
+        ? normalizedAffectedPaths
+        : ["Repository paths still need deterministic build-surface confirmation."];
     const proposedChanges = [
       `Prepare a bounded implementation plan for ${implementationRequest.implementationGoal}.`,
-      ...normalizedAffectedPaths.slice(0, 5).map((pathValue) => `Plan targeted edits for ${pathValue}.`)
+      ...finalAffectedPaths.slice(0, 5).map((pathValue) => `Plan targeted edits for ${pathValue}.`)
     ];
+    const selectedCommands = inventory
+      ? inventory.discoveredValidationCommands.filter(
+          (entry) =>
+            entry.classification === "approval_required" &&
+            (implementationRequest.validationCommands.length === 0 || entry.source === "request")
+        )
+      : [];
     const validationPlan =
-      implementationRequest.validationCommands.length > 0
-        ? implementationRequest.validationCommands.map(
-            (command) => `Review allowlist suitability for \`${command}\` before any future execution.`
-          )
+      selectedCommands.length > 0
+        ? selectedCommands.map((entry) => `Command \`${entry.command}\` is available but approval-required before execution.`)
         : ["Confirm allowlisted validation commands in the next deterministic implementation slice before execution."];
     const approvalRequiredSteps =
       implementationRequest.approvalMode === "apply-capable"
@@ -664,7 +878,7 @@ const implementationPlannerAgent: RuntimeAgent = {
       payload: {
         designRecordRef: implementationRequest.designRecordRef,
         implementationGoal: implementationRequest.implementationGoal,
-        affectedPaths: normalizedAffectedPaths,
+        affectedPaths: finalAffectedPaths,
         proposedChanges,
         validationPlan,
         approvalRequiredSteps,
@@ -686,10 +900,11 @@ const implementationPlannerAgent: RuntimeAgent = {
           targetPaths: implementationRequest.targetPaths,
           validationCommands: implementationRequest.validationCommands,
           constraints: implementationRequest.constraints,
-          designInterfaces: designRecord.payload.interfacesImpacted
+          designInterfaces: designRecord.payload.interfacesImpacted,
+          inventory: inventory ?? null
         },
         synthesizedProposal: {
-          affectedPaths: normalizedAffectedPaths,
+          affectedPaths: finalAffectedPaths,
           approvalRequiredSteps,
           openQuestions
         }
@@ -1079,6 +1294,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["design-intake", designIntakeAgent],
     ["design-inventory", designInventoryAgent],
     ["implementation-intake", implementationIntakeAgent],
+    ["implementation-inventory", implementationInventoryAgent],
     ["implementation-planner", implementationPlannerAgent],
     ["design-analyst", designAnalystAgent],
     ["code-review", codeReviewAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -7,9 +7,11 @@ import {
   designRequestSchema,
   getJsonSchemas,
   implementationArtifactSchema,
+  implementationInventorySchema,
   implementationRequestSchema,
   lifecycleArtifactEnvelopeSchema,
   maintenanceArtifactSchema,
+  normalizedValidationCommandSchema,
   policyDocumentSchema,
   planningRequestSchema,
   planningArtifactSchema,
@@ -27,6 +29,8 @@ describe("schema fixtures", () => {
     expect(() => planningRequestSchema.parse(schemaFixtures.planningRequest)).not.toThrow();
     expect(() => designRequestSchema.parse(schemaFixtures.designRequest)).not.toThrow();
     expect(() => implementationRequestSchema.parse(schemaFixtures.implementationRequest)).not.toThrow();
+    expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
+    expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
   });
 
   it("rejects invalid manifests", () => {
@@ -46,6 +50,8 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.planningRequest).toBeDefined();
     expect(jsonSchemas.designRequest).toBeDefined();
     expect(jsonSchemas.implementationRequest).toBeDefined();
+    expect(jsonSchemas.normalizedValidationCommand).toBeDefined();
+    expect(jsonSchemas.implementationInventory).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
     expect(jsonSchemas.planningArtifact).toBeDefined();
     expect(jsonSchemas.designArtifact).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -314,6 +314,23 @@ export const implementationRequestSchema = z.object({
   approvalMode: z.enum(["proposal-only", "apply-capable"])
 });
 
+export const normalizedValidationCommandSchema = z.object({
+  command: z.string().min(1),
+  source: z.enum(["request", "package-script", "workspace-script"]),
+  classification: z.enum(["allow", "approval_required", "deny"]),
+  reason: z.string().min(1)
+});
+
+export const implementationInventorySchema = z.object({
+  requestedTargetPaths: z.array(z.string().min(1)).default([]),
+  resolvedAffectedPaths: z.array(z.string().min(1)).default([]),
+  affectedPackages: z.array(z.string().min(1)).default([]),
+  entrypoints: z.array(z.string().min(1)).default([]),
+  schemaSurfaces: z.array(z.string().min(1)).default([]),
+  policySurfaces: z.array(z.string().min(1)).default([]),
+  discoveredValidationCommands: z.array(normalizedValidationCommandSchema).default([])
+});
+
 export const repoMetadataSchema = z.object({
   root: z.string().min(1),
   name: z.string().min(1),
@@ -635,6 +652,8 @@ export const schemaRegistry = {
   planningRequest: planningRequestSchema,
   designRequest: designRequestSchema,
   implementationRequest: implementationRequestSchema,
+  normalizedValidationCommand: normalizedValidationCommandSchema,
+  implementationInventory: implementationInventorySchema,
   policyDocument: policyDocumentSchema,
   effectivePolicySnapshot: effectivePolicySnapshotSchema,
   workflowDefinition: workflowDefinitionSchema,
@@ -834,6 +853,31 @@ const implementationRequestFixture = {
   approvalMode: "proposal-only"
 } as const;
 
+const normalizedValidationCommandFixture = {
+  command: "pnpm test",
+  source: "request",
+  classification: "approval_required",
+  reason: "Requested command matches a discovered allowlisted validation script."
+} as const;
+
+const implementationInventoryFixture = {
+  requestedTargetPaths: ["packages/cli", "packages/runtime"],
+  resolvedAffectedPaths: ["packages/cli/src/index.ts", "packages/runtime/src/index.ts"],
+  affectedPackages: ["packages/cli", "packages/runtime"],
+  entrypoints: ["packages/cli/src/index.ts", "packages/runtime/src/index.ts"],
+  schemaSurfaces: ["packages/schemas/src/index.ts"],
+  policySurfaces: ["packages/policy-engine/src/index.ts"],
+  discoveredValidationCommands: [
+    normalizedValidationCommandFixture,
+    {
+      command: "pnpm release:publish",
+      source: "package-script",
+      classification: "deny",
+      reason: "Command is not in the bounded allowlist for implementation validation."
+    }
+  ]
+} as const;
+
 export const schemaFixtures = {
   finding: {
     id: "finding-1",
@@ -939,6 +983,8 @@ export const schemaFixtures = {
     questions: ["How should planning artifacts be referenced downstream?"]
   },
   implementationRequest: implementationRequestFixture,
+  normalizedValidationCommand: normalizedValidationCommandFixture,
+  implementationInventory: implementationInventoryFixture,
   lifecycleArtifactEnvelope: planningArtifactFixture,
   planningArtifact: planningArtifactFixture,
   designArtifact: designArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -5,8 +5,10 @@ import type {
   DesignArtifactOption,
   DesignRequest,
   ImplementationArtifact,
+  ImplementationInventory,
   ImplementationRequest,
   MaintenanceArtifact,
+  NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
   ReleaseArtifact,
@@ -42,5 +44,9 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<DesignRequest["planningBriefRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
+    expectTypeOf<ImplementationInventory["resolvedAffectedPaths"]>().toEqualTypeOf<string[]>();
+    expectTypeOf<NormalizedValidationCommand["classification"]>().toEqualTypeOf<
+      "allow" | "approval_required" | "deny"
+    >();
   });
 });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -27,9 +27,11 @@ import {
   findingSchema,
   implementationArtifactPayloadSchema,
   implementationArtifactSchema,
+  implementationInventorySchema,
   implementationRequestSchema,
   maintenanceArtifactPayloadSchema,
   maintenanceArtifactSchema,
+  normalizedValidationCommandSchema,
   policyDocumentSchema,
   planningRequestSchema,
   planningArtifactPayloadSchema,
@@ -75,9 +77,11 @@ export type DesignArtifact = Infer<typeof designArtifactSchema>;
 export type DesignRequest = Infer<typeof designRequestSchema>;
 export type ImplementationArtifactPayload = Infer<typeof implementationArtifactPayloadSchema>;
 export type ImplementationArtifact = Infer<typeof implementationArtifactSchema>;
+export type ImplementationInventory = Infer<typeof implementationInventorySchema>;
 export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
 export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
 export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;
+export type NormalizedValidationCommand = Infer<typeof normalizedValidationCommandSchema>;
 export type ReleaseVerificationCheck = Infer<typeof releaseVerificationCheckSchema>;
 export type ReleaseVersionTarget = Infer<typeof releaseVersionTargetSchema>;
 export type ReleaseArtifactPayload = Infer<typeof releaseArtifactPayloadSchema>;


### PR DESCRIPTION
## Summary
- add deterministic implementation inventory and normalized validation command contracts
- wire the implementation workflow and planner through a new `implementation-inventory` deterministic node
- add focused schema, shared-type, builtin-agent, CLI, and starter-agent coverage

## Issue
Closes #153

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts agents/implementation-planner/src/index.test.ts`
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo evaluator flow for `planning-discovery`, `architecture-design-review`, `implementation-proposal`, and `explain last-run --json`

## Notes
- The default path remains read-only and proposal-only.
- Public workflow docs/support status are intentionally unchanged in this slice; promotion to `Official` happens after the implementation family is fully complete.