### PR TITLE
Add qa-review intake workflow

### DIFF
--- a/.agentops/workflows/qa-review.yaml
+++ b/.agentops/workflows/qa-review.yaml
@@ -1,0 +1,17 @@
+version: 1
+name: qa-review
+description: Validate a bounded QA request and prepare it for later QA analysis stages.
+trigger: manual
+catalog:
+  domain: test
+  supportLevel: official
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: qa-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final

--- a/.changeset/qa-review-intake.md
+++ b/.changeset/qa-review-intake.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add the bounded QA request contract and the initial official `qa-review` workflow asset with deterministic intake validation.

--- a/docs/TEST_QA_WORKFLOWS.md
+++ b/docs/TEST_QA_WORKFLOWS.md
@@ -91,6 +91,15 @@ Recommended input model:
 - add `.agentops/requests/qa.yaml`
 - allow references to design records, implementation proposals, or local validation outputs
 
+Recommended first request fields:
+
+- `targetRef` as required reference to a prior artifact bundle or bounded local validation output
+- `evidenceSources` as optional additional local evidence paths
+- `executedChecks` as optional list of already-run validation commands
+- `focusAreas` as optional list of QA emphasis areas
+- `constraints` as optional bounded QA constraints
+- `releaseContext` as optional enum describing whether the request is exploratory, candidate-facing, or blocking
+
 ### Workflow Stages
 
 1. intake normalization
@@ -162,4 +171,3 @@ This epic should be decomposed into at least:
 2. `qa-analyst` starter agent and `qa-report` artifact emission
 3. deterministic test-output normalization and QA evidence ingestion
 4. policy/runtime wiring for QA-specific validation commands and evidence visibility
-

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -571,4 +571,95 @@ describe("cli smoke flows", () => {
     const explanation = explainLastRun(root);
     expect(explanation.artifactKinds).toContain("implementation-proposal");
   });
