### PR TITLE
Add qa-analyst and qa-report emission

### DIFF
--- a/.agentops/workflows/qa-review.yaml
+++ b/.agentops/workflows/qa-review.yaml
@@ -1,6 +1,6 @@
 version: 1
 name: qa-review
-description: Validate a bounded QA request and prepare it for later QA analysis stages.
+description: Validate a bounded QA request and synthesize a read-only QA report.
 trigger: manual
 catalog:
   domain: test
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: qa-intake
     outputs_to: agentResults.intake
+  - id: qa
+    kind: reasoning
+    agent: qa-analyst
+    outputs_to: agentResults.qa
   - id: report
     kind: report
     outputs_to: reports.final

--- a/.changeset/qa-report-emission.md
+++ b/.changeset/qa-report-emission.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add the bounded `qa-analyst` starter agent and emit `qa-report` lifecycle artifacts for `qa-review`.

--- a/agents/qa-analyst/agent.manifest.json
+++ b/agents/qa-analyst/agent.manifest.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "name": "qa-analyst",
+  "displayName": "QA Analyst",
+  "category": "qa",
+  "runtime": {
+    "minVersion": "0.1.0",
+    "kind": "reasoning"
+  },
+  "permissions": {
+    "model": true,
+    "network": false,
+    "tools": [],
+    "readPaths": ["**/*"],
+    "writePaths": []
+  },
+  "inputs": ["workflowInputs", "repo", "changes", "agentResults"],
+  "outputs": ["lifecycleArtifacts"],
+  "contextPolicy": {
+    "sections": ["workflowInputs", "repo", "changes", "agentResults"],
+    "minimalContext": true
+  },
+  "catalog": {
+    "domain": "test",
+    "supportLevel": "internal",
+    "maturity": "mvp",
+    "trustScope": "official-core-only"
+  },
+  "trust": {
+    "tier": "core",
+    "source": "official",
+    "reviewed": true
+  }
+}

--- a/agents/qa-analyst/package.json
+++ b/agents/qa-analyst/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@h9-foundry/agentforge-agent-qa-analyst",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "agent.manifest.json"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@h9-foundry/agentforge-schemas": "workspace:*",
+    "@h9-foundry/agentforge-sdk": "workspace:*",
+    "@h9-foundry/agentforge-shared-types": "workspace:*"
+  }
+}

--- a/agents/qa-analyst/src/index.test.ts
+++ b/agents/qa-analyst/src/index.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import { qaAnalystAgent } from "./index.js";
+
+describe("qa analyst agent", () => {
+  it("emits a qa-report artifact from validated inputs", async () => {
+    const output = await qaAnalystAgent.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-qa",
+        workflow: "qa-review",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: ["packages"],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          qaRequest: {
+            targetRef: ".agentops/runs/run-impl/bundle.json",
+            evidenceSources: [".agentops/runs/run-impl/summary.md"],
+            executedChecks: ["pnpm test"],
+            focusAreas: ["coverage"],
+            constraints: ["Keep QA evidence collection read-only"],
+            releaseContext: "candidate"
+          },
+          requestFile: ".agentops/requests/qa.yaml"
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              targetRef: ".agentops/runs/run-impl/bundle.json",
+              evidenceSources: [".agentops/runs/run-impl/bundle.json", ".agentops/runs/run-impl/summary.md"],
+              executedChecks: ["pnpm test"],
+              focusAreas: ["coverage"],
+              constraints: ["Keep QA evidence collection read-only"],
+              targetType: "artifact-bundle"
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.lifecycleArtifacts).toHaveLength(1);
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("qa-report");
+    expect(artifact && artifact.artifactKind === "qa-report").toBe(true);
+    if (!artifact || artifact.artifactKind !== "qa-report") {
+      throw new Error("Expected qa-report artifact.");
+    }
+
+    expect(artifact.payload.targetRef).toBe(".agentops/runs/run-impl/bundle.json");
+    expect(artifact.payload.executedChecks).toContain("pnpm test");
+    expect(artifact.payload.coverageGaps).toContain(
+      "Coverage evidence still needs deterministic normalization before it can be promoted to an official QA signal."
+    );
+  });
+});

