### PR TITLE
Handle incomplete latest runs in explain last-run

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -257,6 +257,38 @@ describe("cli smoke flows", () => {
     expect(explanation.blockedPlugins).toBe(0);
   });
 
+  it("skips incomplete latest run directories when explaining the last run", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentops-cli-explain-incomplete-"));
+    writeFileSync(join(root, "package.json"), '{"name":"fixture"}');
+    initProject(root);
+
+    const completeRunRoot = join(root, ".agentops", "runs", "2026-03-17-complete");
+    mkdirSync(completeRunRoot, { recursive: true });
+    writeFileSync(
+      join(completeRunRoot, "bundle.json"),
+      JSON.stringify(
+        {
+          runId: "2026-03-17-complete",
+          status: "success",
+          findings: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [],
+          entries: []
+        },
+        null,
+        2
+      )
+    );
+
+    const incompleteRunRoot = join(root, ".agentops", "runs", "2026-03-18-incomplete");
+    mkdirSync(incompleteRunRoot, { recursive: true });
+
+    const explanation = explainLastRun(root);
+    expect(explanation.runId).toBe("2026-03-17-complete");
+    expect(explanation.status).toBe("success");
+    expect(explanation.jsonPath).toBe(join(completeRunRoot, "bundle.json"));
+  });
+
   it("prints first-run guidance for the current wedge in plain-text mode", () => {
     const root = createGitFixture("agentops-cli-guidance-");
     ensureBuiltCli();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -779,10 +779,10 @@ export function explainLastRun(cwd = process.cwd()): LastRunExplanation {
   const config = loadAgentForgeConfig(root);
   const runsRoot = join(root, config.runtime.runsPath);
   const entries = existsSync(runsRoot) ? readdirSync(runsRoot).sort() : [];
-  const latest = entries.at(-1);
+  const latest = [...entries].reverse().find((entry) => existsSync(join(runsRoot, entry, "bundle.json")));
 
   if (!latest) {
-    throw new Error("No recorded runs found.");
+    throw new Error("No complete recorded runs found.");
   }
 
   const bundle = JSON.parse(readFileSync(join(runsRoot, latest, "bundle.json"), "utf8")) as Record<string, unknown>;


### PR DESCRIPTION
## Summary
- skip incomplete latest run directories when resolving `explain last-run`
- return the latest complete run bundle instead of crashing on missing `bundle.json`
- add regression coverage for an incomplete latest run directory

Closes #184.

## Validation
- `pnpm exec vitest run packages/cli/src/index.test.ts`
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`