### PR TITLE
Promote implementation-proposal as official

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 ## What You Can Do Today
 
 - try the current official workflow wedge with the published CLI, without cloning this monorepo
-- initialize a repository, scan it, run `pr-review`, `planning-discovery`, and `architecture-design-review`
-- inspect generated audit bundles plus lifecycle artifacts such as `planning-brief` and `design-record`
+- initialize a repository, scan it, run `pr-review`, `planning-discovery`, and `architecture-design-review`, then use the current repo build for `implementation-proposal` until the next package release ships it
+- inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, and `implementation-proposal`
 - evaluate the secure-by-default runtime model before broader SDLC workflow support lands
 
 ## Try It In 2 Minutes
@@ -63,10 +63,11 @@ For the new lifecycle wedges, `bundle.json` also persists one structured lifecyc
 
 - `planning-discovery` emits `planning-brief`
 - `architecture-design-review` emits `design-record`
+- `implementation-proposal` emits an `implementation-proposal` artifact with deterministic inventory, validation-command classification, and a proposal-only next-step plan
 
 ## Project Definition
 
-AgentForge provides the runtime, policy, context, audit, and packaging foundation for software engineering workflows that need to reason over a repository without abandoning deterministic controls. The current product wedge is a local, repo-first `pr-review` workflow that demonstrates the model end to end.
+AgentForge provides the runtime, policy, context, audit, and packaging foundation for software engineering workflows that need to reason over a repository without abandoning deterministic controls. The current official workflow surface is local and repo-first: `pr-review`, `planning-discovery`, `architecture-design-review`, and `implementation-proposal`.
 
 ## Problem Statement
 
@@ -94,11 +95,12 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 ### Available Now
 
 - secure-by-default runtime, policy, context, audit, and schema foundation
-- three official local workflow slices:
+- four official local workflow slices:
   - `.agentops/workflows/pr-review.yaml`
   - `.agentops/workflows/planning-discovery.yaml`
   - `.agentops/workflows/architecture-design-review.yaml`
-- official starter agents for context collection, planning analysis, design analysis, security audit, code review, and test generation
+  - `.agentops/workflows/implementation-proposal.yaml`
+- official starter agents for context collection, planning analysis, design analysis, implementation planning, security audit, code review, and test generation
 - internal starter adapters for filesystem, git, shell, and GitHub-aware mediation
 - public npm packages for the runtime core, CLI, contracts, and audit surfaces
 - GitHub Actions release automation, trusted publishing, and package verification tooling
@@ -125,7 +127,7 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 | --- | --- | --- |
 | Plan / intake / discovery | Available now | `planning-discovery` is an official local workflow that emits a `planning-brief` artifact. |
 | Architecture / design | Available now | `architecture-design-review` is an official local workflow that consumes a planning brief and emits a `design-record` artifact. |
-| Build / implementation | Planned | No implementation workflow yet beyond secure runtime scaffolding. |
+| Build / implementation | Available now | `implementation-proposal` is an official local workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
 | Review / test / QA | Available now | The `pr-review` wedge covers review, security audit, and proposed test-generation outputs. |
 | Security / compliance / DevSecOps | Partial | Policy, trust, redaction, and audit exist; broader security workflows are planned. |
 | Release / CI/CD | Partial | Release verification and package publishing exist; broader CI/CD workflow coverage is planned. |
@@ -153,7 +155,7 @@ Current runtime flow:
 5. Adapters are invoked only after policy mediation.
 6. Audit bundles and summaries are written under `.agentops/runs/<run-id>/`.
 
-For the official planning and design wedges, the same run directory now also persists lifecycle artifacts inside `bundle.json`, which makes the planning-to-design handoff inspectable without widening the side-effect posture.
+For the official planning, design, and implementation wedges, the same run directory now also persists lifecycle artifacts inside `bundle.json`, which makes the planning-to-design-to-implementation handoff inspectable without widening the side-effect posture.
 
 See [docs/architecture.md](docs/architecture.md), [docs/runtime-model.md](docs/runtime-model.md), [docs/policy-model.md](docs/policy-model.md), and [docs/security-model.md](docs/security-model.md).
 

--- a/docs/BUILD_IMPLEMENTATION_WORKFLOW.md
+++ b/docs/BUILD_IMPLEMENTATION_WORKFLOW.md
@@ -1,10 +1,8 @@
 # Build And Implementation Workflow MVP
 