--- a/agents/qa-analyst/src/index.ts
+++ b/agents/qa-analyst/src/index.ts
@@ -1,0 +1,201 @@
+import { agentManifestSchema, agentOutputSchema, qaArtifactSchema } from "@h9-foundry/agentforge-schemas";
+import type { QaArtifact, QaRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: string): T | undefined {
+  if (!isRecord(stateSlice.workflowInputs)) {
+    return undefined;
+  }
+
+  return stateSlice.workflowInputs[key] as T | undefined;
+}
+
+function buildArtifactEnvelopeBase(state: WorkflowStateEnvelope, summary: string, inputRefs: readonly string[]) {
+  return {
+    schemaVersion: state.version,
+    workflow: {
+      name: state.workflow,
+      displayName: "QA Review"
+    },
+    source: {
+      sourceType: "workflow-run" as const,
+      runId: state.runId,
+      inputRefs: [...inputRefs],
+      issueRefs: []
+    },
+    status: "complete" as const,
+    generatedAt: new Date().toISOString(),
+    repo: {
+      root: state.repo.root,
+      name: state.repo.name,
+      branch: state.repo.branch
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" as const : "local" as const,
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
+    },
+    auditLink: {
+      entryIds: [],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary
+  };
+}
+
+export const manifest = agentManifestSchema.parse({
+  version: 1,
+  name: "qa-analyst",
+  displayName: "QA Analyst",
+  category: "qa",
+  runtime: {
+    minVersion: "0.1.0",
+    kind: "reasoning"
+  },
+  permissions: {
+    model: true,
+    network: false,
+    tools: [],
+    readPaths: ["**/*"],
+    writePaths: []
+  },
+  inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+  outputs: ["lifecycleArtifacts"],
+  contextPolicy: {
+    sections: ["workflowInputs", "repo", "changes", "agentResults"],
+    minimalContext: true
+  },
+  catalog: {
+    domain: "test",
+    supportLevel: "internal",
+    maturity: "mvp",
+    trustScope: "official-core-only"
+  },
+  trust: {
+    tier: "core",
+    source: "official",
+    reviewed: true
+  }
+});
+
+export const qaAnalystAgent: RuntimeAgent = {
+  manifest,
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const qaRequest = getWorkflowInput<QaRequest>(stateSlice, "qaRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!qaRequest) {
+      throw new Error("qa-review requires validated QA inputs before QA analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const normalizedEvidenceSources = asStringArray(intakeMetadata.evidenceSources);
+    const normalizedExecutedChecks = asStringArray(intakeMetadata.executedChecks);
+    const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
+    const normalizedConstraints = asStringArray(intakeMetadata.constraints);
+    const targetType = typeof intakeMetadata.targetType === "string" ? intakeMetadata.targetType : "local-reference";
+    const evidenceSources =
+      normalizedEvidenceSources.length > 0
+        ? normalizedEvidenceSources
+        : [...new Set([qaRequest.targetRef, ...qaRequest.evidenceSources])];
+    const executedChecks = normalizedExecutedChecks.length > 0 ? normalizedExecutedChecks : qaRequest.executedChecks;
+    const focusAreas = normalizedFocusAreas.length > 0 ? normalizedFocusAreas : qaRequest.focusAreas;
+    const findings =
+      focusAreas.length > 0
+        ? focusAreas.map((focusArea, index) => ({
+            id: `qa-finding-${index + 1}`,
+            title: `Inspect ${focusArea} evidence before promotion`,
+            summary: `QA review flagged ${focusArea} as an area requiring bounded interpretation for ${qaRequest.targetRef}.`,
+            severity: qaRequest.releaseContext === "blocking" ? "high" : qaRequest.releaseContext === "candidate" ? "medium" : "low",
+            rationale: `The MVP QA workflow remains read-only and request-driven, so ${focusArea} still depends on referenced evidence rather than automatic execution.`,
+            confidence: 0.74,
+            location: qaRequest.targetRef,
+            tags: ["qa", focusArea]
+          }))
+        : [
+            {
+              id: "qa-finding-1",
+              title: "Review referenced QA evidence before promotion",
+              summary: `QA review requires bounded interpretation of the referenced evidence for ${qaRequest.targetRef}.`,
+              severity: qaRequest.releaseContext === "blocking" ? "high" : "medium",
+              rationale: "The current QA workflow synthesizes a report from validated references and does not execute arbitrary test commands.",
+              confidence: 0.71,
+              location: qaRequest.targetRef,
+              tags: ["qa", "evidence"]
+            }
+          ];
+    const coverageGaps = [
+      ...(evidenceSources.length === 0 ? ["No QA evidence sources were provided beyond the target reference."] : []),
+      ...(focusAreas.includes("coverage") ? ["Coverage evidence still needs deterministic normalization before it can be promoted to an official QA signal."] : []),
+      ...(executedChecks.length === 0 ? ["No executed validation checks were recorded in the request."] : [])
+    ];
+    const recommendedNextChecks = [
+      ...executedChecks.map((command) => `Review the recorded output for \`${command}\` before promotion.`),
+      ...focusAreas.map((focusArea) => `Confirm whether ${focusArea} needs additional deterministic QA evidence.`),
+      ...(normalizedConstraints.length > 0 ? [`Keep QA follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
+    ];
+    const summary = `QA report prepared for ${qaRequest.targetRef}.`;
+    const qaReport = qaArtifactSchema.parse({
+      ...buildArtifactEnvelopeBase(state, summary, [requestFile ?? ".agentops/requests/qa.yaml", qaRequest.targetRef, ...qaRequest.evidenceSources]),
+      artifactKind: "qa-report",
+      lifecycleDomain: "test",
+      payload: {
+        targetRef: qaRequest.targetRef,
+        evidenceSources,
+        executedChecks,
+        findings,
+        coverageGaps,
+        recommendedNextChecks:
+          recommendedNextChecks.length > 0
+            ? recommendedNextChecks
+            : ["Capture additional bounded QA evidence before promotion."],
+        releaseImpact:
+          qaRequest.releaseContext === "blocking"
+            ? "release-blocking QA findings require resolution before promotion."
+            : qaRequest.releaseContext === "candidate"
+              ? "candidate release still requires explicit QA review before promotion."
+              : "no release context was supplied; QA output remains advisory."
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [qaReport satisfies QaArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.74,
+      metadata: {
+        deterministicInputs: {
+          targetRef: qaRequest.targetRef,
+          targetType,
+          evidenceSources,
+          executedChecks,
+          focusAreas,
+          constraints: normalizedConstraints
+        },
+        synthesizedAssessment: {
+          releaseContext: qaRequest.releaseContext,
+          recommendedNextChecks: qaReport.payload.recommendedNextChecks,
+          coverageGaps: qaReport.payload.coverageGaps
+        }
+      }
+    });
+  }
+};

--- a/agents/qa-analyst/tsconfig.json
+++ b/agents/qa-analyst/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../../packages/schemas" }, { "path": "../../packages/sdk" }, { "path": "../../packages/shared-types" }]
+}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -672,10 +672,15 @@ describe("cli smoke flows", () => {
 
     const bundle = JSON.parse(readFileSync(qaRun.jsonPath, "utf8")) as {
       workflow: string;
-      lifecycleArtifacts: unknown[];
+      lifecycleArtifacts: Array<{ artifactKind: string; payload?: Record<string, unknown> }>;
     };
     expect(bundle.workflow).toBe("qa-review");
-    expect(bundle.lifecycleArtifacts).toHaveLength(0);
+    expect(bundle.lifecycleArtifacts).toHaveLength(1);
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("qa-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.targetRef).toBe(`.agentops/runs/${implementationRun.runId}/bundle.json`);
+
+    const explanation = explainLastRun(root);
+    expect(explanation.artifactKinds).toContain("qa-report");
   });
 
   it("rejects underspecified qa-review requests before reasoning", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -222,7 +222,7 @@ nodes:
 
 const qaWorkflowTemplate = `version: 1
 name: qa-review
-description: Validate a bounded QA request and prepare it for later QA analysis stages.
+description: Validate a bounded QA request and synthesize a read-only QA report.
 trigger: manual
 catalog:
   domain: test
@@ -234,6 +234,10 @@ nodes:
     kind: deterministic
     agent: qa-intake
     outputs_to: agentResults.intake
+  - id: qa
+    kind: reasoning
+    agent: qa-analyst
+    outputs_to: agentResults.qa
   - id: report
     kind: report
     outputs_to: reports.final

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -7,6 +7,7 @@ import {
   designArtifactSchema,
   implementationArtifactSchema,
   implementationInventorySchema,
+  qaArtifactSchema,
   qaRequestSchema,
   planningArtifactSchema
 } from "@h9-foundry/agentforge-schemas";
@@ -20,6 +21,7 @@ import type {
   NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
+  QaArtifact,
   QaRequest,
   WorkflowStateEnvelope
 } from "@h9-foundry/agentforge-shared-types";
@@ -675,6 +677,155 @@ const qaIntakeAgent: RuntimeAgent = {
           evidenceSources: [...new Set([qaRequest.targetRef, ...qaRequest.evidenceSources])]
         }),
         targetType
+      }
+    });
+  }
+};
+
+const qaAnalystAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "qa-analyst",
+    displayName: "QA Analyst",
+    category: "qa",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "reasoning"
+    },
+    permissions: {
+      model: true,
+      network: false,
+      tools: [],
+      readPaths: ["**/*"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+    outputs: ["lifecycleArtifacts"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "changes", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "test",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const qaRequest = getWorkflowInput<QaRequest>(stateSlice, "qaRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!qaRequest) {
+      throw new Error("qa-review requires validated QA inputs before QA analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const normalizedEvidenceSources = asStringArray(intakeMetadata.evidenceSources);
+    const normalizedExecutedChecks = asStringArray(intakeMetadata.executedChecks);
+    const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
+    const normalizedConstraints = asStringArray(intakeMetadata.constraints);
+    const targetType = typeof intakeMetadata.targetType === "string" ? intakeMetadata.targetType : "local-reference";
+    const evidenceSources =
+      normalizedEvidenceSources.length > 0
+        ? normalizedEvidenceSources
+        : [...new Set([qaRequest.targetRef, ...qaRequest.evidenceSources])];
+    const executedChecks = normalizedExecutedChecks.length > 0 ? normalizedExecutedChecks : qaRequest.executedChecks;
+    const focusAreas = normalizedFocusAreas.length > 0 ? normalizedFocusAreas : qaRequest.focusAreas;
+    const findings =
+      focusAreas.length > 0
+        ? focusAreas.map((focusArea, index) => ({
+            id: `qa-finding-${index + 1}`,
+            title: `Inspect ${focusArea} evidence before promotion`,
+            summary: `QA review flagged ${focusArea} as an area requiring bounded interpretation for ${qaRequest.targetRef}.`,
+            severity: qaRequest.releaseContext === "blocking" ? "high" : qaRequest.releaseContext === "candidate" ? "medium" : "low",
+            rationale: `The MVP QA workflow remains read-only and request-driven, so ${focusArea} still depends on referenced evidence rather than automatic execution.`,
+            confidence: 0.74,
+            location: qaRequest.targetRef,
+            tags: ["qa", focusArea]
+          }))
+        : [
+            {
+              id: "qa-finding-1",
+              title: "Review referenced QA evidence before promotion",
+              summary: `QA review requires bounded interpretation of the referenced evidence for ${qaRequest.targetRef}.`,
+              severity: qaRequest.releaseContext === "blocking" ? "high" : "medium",
+              rationale: "The current QA workflow synthesizes a report from validated references and does not execute arbitrary test commands.",
+              confidence: 0.71,
+              location: qaRequest.targetRef,
+              tags: ["qa", "evidence"]
+            }
+          ];
+    const coverageGaps = [
+      ...(evidenceSources.length === 0 ? ["No QA evidence sources were provided beyond the target reference."] : []),
+      ...(focusAreas.includes("coverage") ? ["Coverage evidence still needs deterministic normalization before it can be promoted to an official QA signal."] : []),
+      ...(executedChecks.length === 0 ? ["No executed validation checks were recorded in the request."] : [])
+    ];
+    const recommendedNextChecks = [
+      ...executedChecks.map((command) => `Review the recorded output for \`${command}\` before promotion.`),
+      ...focusAreas.map((focusArea) => `Confirm whether ${focusArea} needs additional deterministic QA evidence.`),
+      ...(normalizedConstraints.length > 0 ? [`Keep QA follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
+    ];
+    const summary = `QA report prepared for ${qaRequest.targetRef}.`;
+    const qaReport = qaArtifactSchema.parse({
+      ...buildArtifactEnvelopeBase(
+        state,
+        summary,
+        [requestFile ?? ".agentops/requests/qa.yaml", qaRequest.targetRef, ...qaRequest.evidenceSources],
+        []
+      ),
+      artifactKind: "qa-report",
+      lifecycleDomain: "test",
+      workflow: {
+        name: state.workflow,
+        displayName: "QA Review"
+      },
+      payload: {
+        targetRef: qaRequest.targetRef,
+        evidenceSources,
+        executedChecks,
+        findings,
+        coverageGaps,
+        recommendedNextChecks:
+          recommendedNextChecks.length > 0
+            ? recommendedNextChecks
+            : ["Capture additional bounded QA evidence before promotion."],
+        releaseImpact:
+          qaRequest.releaseContext === "blocking"
+            ? "release-blocking QA findings require resolution before promotion."
+            : qaRequest.releaseContext === "candidate"
+              ? "candidate release still requires explicit QA review before promotion."
+              : "no release context was supplied; QA output remains advisory."
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [qaReport satisfies QaArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.74,
+      metadata: {
+        deterministicInputs: {
+          targetRef: qaRequest.targetRef,
+          targetType,
+          evidenceSources,
+          executedChecks,
+          focusAreas,
+          constraints: normalizedConstraints
+        },
+        synthesizedAssessment: {
+          releaseContext: qaRequest.releaseContext,
+          recommendedNextChecks: qaReport.payload.recommendedNextChecks,
+          coverageGaps: qaReport.payload.coverageGaps
+        }
       }
     });
   }
@@ -1365,6 +1516,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["design-inventory", designInventoryAgent],
     ["implementation-intake", implementationIntakeAgent],
     ["qa-intake", qaIntakeAgent],
+    ["qa-analyst", qaAnalystAgent],
     ["implementation-inventory", implementationInventoryAgent],
     ["implementation-planner", implementationPlannerAgent],
     ["design-analyst", designAnalystAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   maintenanceArtifactSchema,
   normalizedValidationCommandSchema,
   policyDocumentSchema,
+  qaArtifactSchema,
   qaRequestSchema,
   planningRequestSchema,
   planningArtifactSchema,
@@ -59,6 +60,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.planningArtifact).toBeDefined();
     expect(jsonSchemas.designArtifact).toBeDefined();
     expect(jsonSchemas.implementationArtifact).toBeDefined();
+    expect(jsonSchemas.qaArtifact).toBeDefined();
     expect(jsonSchemas.reviewArtifact).toBeDefined();
     expect(jsonSchemas.releaseArtifact).toBeDefined();
     expect(jsonSchemas.maintenanceArtifact).toBeDefined();
@@ -145,6 +147,7 @@ describe("schema fixtures", () => {
     expect(() => planningArtifactSchema.parse(schemaFixtures.planningArtifact)).not.toThrow();
     expect(() => designArtifactSchema.parse(schemaFixtures.designArtifact)).not.toThrow();
     expect(() => implementationArtifactSchema.parse(schemaFixtures.implementationArtifact)).not.toThrow();
+    expect(() => qaArtifactSchema.parse(schemaFixtures.qaArtifact)).not.toThrow();
     expect(() => reviewArtifactSchema.parse(schemaFixtures.reviewArtifact)).not.toThrow();
     expect(() => releaseArtifactSchema.parse(schemaFixtures.releaseArtifact)).not.toThrow();
     expect(() => maintenanceArtifactSchema.parse(schemaFixtures.maintenanceArtifact)).not.toThrow();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -17,11 +17,12 @@ export const lifecycleArtifactKindSchema = z.enum([
   "planning-brief",
   "design-record",
   "implementation-proposal",
+  "qa-report",
   "review-report",
   "release-report",
   "maintenance-report"
 ]);
-export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "review", "release", "maintain"]);
+export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "test", "review", "release", "maintain"]);
 export const lifecycleArtifactSourceTypeSchema = z.enum(["workflow-run", "manual-input", "imported"]);
 export const lifecycleArtifactStatusSchema = z.enum(["draft", "complete", "superseded", "cancelled"]);
 export const catalogDomainSchema = z.enum([
@@ -507,6 +508,16 @@ export const reviewArtifactPayloadSchema = z.object({
   approvalRecommendations: z.array(z.string().min(1)).default([])
 });
 
+export const qaArtifactPayloadSchema = z.object({
+  targetRef: z.string().min(1),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  executedChecks: z.array(z.string().min(1)).default([]),
+  findings: z.array(findingSchema).default([]),
+  coverageGaps: z.array(z.string().min(1)).default([]),
+  recommendedNextChecks: z.array(z.string().min(1)).default([]),
+  releaseImpact: z.string().min(1)
+});
+
 export const implementationArtifactPayloadSchema = z.object({
   designRecordRef: z.string().min(1),
   implementationGoal: z.string().min(1),
@@ -572,6 +583,12 @@ export const implementationArtifactSchema = lifecycleArtifactEnvelopeSchema.exte
   payload: implementationArtifactPayloadSchema
 });
 
+export const qaArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("qa-report"),
+  lifecycleDomain: z.literal("test"),
+  payload: qaArtifactPayloadSchema
+});
+
 export const reviewArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   artifactKind: z.literal("review-report"),
   lifecycleDomain: z.literal("review"),
@@ -594,6 +611,7 @@ export const lifecycleArtifactSchema = z.discriminatedUnion("artifactKind", [
   planningArtifactSchema,
   designArtifactSchema,
   implementationArtifactSchema,
+  qaArtifactSchema,
   reviewArtifactSchema,
   releaseArtifactSchema,
   maintenanceArtifactSchema
@@ -642,6 +660,7 @@ export const schemaRegistry = {
   designArtifactOption: designArtifactOptionSchema,
   designArtifactPayload: designArtifactPayloadSchema,
   implementationArtifactPayload: implementationArtifactPayloadSchema,
+  qaArtifactPayload: qaArtifactPayloadSchema,
   reviewArtifactPayload: reviewArtifactPayloadSchema,
   releaseVerificationCheck: releaseVerificationCheckSchema,
   releaseVersionTarget: releaseVersionTargetSchema,
@@ -650,6 +669,7 @@ export const schemaRegistry = {
   planningArtifact: planningArtifactSchema,
   designArtifact: designArtifactSchema,
   implementationArtifact: implementationArtifactSchema,
+  qaArtifact: qaArtifactSchema,
   reviewArtifact: reviewArtifactSchema,
   releaseArtifact: releaseArtifactSchema,
   maintenanceArtifact: maintenanceArtifactSchema,
@@ -777,6 +797,33 @@ const implementationArtifactFixture = {
     ],
     risks: ["Affected repository surfaces may widen once deterministic inventory lands."],
     openQuestions: ["Which validation commands should become allowlisted in the next slice?"]
+  }
+} as const;
+
+const qaArtifactFixture = {
+  ...lifecycleArtifactFixtureBase,
+  artifactKind: "qa-report",
+  lifecycleDomain: "test",
+  summary: "QA report for the bounded implementation proposal handoff.",
+  payload: {
+    targetRef: ".agentops/runs/run-789/bundle.json",
+    evidenceSources: [".agentops/runs/run-789/summary.md"],
+    executedChecks: ["pnpm test"],
+    findings: [
+      {
+        id: "qa-finding-1",
+        title: "Coverage evidence still needs review",
+        summary: "The bounded QA handoff references validation output, but coverage evidence still needs interpretation.",
+        severity: "medium",
+        rationale: "The MVP QA workflow is read-only and request-driven, so it cannot infer full coverage status without normalized evidence.",
+        confidence: 0.82,
+        location: ".agentops/requests/qa.yaml",
+        tags: ["qa", "coverage"]
+      }
+    ],
+    coverageGaps: ["Coverage evidence was referenced but not normalized into a deterministic summary."],
+    recommendedNextChecks: ["Review the referenced validation output before promotion.", "Confirm release-risk expectations with the owning maintainer."],
+    releaseImpact: "candidate release requires QA follow-up before promotion."
   }
 } as const;
 
@@ -1009,6 +1056,7 @@ export const schemaFixtures = {
   planningArtifact: planningArtifactFixture,
   designArtifact: designArtifactFixture,
   implementationArtifact: implementationArtifactFixture,
+  qaArtifact: qaArtifactFixture,
   reviewArtifact: reviewArtifactFixture,
   releaseArtifact: releaseArtifactFixture,
   maintenanceArtifact: maintenanceArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -11,6 +11,7 @@ import type {
   NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
+  QaArtifact,
   QaRequest,
   ReleaseArtifact,
   ReleaseVerificationCheck,
@@ -26,6 +27,8 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<DesignArtifact["lifecycleDomain"]>().toEqualTypeOf<"design">();
     expectTypeOf<ImplementationArtifact["artifactKind"]>().toEqualTypeOf<"implementation-proposal">();
     expectTypeOf<ImplementationArtifact["lifecycleDomain"]>().toEqualTypeOf<"build">();
+    expectTypeOf<QaArtifact["artifactKind"]>().toEqualTypeOf<"qa-report">();
+    expectTypeOf<QaArtifact["lifecycleDomain"]>().toEqualTypeOf<"test">();
     expectTypeOf<ReviewArtifact["artifactKind"]>().toEqualTypeOf<"review-report">();
     expectTypeOf<ReviewArtifact["lifecycleDomain"]>().toEqualTypeOf<"review">();
     expectTypeOf<ReleaseArtifact["artifactKind"]>().toEqualTypeOf<"release-report">();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -33,6 +33,8 @@ import {
   maintenanceArtifactSchema,
   normalizedValidationCommandSchema,
   policyDocumentSchema,
+  qaArtifactPayloadSchema,
+  qaArtifactSchema,
   qaRequestSchema,
   planningRequestSchema,
   planningArtifactPayloadSchema,
@@ -80,6 +82,8 @@ export type ImplementationArtifactPayload = Infer<typeof implementationArtifactP
 export type ImplementationArtifact = Infer<typeof implementationArtifactSchema>;
 export type ImplementationInventory = Infer<typeof implementationInventorySchema>;
 export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
+export type QaArtifactPayload = Infer<typeof qaArtifactPayloadSchema>;
+export type QaArtifact = Infer<typeof qaArtifactSchema>;
 export type QaRequest = Infer<typeof qaRequestSchema>;
 export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
 export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-types
 
+  agents/qa-analyst:
+    dependencies:
+      '@h9-foundry/agentforge-schemas':
+        specifier: workspace:*
+        version: link:../../packages/schemas
+      '@h9-foundry/agentforge-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@h9-foundry/agentforge-shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
+
   agents/security-audit:
     dependencies:
       '@h9-foundry/agentforge-schemas':


### PR DESCRIPTION
## Summary
- add the bounded `qa-analyst` starter agent package and built-in QA reasoning path
- add `qa-report` lifecycle artifact contracts and emit them from `qa-review`
- keep QA evidence normalization and public docs/support-matrix promotion out of scope for `#154`

Closes #147.

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/index.test.ts agents/qa-analyst/src/index.test.ts`
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo planning -> design -> implementation -> qa handoff with `qa-review --json`

## Notes
- This slice adds the QA artifact/agent path only.
- Deterministic QA evidence normalization remains in #154.
- Public README / quickstart / support-matrix promotion for `qa-review` stays deferred until `#154` lands and the full workflow is ready to mark official.