+
+  it("runs qa-review after a valid implementation-proposal handoff", async () => {
+    const root = createGitFixture("agentops-qa-");
+
+    initProject(root);
+
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Plan a bounded QA workflow handoff",
+        "goals:",
+        "  - Produce a planning brief for the QA workflow",
+        "constraints:",
+        "  - Keep the workflow local-first",
+        "  - Keep the workflow read-only by default"
+      ].join("\n")
+    );
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "design.yaml"),
+      [
+        `planningBriefRef: .agentops/runs/${planningRun.runId}/bundle.json`,
+        "decisionTarget: Choose the first QA workflow implementation shape",
+        "pathHints:",
+        "  - .agentops/agentops.yaml",
+        "  - .agentops/policy.yaml",
+        "alternatives:",
+        "  - single-pass-qa"
+      ].join("\n")
+    );
+    const designRun = await runLocalWorkflow("architecture-design-review", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        `designRecordRef: .agentops/runs/${designRun.runId}/bundle.json`,
+        "implementationGoal: Prepare the next bounded implementation proposal",
+        "approvalMode: proposal-only",
+        "targetPaths:",
+        "  - .agentops/agentops.yaml",
+        "  - .agentops/policy.yaml",
+        "validationCommands:",
+        "  - pnpm test",
+        "constraints:",
+        "  - Keep the default path read-only"
+      ].join("\n")
+    );
+    const implementationRun = await runLocalWorkflow("implementation-proposal", root);
+
+    writeFileSync(
+      join(root, ".agentops", "requests", "qa.yaml"),
+      [
+        `targetRef: .agentops/runs/${implementationRun.runId}/bundle.json`,
+        "evidenceSources:",
+        "  - .agentops/runs/" + implementationRun.runId + "/summary.md",
+        "executedChecks:",
+        "  - pnpm test",
+        "focusAreas:",
+        "  - coverage",
+        "constraints:",
+        "  - Keep QA evidence collection read-only",
+        "releaseContext: candidate"
+      ].join("\n")
+    );
+
+    const qaRun = await runLocalWorkflow("qa-review", root);
+    expect(qaRun.status).toBe("success");
+
+    const bundle = JSON.parse(readFileSync(qaRun.jsonPath, "utf8")) as {
+      workflow: string;
+      lifecycleArtifacts: unknown[];
+    };
+    expect(bundle.workflow).toBe("qa-review");
+    expect(bundle.lifecycleArtifacts).toHaveLength(0);
+  });
+
+  it("rejects underspecified qa-review requests before reasoning", async () => {
+    const root = createGitFixture("agentops-qa-invalid-");
+
+    initProject(root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "qa.yaml"),
+      [
+        "evidenceSources:",
+        "  - .agentops/policy.yaml",
+        "executedChecks:",
+        "  - pnpm test"
+      ].join("\n")
+    );
+
+    await expect(runLocalWorkflow("qa-review", root)).rejects.toThrow(/targetRef/i);
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import {
   implementationRequestSchema,
   planningArtifactSchema,
   planningRequestSchema,
+  qaRequestSchema,
   workflowDefinitionSchema
 } from "@h9-foundry/agentforge-schemas";
 import type {
@@ -26,6 +27,7 @@ import type {
   ImplementationRequest,
   PlanningArtifact,
   PlanningRequest,
+  QaRequest,
   WorkflowDefinition
 } from "@h9-foundry/agentforge-shared-types";
 import type { RuntimeAgent, ToolAdapter } from "@h9-foundry/agentforge-sdk";
@@ -218,6 +220,25 @@ nodes:
     outputs_to: reports.final
 `;
 
+const qaWorkflowTemplate = `version: 1
+name: qa-review
+description: Validate a bounded QA request and prepare it for later QA analysis stages.
+trigger: manual
+catalog:
+  domain: test
+  supportLevel: official
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: qa-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final
+`;
+
 function loadYaml(filePath: string): unknown {
   return yaml.load(readFileSync(filePath, "utf8"));
 }
@@ -365,6 +386,21 @@ function prepareWorkflowInputs(
     return {
       implementationRequest: implementationRequest satisfies ImplementationRequest,
       designRecord,
+      requestFile: requestPath
+    };
+  }
+
+  if (workflow.name === "qa-review") {
+    const requestPath = ".agentops/requests/qa.yaml";
+    ensureReadablePath(policyEngine, requestPath, "QA request");
+    const qaRequest = readYamlFile(join(root, requestPath), qaRequestSchema, "QA request");
+    ensureReadablePath(policyEngine, qaRequest.targetRef, "QA target reference");
+    for (const evidenceSource of qaRequest.evidenceSources) {
+      ensureReadablePath(policyEngine, evidenceSource, "QA evidence source");
+    }
+
+    return {
+      qaRequest: qaRequest satisfies QaRequest,
       requestFile: requestPath
     };
   }
@@ -532,6 +568,10 @@ function ensureInitFiles(root: string): string[] {
     {
       path: join(workflowsDir, "implementation-proposal.yaml"),
       contents: implementationWorkflowTemplate
+    },
+    {
+      path: join(workflowsDir, "qa-review.yaml"),
+      contents: qaWorkflowTemplate
     }
   ];
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -7,6 +7,7 @@ import {
   designArtifactSchema,
   implementationArtifactSchema,
   implementationInventorySchema,
+  qaRequestSchema,
   planningArtifactSchema
 } from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
@@ -19,6 +20,7 @@ import type {
   NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
+  QaRequest,
   WorkflowStateEnvelope
 } from "@h9-foundry/agentforge-shared-types";
 
@@ -605,6 +607,74 @@ const implementationIntakeAgent: RuntimeAgent = {
         targetPaths: implementationRequest.targetPaths,
         validationCommands: implementationRequest.validationCommands,
         designDecisionSummary: designRecord.payload.decisionSummary
+      }
+    });
+  }
+};
+
+const qaIntakeAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "qa-intake",
+    displayName: "QA Intake",
+    category: "qa",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "context"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "test",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const qaRequest = getWorkflowInput<QaRequest>(stateSlice, "qaRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!qaRequest) {
+      throw new Error("qa-review requires a validated QA request before runtime execution.");
+    }
+
+    const targetType =
+      qaRequest.targetRef.endsWith("bundle.json")
+        ? "artifact-bundle"
+        : qaRequest.targetRef.endsWith(".xml") || qaRequest.targetRef.endsWith(".json") || qaRequest.targetRef.endsWith(".log")
+          ? "validation-output"
+          : "local-reference";
+
+    return agentOutputSchema.parse({
+      summary: `Loaded QA request from ${requestFile ?? ".agentops/requests/qa.yaml"} targeting ${qaRequest.targetRef}.`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: {
+        ...qaRequestSchema.parse({
+          ...qaRequest,
+          evidenceSources: [...new Set([qaRequest.targetRef, ...qaRequest.evidenceSources])]
+        }),
+        targetType
       }
     });
   }
@@ -1294,6 +1364,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["design-intake", designIntakeAgent],
     ["design-inventory", designInventoryAgent],
     ["implementation-intake", implementationIntakeAgent],
+    ["qa-intake", qaIntakeAgent],
     ["implementation-inventory", implementationInventoryAgent],
     ["implementation-planner", implementationPlannerAgent],
     ["design-analyst", designAnalystAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   maintenanceArtifactSchema,
   normalizedValidationCommandSchema,
   policyDocumentSchema,
+  qaRequestSchema,
   planningRequestSchema,
   planningArtifactSchema,
   releaseArtifactSchema,
@@ -29,6 +30,7 @@ describe("schema fixtures", () => {
     expect(() => planningRequestSchema.parse(schemaFixtures.planningRequest)).not.toThrow();
     expect(() => designRequestSchema.parse(schemaFixtures.designRequest)).not.toThrow();
     expect(() => implementationRequestSchema.parse(schemaFixtures.implementationRequest)).not.toThrow();
+    expect(() => qaRequestSchema.parse(schemaFixtures.qaRequest)).not.toThrow();
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
   });
@@ -50,6 +52,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.planningRequest).toBeDefined();
     expect(jsonSchemas.designRequest).toBeDefined();
     expect(jsonSchemas.implementationRequest).toBeDefined();
+    expect(jsonSchemas.qaRequest).toBeDefined();
     expect(jsonSchemas.normalizedValidationCommand).toBeDefined();
     expect(jsonSchemas.implementationInventory).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -314,6 +314,15 @@ export const implementationRequestSchema = z.object({
   approvalMode: z.enum(["proposal-only", "apply-capable"])
 });
 
+export const qaRequestSchema = z.object({
+  targetRef: z.string().min(1),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  executedChecks: z.array(z.string().min(1)).default([]),
+  focusAreas: z.array(z.string().min(1)).default([]),
+  constraints: z.array(z.string().min(1)).default([]),
+  releaseContext: z.enum(["none", "candidate", "blocking"]).default("none")
+});
+
 export const normalizedValidationCommandSchema = z.object({
   command: z.string().min(1),
   source: z.enum(["request", "package-script", "workspace-script"]),
@@ -652,6 +661,7 @@ export const schemaRegistry = {
   planningRequest: planningRequestSchema,
   designRequest: designRequestSchema,
   implementationRequest: implementationRequestSchema,
+  qaRequest: qaRequestSchema,
   normalizedValidationCommand: normalizedValidationCommandSchema,
   implementationInventory: implementationInventorySchema,
   policyDocument: policyDocumentSchema,
@@ -853,6 +863,15 @@ const implementationRequestFixture = {
   approvalMode: "proposal-only"
 } as const;
 
+const qaRequestFixture = {
+  targetRef: ".agentops/runs/run-789/bundle.json",
+  evidenceSources: [".agentops/runs/run-789/summary.md"],
+  executedChecks: ["pnpm test -- --runInBand"],
+  focusAreas: ["coverage", "release-risk"],
+  constraints: ["Keep QA evidence collection read-only"],
+  releaseContext: "candidate"
+} as const;
+
 const normalizedValidationCommandFixture = {
   command: "pnpm test",
   source: "request",
@@ -983,6 +1002,7 @@ export const schemaFixtures = {
     questions: ["How should planning artifacts be referenced downstream?"]
   },
   implementationRequest: implementationRequestFixture,
+  qaRequest: qaRequestFixture,
   normalizedValidationCommand: normalizedValidationCommandFixture,
   implementationInventory: implementationInventoryFixture,
   lifecycleArtifactEnvelope: planningArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -11,6 +11,7 @@ import type {
   NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
+  QaRequest,
   ReleaseArtifact,
   ReleaseVerificationCheck,
   ReleaseVersionTarget,
@@ -44,6 +45,7 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<DesignRequest["planningBriefRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
+    expectTypeOf<QaRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationInventory["resolvedAffectedPaths"]>().toEqualTypeOf<string[]>();
     expectTypeOf<NormalizedValidationCommand["classification"]>().toEqualTypeOf<
       "allow" | "approval_required" | "deny"

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -33,6 +33,7 @@ import {
   maintenanceArtifactSchema,
   normalizedValidationCommandSchema,
   policyDocumentSchema,
+  qaRequestSchema,
   planningRequestSchema,
   planningArtifactPayloadSchema,
   planningArtifactSchema,
@@ -79,6 +80,7 @@ export type ImplementationArtifactPayload = Infer<typeof implementationArtifactP
 export type ImplementationArtifact = Infer<typeof implementationArtifactSchema>;
 export type ImplementationInventory = Infer<typeof implementationInventorySchema>;
 export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
+export type QaRequest = Infer<typeof qaRequestSchema>;
 export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
 export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;
 export type NormalizedValidationCommand = Infer<typeof normalizedValidationCommandSchema>;


### PR DESCRIPTION
## Summary
- add the bounded QA request schema and shared types
- add the official `.agentops/workflows/qa-review.yaml` asset plus CLI/init support
- add a deterministic `qa-intake` builtin agent and focused schema/CLI acceptance coverage

## Issue
Closes #140

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/index.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo evaluator flow covering planning, design, implementation, and `qa-review`

## Notes
- This slice is intentionally bounded to request validation plus the runnable `qa-review` asset.
- `qa-report` artifact emission and deterministic evidence normalization remain in #147 and #154.
- The default path remains read-only and bounded.