-This document defines the design target for issue [#53](https://github.com/H9-Foundry/AgentForge/issues/53).
+This document defines the build/implementation workflow direction for issue [#53](https://github.com/H9-Foundry/AgentForge/issues/53).
 
-It describes the first build/implementation workflow wedge AgentForge should add after planning/discovery and architecture/design.
-
-It does **not** claim that this workflow is implemented or officially shipped today.
+It now describes both the first shipped build/implementation wedge and the next follow-on expansion targets after planning/discovery and architecture/design.
 
 ## Why This Exists
 
@@ -65,14 +63,14 @@ Available now:
 - lifecycle artifact envelopes and family schemas
 - lifecycle artifact sanitization and audit linkage
 - runtime/policy contracts for capability envelopes and side-effect classes
-- one official `pr-review` workflow and release/readiness tooling
+- official local workflows for `pr-review`, `planning-discovery`, `architecture-design-review`, and `implementation-proposal`
+- implementation request validation, deterministic inventory, and `implementation-proposal` artifact emission
 
 Not yet available:
 
-- an official build/implementation workflow asset
-- an implementation proposal artifact emitted by the runtime
-- approval-class wiring for proposal versus apply/build execution
-- deterministic build-target inventory as workflow output
+- apply-capable implementation execution on the default path
+- approval-gated build/test execution beyond proposal planning
+- downstream QA, security-review, and release-readiness workflow handoff from implementation artifacts
 
 ## Recommended MVP Wedge
 
@@ -281,4 +279,3 @@ This epic should be decomposed into at least:
 2. `implementation-planner` starter agent and `implementation-proposal` artifact emission
 3. deterministic affected-surface and allowlisted validation-command inventory
 4. approval-gated apply/build execution mediation that preserves read-only defaults
-

--- a/docs/SDLC_COVERAGE.md
+++ b/docs/SDLC_COVERAGE.md
@@ -12,7 +12,7 @@ This document describes lifecycle coverage across AgentForge using three honest 
 | --- | --- | --- | --- |
 | Plan / intake / discovery | Available now | `planning-discovery` is an official local workflow that validates `.agentops/requests/planning.yaml` and emits a `planning-brief` artifact. | Harden the planning workflow with richer request fixtures, policy overlays, and follow-on implementation workflow handoff. |
 | Architecture / design | Available now | `architecture-design-review` is an official local workflow that validates `.agentops/requests/design.yaml`, requires a `planningBriefRef`, and emits a `design-record` artifact. | Expand deterministic impact inventory and downstream implementation/design review handoff. |
-| Build / implementation | Planned | No official workflow yet. | Add implementation workflow support with explicit safe-side-effect policies. |
+| Build / implementation | Available now | `implementation-proposal` is an official local workflow that validates `.agentops/requests/implementation.yaml`, requires a `designRecordRef`, and emits an `implementation-proposal` artifact without widening the default side-effect posture. | Expand from proposal-only implementation planning into downstream QA, security review, and gated apply-capable follow-ons. |
 | Review / test / QA | Available now | `pr-review` workflow with context, security audit, code review, and proposed test generation. | Broaden into dedicated review/test/QA workflow variants. |
 | Security / compliance / DevSecOps | In progress | Policy, redaction, trust metadata, release trust, and audit exist. | Add richer security workflow coverage and security-specific adapters/evals. |
 | Release / CI/CD | In progress | Release verification, trusted publishing, package validation, and GitHub workflows exist. | Add broader release/CI workflow coverage beyond package publishing. |
@@ -32,17 +32,18 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - `architecture-design-review`
   - location: `.agentops/workflows/architecture-design-review.yaml`
   - purpose: validate a design request, consume a planning brief, and emit a `design-record` lifecycle artifact
+- `implementation-proposal`
+  - location: `.agentops/workflows/implementation-proposal.yaml`
+  - purpose: validate an implementation request, consume a design record, and emit an `implementation-proposal` lifecycle artifact
 
 ### In progress
 
-- build / implementation
 - security / DevSecOps
 - release / CI-CD
 - maintenance / dependency / docs hygiene
 
 ### Planned
 
-- build/implementation
 - dedicated test/QA
 - security/DevSecOps
 - release/CI-CD
@@ -59,10 +60,10 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - `test-generation`
 - `planning-analyst`
 - `design-analyst`
+- `implementation-planner`
 
 ### Planned expansion areas
 
-- implementation/build assistance
 - release coordination
 - incident and operational handoff
 - maintenance and upgrade hygiene

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -18,7 +18,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `pr-review` | Official | The current official workflow wedge. |
 | `planning-discovery` | Official | CLI-first planning and intake workflow that emits a `planning-brief` artifact. |
 | `architecture-design-review` | Official | CLI-first design workflow that consumes a planning brief and emits a `design-record` artifact. |
-| build / implementation | Planned | Roadmap item only. |
+| `implementation-proposal` | Official | CLI-first implementation workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
 | test / QA | Planned | The current `pr-review` flow touches QA, but there is no dedicated official QA workflow yet. |
 | security / DevSecOps | Planned | Security controls exist, but not a broader official security workflow family. |
 | release / CI-CD | Planned | Release automation exists, but not as a broader official SDLC workflow family. |
@@ -32,10 +32,10 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `context-collector` | Official | Current starter agent. |
 | `planning-analyst` | Official | Starter planning agent for `planning-discovery`. |
 | `design-analyst` | Official | Starter design agent for `architecture-design-review`. |
+| `implementation-planner` | Official | Starter implementation agent for `implementation-proposal`. |
 | `security-audit` | Official | Current starter agent. |
 | `code-review` | Official | Current starter agent. |
 | `test-generation` | Official | Current starter agent. |
-| build/implementation agents | Planned | Not implemented yet. |
 | release/operations/maintenance agents | Planned | Not implemented yet. |
 
 ## Adapter And Integration Support
@@ -81,6 +81,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | Self-hosted use | Maturity | Notes |
 | --- | --- | --- |
 | planning/design on the AgentForge repo | Official | Covered by `planning-discovery` and `architecture-design-review` with lifecycle artifact output. |
+| implementation planning on the AgentForge repo | Official | Covered by `implementation-proposal` with deterministic inventory and proposal-only output. |
 | PR review and QA on the AgentForge repo | Official | Covered by the current `pr-review` wedge and audit outputs. |
 | release/readiness verification on the AgentForge repo | Official | Covered by `release guide`, `release check`, and `release verify`. |
 | autonomous implementation on the AgentForge repo | Planned | Not an official supported mode yet. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-This quickstart walks through the current official AgentForge wedges: secure local repository review plus the first planning-to-design lifecycle handoff, all with auditable outputs.
+This quickstart walks through the current official AgentForge wedges: secure local repository review plus the planning-to-design-to-implementation lifecycle handoff, all with auditable outputs.
 
 ## Fastest Evaluator Path
 
@@ -90,6 +90,36 @@ npx @h9-foundry/agentforge-cli explain last-run --json
 
 The design bundle should include one `design-record` lifecycle artifact and remain read-only on the normal path.
 
+## Run The Official Implementation Workflow
+
+`implementation-proposal` is implemented on current `main`. Until the next npm release includes it, use the source-build path for this workflow even if you used the published CLI for the earlier evaluator steps.
+
+Create an implementation request that points at the prior design bundle:
+
+```bash
+cat > .agentops/requests/implementation.yaml <<'EOF'
+designRecordRef: .agentops/runs/<design-run-id>/bundle.json
+implementationGoal: Prepare the next bounded implementation proposal
+approvalMode: proposal-only
+targetPaths:
+  - .agentops/agentops.yaml
+  - .agentops/policy.yaml
+validationCommands:
+  - pnpm test
+constraints:
+  - Keep the default path read-only
+EOF
+```
+
+Run the official implementation wedge from the current repo build:
+
+```bash
+node packages/cli/dist/bin.js run implementation-proposal --json
+node packages/cli/dist/bin.js explain last-run --json
+```
+
+The implementation bundle should include one `implementation-proposal` lifecycle artifact with deterministic affected-path inventory plus approval-required validation guidance. The default path remains read-only and proposal-only.
+
 ## Contributor And Source-Build Path
 
 If you want to work on AgentForge itself, build the monorepo locally:
@@ -120,6 +150,7 @@ node packages/cli/dist/bin.js scan
 node packages/cli/dist/bin.js run pr-review
 node packages/cli/dist/bin.js run planning-discovery
 node packages/cli/dist/bin.js run architecture-design-review
+node packages/cli/dist/bin.js run implementation-proposal
 ```
 
 ## Inspect The Latest Run


### PR DESCRIPTION
## Summary
- update the public docs and support matrix to reflect `implementation-proposal` as an official workflow
- add the implementation step to the quickstart with the current repo-build caveat until the next npm release ships it
- update the implementation workflow design doc so it distinguishes the shipped wedge from later expansion work

## Context
Follow-up to #153 and tracker #83.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test; echo EXIT:$?`

## Notes
- This is a docs-only promotion slice.
- The docs explicitly note that `implementation-proposal` is implemented on `main` and will reach the published CLI on the next release.