### PR TITLE
Version public AgentForge packages

### DIFF
--- a/.changeset/implementation-inventory.md
+++ b/.changeset/implementation-inventory.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add deterministic implementation inventory metadata and allowlisted validation command normalization for the implementation-proposal workflow.

--- a/.changeset/implementation-proposal-artifact.md
+++ b/.changeset/implementation-proposal-artifact.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add implementation-proposal artifact emission and the bounded implementation planner workflow node.

--- a/.changeset/implementation-proposal-request.md
+++ b/.changeset/implementation-proposal-request.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add the implementation request schema and local workflow intake path for `implementation-proposal`.

--- a/.changeset/qa-review-intake.md
+++ b/.changeset/qa-review-intake.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add the bounded QA request contract and the initial official `qa-review` workflow asset with deterministic intake validation.

--- a/agents/design-analyst/CHANGELOG.md
+++ b/agents/design-analyst/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @h9-foundry/agentforge-agent-design-analyst
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-schemas@0.6.0
+  - @h9-foundry/agentforge-shared-types@0.6.0
+  - @h9-foundry/agentforge-sdk@0.6.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/agents/design-analyst/package.json
+++ b/agents/design-analyst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-design-analyst",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/agents/implementation-planner/CHANGELOG.md
+++ b/agents/implementation-planner/CHANGELOG.md
@@ -1,3 +1,15 @@
 # @h9-foundry/agentforge-agent-implementation-planner
 
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-schemas@0.6.0
+  - @h9-foundry/agentforge-shared-types@0.6.0
+  - @h9-foundry/agentforge-sdk@0.6.0
+
 Private starter agent package for the bounded `implementation-proposal` workflow wedge.

--- a/agents/implementation-planner/package.json
+++ b/agents/implementation-planner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-implementation-planner",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/agents/planning-analyst/CHANGELOG.md
+++ b/agents/planning-analyst/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @h9-foundry/agentforge-agent-planning-analyst
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-schemas@0.6.0
+  - @h9-foundry/agentforge-shared-types@0.6.0
+  - @h9-foundry/agentforge-sdk@0.6.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/agents/planning-analyst/package.json
+++ b/agents/planning-analyst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-planning-analyst",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @h9-foundry/agentforge-audit
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-shared-types@0.6.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-audit",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,28 @@
 # @h9-foundry/agentforge-cli
 
+## 0.6.0
+
+### Minor Changes
+
+- 01934f6: Add deterministic implementation inventory metadata and allowlisted validation command normalization for the implementation-proposal workflow.
+- b32f49a: Add implementation-proposal artifact emission and the bounded implementation planner workflow node.
+- ed5d181: Add the implementation request schema and local workflow intake path for `implementation-proposal`.
+- 5ec8683: Add the bounded QA request contract and the initial official `qa-review` workflow asset with deterministic intake validation.
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-schemas@0.6.0
+  - @h9-foundry/agentforge-shared-types@0.6.0
+  - @h9-foundry/agentforge-context-engine@0.6.0
+  - @h9-foundry/agentforge-policy-engine@0.6.0
+  - @h9-foundry/agentforge-runtime@0.6.0
+  - @h9-foundry/agentforge-audit@0.6.0
+  - @h9-foundry/agentforge-sdk@0.6.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-cli",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/context-engine/CHANGELOG.md
+++ b/packages/context-engine/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @h9-foundry/agentforge-context-engine
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-schemas@0.6.0
+  - @h9-foundry/agentforge-shared-types@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Repository and execution context collection for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/policy-engine/CHANGELOG.md
+++ b/packages/policy-engine/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @h9-foundry/agentforge-policy-engine
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-schemas@0.6.0
+  - @h9-foundry/agentforge-shared-types@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @h9-foundry/agentforge-runtime
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-schemas@0.6.0
+  - @h9-foundry/agentforge-shared-types@0.6.0
+  - @h9-foundry/agentforge-policy-engine@0.6.0
+  - @h9-foundry/agentforge-audit@0.6.0
+  - @h9-foundry/agentforge-sdk@0.6.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @h9-foundry/agentforge-schemas
 
+## 0.6.0
+
+### Minor Changes
+
+- 01934f6: Add deterministic implementation inventory metadata and allowlisted validation command normalization for the implementation-proposal workflow.
+- b32f49a: Add implementation-proposal artifact emission and the bounded implementation planner workflow node.
+- ed5d181: Add the implementation request schema and local workflow intake path for `implementation-proposal`.
+- 5ec8683: Add the bounded QA request contract and the initial official `qa-review` workflow asset with deterministic intake validation.
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @h9-foundry/agentforge-sdk
 
+## 0.6.0
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-shared-types@0.6.0
+
 ## 0.5.0
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @h9-foundry/agentforge-shared-types
 
+## 0.6.0
+
+### Minor Changes
+
+- 01934f6: Add deterministic implementation inventory metadata and allowlisted validation command normalization for the implementation-proposal workflow.
+- b32f49a: Add implementation-proposal artifact emission and the bounded implementation planner workflow node.
+- ed5d181: Add the implementation request schema and local workflow intake path for `implementation-proposal`.
+- 5ec8683: Add the bounded QA request contract and the initial official `qa-review` workflow asset with deterministic intake validation.
+
+### Patch Changes
+
+- Updated dependencies [01934f6]
+- Updated dependencies [b32f49a]
+- Updated dependencies [ed5d181]
+- Updated dependencies [5ec8683]
+  - @h9-foundry/agentforge-schemas@0.6.0
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
   "license": "MIT",
   "author": "H9 Foundry",


### PR DESCRIPTION
## Summary
- replace stuck bot release PR #178 with a human-owned 0.6.0 version PR
- version the latest public AgentForge packages and generate changelog entries
- remove consumed changesets for implementation-proposal and qa-review intake work

## Validation
- generated via `pnpm release:version`
- release/publish will be verified after merge

## Notes
- This PR intentionally contains only package/changelog/version-file changes.
- Replaces #178, which remained blocked without required checks attached.