### PR TITLE
Implement deterministic QA evidence normalization

### DIFF
--- a/.agentops/workflows/qa-review.yaml
+++ b/.agentops/workflows/qa-review.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: qa-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: qa-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: qa
     kind: reasoning
     agent: qa-analyst

--- a/.changeset/qa-evidence-normalization.md
+++ b/.changeset/qa-evidence-normalization.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Normalize bounded QA evidence deterministically and wire `qa-review` to consume allowlisted validation evidence before QA reasoning.

--- a/agents/qa-analyst/src/index.ts
+++ b/agents/qa-analyst/src/index.ts
@@ -104,11 +104,19 @@ export const qaAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const normalizedEvidenceSources = asStringArray(intakeMetadata.evidenceSources);
-    const normalizedExecutedChecks = asStringArray(intakeMetadata.executedChecks);
+    const evidenceMetadata = isRecord(stateSlice.agentResults?.evidence?.metadata) ? stateSlice.agentResults.evidence.metadata : {};
+    const normalizedEvidenceSources = asStringArray(evidenceMetadata.normalizedEvidenceSources);
+    const normalizedExecutedChecks = asStringArray(evidenceMetadata.normalizedExecutedChecks);
     const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
     const normalizedConstraints = asStringArray(intakeMetadata.constraints);
-    const targetType = typeof intakeMetadata.targetType === "string" ? intakeMetadata.targetType : "local-reference";
+    const missingEvidenceSources = asStringArray(evidenceMetadata.missingEvidenceSources);
+    const unrecognizedExecutedChecks = asStringArray(evidenceMetadata.unrecognizedExecutedChecks);
+    const targetType =
+      typeof evidenceMetadata.targetType === "string"
+        ? evidenceMetadata.targetType
+        : typeof intakeMetadata.targetType === "string"
+          ? intakeMetadata.targetType
+          : "local-reference";
     const evidenceSources =
       normalizedEvidenceSources.length > 0
         ? normalizedEvidenceSources
@@ -141,8 +149,10 @@ export const qaAnalystAgent: RuntimeAgent = {
           ];
     const coverageGaps = [
       ...(evidenceSources.length === 0 ? ["No QA evidence sources were provided beyond the target reference."] : []),
+      ...missingEvidenceSources.map((pathValue) => `Referenced QA evidence is missing: ${pathValue}`),
       ...(focusAreas.includes("coverage") ? ["Coverage evidence still needs deterministic normalization before it can be promoted to an official QA signal."] : []),
-      ...(executedChecks.length === 0 ? ["No executed validation checks were recorded in the request."] : [])
+      ...(executedChecks.length === 0 ? ["No executed validation checks were recorded in the request."] : []),
+      ...unrecognizedExecutedChecks.map((command) => `Executed check is outside the bounded allowlist and still needs manual interpretation: ${command}`)
     ];
     const recommendedNextChecks = [
       ...executedChecks.map((command) => `Review the recorded output for \`${command}\` before promotion.`),

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -699,4 +699,24 @@ describe("cli smoke flows", () => {
 
     await expect(runLocalWorkflow("qa-review", root)).rejects.toThrow(/targetRef/i);
   });
+
+  it("rejects qa-review when the referenced QA target does not exist", async () => {
+    const root = createGitFixture("agentops-qa-missing-target-");
+
+    initProject(root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "qa.yaml"),
+      [
+        "targetRef: .agentops/runs/missing/bundle.json",
+        "evidenceSources:",
+        "  - .agentops/runs/missing/summary.md",
+        "executedChecks:",
+        "  - pnpm test",
+        "focusAreas:",
+        "  - coverage"
+      ].join("\n")
+    );
+
+    await expect(runLocalWorkflow("qa-review", root)).rejects.toThrow(/QA target reference not found/i);
+  });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -234,6 +234,10 @@ nodes:
     kind: deterministic
     agent: qa-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: qa-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: qa
     kind: reasoning
     agent: qa-analyst

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -138,3 +138,103 @@ describe("builtin implementation inventory agent", () => {
     );
   });
 });
+
+describe("builtin qa evidence normalizer", () => {
+  it("normalizes bounded QA evidence and allowlisted validation commands", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentforge-qa-evidence-"));
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify(
+        {
+          name: "fixture-root",
+          scripts: {
+            test: "vitest run",
+            lint: "eslint ."
+          }
+        },
+        null,
+        2
+      )
+    );
+    mkdirSync(join(root, ".agentops", "runs", "run-impl"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "runs", "run-impl", "bundle.json"),
+      JSON.stringify(
+        {
+          lifecycleArtifacts: [
+            {
+              artifactKind: "implementation-proposal",
+              payload: {
+                affectedPaths: ["packages/app/src/index.ts"]
+              }
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(root, ".agentops", "runs", "run-impl", "summary.md"), "# summary\n");
+    mkdirSync(join(root, "packages", "app"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "app", "package.json"),
+      JSON.stringify(
+        {
+          name: "@fixture/app",
+          scripts: {
+            test: "vitest run"
+          }
+        },
+        null,
+        2
+      )
+    );
+
+    const agent = createBuiltinAgentRegistry().get("qa-evidence-normalizer");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        repo: {
+          root,
+          name: "fixture-root",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        workflowInputs: {
+          qaRequest: {
+            targetRef: ".agentops/runs/run-impl/bundle.json",
+            evidenceSources: [".agentops/runs/run-impl/summary.md"],
+            executedChecks: ["pnpm test"],
+            focusAreas: ["coverage"],
+            constraints: ["Keep QA evidence collection read-only"],
+            releaseContext: "candidate"
+          }
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              targetType: "artifact-bundle"
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.metadata?.normalizedEvidenceSources).toEqual([
+      ".agentops/runs/run-impl/bundle.json",
+      ".agentops/runs/run-impl/summary.md"
+    ]);
+    expect(output.metadata?.referencedArtifactKinds).toContain("implementation-proposal");
+    expect(output.metadata?.allowedValidationCommands).toEqual(
+      expect.arrayContaining([expect.objectContaining({ command: "pnpm test", classification: "approval_required" })])
+    );
+    expect(output.metadata?.unrecognizedExecutedChecks).toEqual([]);
+  });
+});

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -8,6 +8,7 @@ import {
   implementationArtifactSchema,
   implementationInventorySchema,
   qaArtifactSchema,
+  qaEvidenceNormalizationSchema,
   qaRequestSchema,
   planningArtifactSchema
 } from "@h9-foundry/agentforge-schemas";
@@ -22,6 +23,7 @@ import type {
   PlanningArtifact,
   PlanningRequest,
   QaArtifact,
+  QaEvidenceNormalization,
   QaRequest,
   WorkflowStateEnvelope
 } from "@h9-foundry/agentforge-shared-types";
@@ -123,6 +125,61 @@ function buildValidationCommand(
   }
 
   return `${packageManager} ${scriptName}`;
+}
+
+function collectValidationCommands(
+  repoRoot: string | undefined,
+  packageManager: string,
+  packageScopes: readonly string[]
+): NormalizedValidationCommand[] {
+  const discoveredValidationCommands: NormalizedValidationCommand[] = [];
+  const registerScripts = (packageJsonPath: string, source: "package-script" | "workspace-script", packageName?: string) => {
+    const scripts = parsePackageScripts(packageJsonPath);
+    for (const scriptName of Object.keys(scripts)) {
+      const command = buildValidationCommand(packageManager, scriptName, packageName);
+      discoveredValidationCommands.push({
+        command,
+        source,
+        classification: allowedValidationScriptNames.has(scriptName) ? "approval_required" : "deny",
+        reason: allowedValidationScriptNames.has(scriptName)
+          ? "Discovered from a bounded repository script; execution would still require approval."
+          : "Command is not in the bounded allowlist for workflow validation."
+      });
+    }
+  };
+
+  if (!repoRoot) {
+    return discoveredValidationCommands;
+  }
+
+  registerScripts(join(repoRoot, "package.json"), "package-script");
+  for (const packageScope of packageScopes) {
+    const packageJsonPath = join(repoRoot, packageScope, "package.json");
+    if (!existsSync(packageJsonPath)) {
+      continue;
+    }
+
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
+    const packageName = isRecord(parsed) && typeof parsed.name === "string" ? parsed.name : packageScope;
+    registerScripts(packageJsonPath, "workspace-script", packageName);
+  }
+
+  return discoveredValidationCommands;
+}
+
+function loadBundleArtifactKinds(bundlePath: string): string[] {
+  if (!existsSync(bundlePath)) {
+    return [];
+  }
+
+  const parsed = JSON.parse(readFileSync(bundlePath, "utf8")) as unknown;
+  if (!isRecord(parsed) || !Array.isArray(parsed.lifecycleArtifacts)) {
+    return [];
+  }
+
+  return parsed.lifecycleArtifacts
+    .map((artifact) => (isRecord(artifact) && typeof artifact.artifactKind === "string" ? artifact.artifactKind : undefined))
+    .filter((artifactKind): artifactKind is string => Boolean(artifactKind));
 }
 
 function derivePackageScope(pathValue: string): string | undefined {
@@ -682,6 +739,115 @@ const qaIntakeAgent: RuntimeAgent = {
   }
 };
 
+const qaEvidenceNormalizationAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "qa-evidence-normalizer",
+    displayName: "QA Evidence Normalizer",
+    category: "qa",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**", "**/package.json", "**/*.json", "**/*.xml", "**/*.log", "**/*.md"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "agentResults"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "test",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const qaRequest = getWorkflowInput<QaRequest>(stateSlice, "qaRequest");
+    if (!qaRequest) {
+      throw new Error("qa-review requires validated QA request inputs before evidence normalization.");
+    }
+
+    const repoRoot = stateSlice.repo?.root;
+    const packageManager = stateSlice.repo?.packageManager || "pnpm";
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const targetType = typeof intakeMetadata.targetType === "string" ? intakeMetadata.targetType : "local-reference";
+    const targetPath = repoRoot ? join(repoRoot, qaRequest.targetRef) : qaRequest.targetRef;
+    if (repoRoot && !existsSync(targetPath)) {
+      throw new Error(`QA target reference not found: ${qaRequest.targetRef}`);
+    }
+
+    const referencedArtifactKinds = targetType === "artifact-bundle" ? loadBundleArtifactKinds(targetPath) : [];
+    const normalizedEvidenceSources = [...new Set([qaRequest.targetRef, ...qaRequest.evidenceSources])];
+    const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
+    if (missingEvidenceSources.length > 0) {
+      throw new Error(`QA evidence source not found: ${missingEvidenceSources[0]}`);
+    }
+
+    const bundleAffectedPaths =
+      targetType === "artifact-bundle" && referencedArtifactKinds.includes("implementation-proposal") && existsSync(targetPath)
+        ? asStringArray(
+            (() => {
+              const parsed = JSON.parse(readFileSync(targetPath, "utf8")) as unknown;
+              if (!isRecord(parsed) || !Array.isArray(parsed.lifecycleArtifacts)) {
+                return [];
+              }
+
+              const implementationArtifact = parsed.lifecycleArtifacts.find(
+                (artifact) =>
+                  isRecord(artifact) &&
+                  artifact.artifactKind === "implementation-proposal" &&
+                  isRecord(artifact.payload) &&
+                  Array.isArray(artifact.payload.affectedPaths)
+              ) as { payload?: { affectedPaths?: unknown[] } } | undefined;
+              return implementationArtifact?.payload?.affectedPaths ?? [];
+            })()
+          )
+        : [];
+    const affectedPackages = [...new Set(bundleAffectedPaths.map((pathValue) => derivePackageScope(pathValue)).filter((value): value is string => Boolean(value)))];
+    const allowedValidationCommands = collectValidationCommands(repoRoot, packageManager, affectedPackages).filter(
+      (entry) => entry.classification === "approval_required"
+    );
+    const allowlistedCommands = new Set(allowedValidationCommands.map((entry) => entry.command));
+    const normalizedExecutedChecks = qaRequest.executedChecks.map(normalizeRequestedCommand);
+    const unrecognizedExecutedChecks = normalizedExecutedChecks.filter((command) => !allowlistedCommands.has(command));
+    const normalization = qaEvidenceNormalizationSchema.parse({
+      targetRef: qaRequest.targetRef,
+      targetType,
+      referencedArtifactKinds,
+      normalizedEvidenceSources,
+      missingEvidenceSources: [],
+      normalizedExecutedChecks,
+      unrecognizedExecutedChecks,
+      affectedPackages,
+      allowedValidationCommands
+    });
+
+    return agentOutputSchema.parse({
+      summary: `Normalized QA evidence across ${normalization.normalizedEvidenceSources.length} source(s) and ${normalization.allowedValidationCommands.length} allowlisted validation command(s).`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: normalization satisfies QaEvidenceNormalization
+    });
+  }
+};
+
 const qaAnalystAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -726,11 +892,19 @@ const qaAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const normalizedEvidenceSources = asStringArray(intakeMetadata.evidenceSources);
-    const normalizedExecutedChecks = asStringArray(intakeMetadata.executedChecks);
+    const evidenceMetadata = isRecord(stateSlice.agentResults?.evidence?.metadata) ? stateSlice.agentResults.evidence.metadata : {};
+    const normalizedEvidenceSources = asStringArray(evidenceMetadata.normalizedEvidenceSources);
+    const normalizedExecutedChecks = asStringArray(evidenceMetadata.normalizedExecutedChecks);
     const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
     const normalizedConstraints = asStringArray(intakeMetadata.constraints);
-    const targetType = typeof intakeMetadata.targetType === "string" ? intakeMetadata.targetType : "local-reference";
+    const missingEvidenceSources = asStringArray(evidenceMetadata.missingEvidenceSources);
+    const unrecognizedExecutedChecks = asStringArray(evidenceMetadata.unrecognizedExecutedChecks);
+    const targetType =
+      typeof evidenceMetadata.targetType === "string"
+        ? evidenceMetadata.targetType
+        : typeof intakeMetadata.targetType === "string"
+          ? intakeMetadata.targetType
+          : "local-reference";
     const evidenceSources =
       normalizedEvidenceSources.length > 0
         ? normalizedEvidenceSources
@@ -763,8 +937,10 @@ const qaAnalystAgent: RuntimeAgent = {
           ];
     const coverageGaps = [
       ...(evidenceSources.length === 0 ? ["No QA evidence sources were provided beyond the target reference."] : []),
+      ...missingEvidenceSources.map((pathValue) => `Referenced QA evidence is missing: ${pathValue}`),
       ...(focusAreas.includes("coverage") ? ["Coverage evidence still needs deterministic normalization before it can be promoted to an official QA signal."] : []),
-      ...(executedChecks.length === 0 ? ["No executed validation checks were recorded in the request."] : [])
+      ...(executedChecks.length === 0 ? ["No executed validation checks were recorded in the request."] : []),
+      ...unrecognizedExecutedChecks.map((command) => `Executed check is outside the bounded allowlist and still needs manual interpretation: ${command}`)
     ];
     const recommendedNextChecks = [
       ...executedChecks.map((command) => `Review the recorded output for \`${command}\` before promotion.`),
@@ -912,35 +1088,7 @@ const implementationInventoryAgent: RuntimeAgent = {
         )
       )
     ];
-    const discoveredValidationCommands: NormalizedValidationCommand[] = [];
-    const registerScripts = (packageJsonPath: string, source: "package-script" | "workspace-script", packageName?: string) => {
-      const scripts = parsePackageScripts(packageJsonPath);
-      for (const scriptName of Object.keys(scripts)) {
-        const command = buildValidationCommand(packageManager, scriptName, packageName);
-        discoveredValidationCommands.push({
-          command,
-          source,
-          classification: allowedValidationScriptNames.has(scriptName) ? "approval_required" : "deny",
-          reason: allowedValidationScriptNames.has(scriptName)
-            ? "Discovered from a bounded repository script; execution would still require approval."
-            : "Command is not in the bounded allowlist for implementation validation."
-        });
-      }
-    };
-
-    if (repoRoot) {
-      registerScripts(join(repoRoot, "package.json"), "package-script");
-      for (const packageScope of affectedPackages) {
-        const packageJsonPath = join(repoRoot, packageScope, "package.json");
-        if (!existsSync(packageJsonPath)) {
-          continue;
-        }
-
-        const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
-        const packageName = isRecord(parsed) && typeof parsed.name === "string" ? parsed.name : packageScope;
-        registerScripts(packageJsonPath, "workspace-script", packageName);
-      }
-    }
+    const discoveredValidationCommands = collectValidationCommands(repoRoot, packageManager, affectedPackages);
 
     const normalizedRequestedCommands = implementationRequest.validationCommands.map(normalizeRequestedCommand);
     const allowlistedCommands = new Set(
@@ -1516,6 +1664,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["design-inventory", designInventoryAgent],
     ["implementation-intake", implementationIntakeAgent],
     ["qa-intake", qaIntakeAgent],
+    ["qa-evidence-normalizer", qaEvidenceNormalizationAgent],
     ["qa-analyst", qaAnalystAgent],
     ["implementation-inventory", implementationInventoryAgent],
     ["implementation-planner", implementationPlannerAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   normalizedValidationCommandSchema,
   policyDocumentSchema,
   qaArtifactSchema,
+  qaEvidenceNormalizationSchema,
   qaRequestSchema,
   planningRequestSchema,
   planningArtifactSchema,
@@ -34,6 +35,7 @@ describe("schema fixtures", () => {
     expect(() => qaRequestSchema.parse(schemaFixtures.qaRequest)).not.toThrow();
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
+    expect(() => qaEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization)).not.toThrow();
   });
 
   it("rejects invalid manifests", () => {
@@ -56,6 +58,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.qaRequest).toBeDefined();
     expect(jsonSchemas.normalizedValidationCommand).toBeDefined();
     expect(jsonSchemas.implementationInventory).toBeDefined();
+    expect(jsonSchemas.qaEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
     expect(jsonSchemas.planningArtifact).toBeDefined();
     expect(jsonSchemas.designArtifact).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -341,6 +341,18 @@ export const implementationInventorySchema = z.object({
   discoveredValidationCommands: z.array(normalizedValidationCommandSchema).default([])
 });
 
+export const qaEvidenceNormalizationSchema = z.object({
+  targetRef: z.string().min(1),
+  targetType: z.enum(["artifact-bundle", "validation-output", "local-reference"]),
+  referencedArtifactKinds: z.array(z.string().min(1)).default([]),
+  normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
+  missingEvidenceSources: z.array(z.string().min(1)).default([]),
+  normalizedExecutedChecks: z.array(z.string().min(1)).default([]),
+  unrecognizedExecutedChecks: z.array(z.string().min(1)).default([]),
+  affectedPackages: z.array(z.string().min(1)).default([]),
+  allowedValidationCommands: z.array(normalizedValidationCommandSchema).default([])
+});
+
 export const repoMetadataSchema = z.object({
   root: z.string().min(1),
   name: z.string().min(1),
@@ -684,6 +696,7 @@ export const schemaRegistry = {
   qaRequest: qaRequestSchema,
   normalizedValidationCommand: normalizedValidationCommandSchema,
   implementationInventory: implementationInventorySchema,
+  qaEvidenceNormalization: qaEvidenceNormalizationSchema,
   policyDocument: policyDocumentSchema,
   effectivePolicySnapshot: effectivePolicySnapshotSchema,
   workflowDefinition: workflowDefinitionSchema,
@@ -944,6 +957,26 @@ const implementationInventoryFixture = {
   ]
 } as const;
 
+const qaEvidenceNormalizationFixture = {
+  targetRef: ".agentops/runs/run-789/bundle.json",
+  targetType: "artifact-bundle",
+  referencedArtifactKinds: ["implementation-proposal"],
+  normalizedEvidenceSources: [".agentops/runs/run-789/bundle.json", ".agentops/runs/run-789/summary.md"],
+  missingEvidenceSources: [],
+  normalizedExecutedChecks: ["pnpm test"],
+  unrecognizedExecutedChecks: [],
+  affectedPackages: ["packages/cli"],
+  allowedValidationCommands: [
+    normalizedValidationCommandFixture,
+    {
+      command: "pnpm build",
+      source: "package-script",
+      classification: "approval_required",
+      reason: "Discovered from a bounded repository script; execution would still require approval."
+    }
+  ]
+} as const;
+
 export const schemaFixtures = {
   finding: {
     id: "finding-1",
@@ -1052,6 +1085,7 @@ export const schemaFixtures = {
   qaRequest: qaRequestFixture,
   normalizedValidationCommand: normalizedValidationCommandFixture,
   implementationInventory: implementationInventoryFixture,
+  qaEvidenceNormalization: qaEvidenceNormalizationFixture,
   lifecycleArtifactEnvelope: planningArtifactFixture,
   planningArtifact: planningArtifactFixture,
   designArtifact: designArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -12,6 +12,7 @@ import type {
   PlanningArtifact,
   PlanningRequest,
   QaArtifact,
+  QaEvidenceNormalization,
   QaRequest,
   ReleaseArtifact,
   ReleaseVerificationCheck,
@@ -49,6 +50,9 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
     expectTypeOf<QaRequest["targetRef"]>().toEqualTypeOf<string>();
+    expectTypeOf<QaEvidenceNormalization["targetType"]>().toEqualTypeOf<
+      "artifact-bundle" | "validation-output" | "local-reference"
+    >();
     expectTypeOf<ImplementationInventory["resolvedAffectedPaths"]>().toEqualTypeOf<string[]>();
     expectTypeOf<NormalizedValidationCommand["classification"]>().toEqualTypeOf<
       "allow" | "approval_required" | "deny"

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -35,6 +35,7 @@ import {
   policyDocumentSchema,
   qaArtifactPayloadSchema,
   qaArtifactSchema,
+  qaEvidenceNormalizationSchema,
   qaRequestSchema,
   planningRequestSchema,
   planningArtifactPayloadSchema,
@@ -84,6 +85,7 @@ export type ImplementationInventory = Infer<typeof implementationInventorySchema
 export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
 export type QaArtifactPayload = Infer<typeof qaArtifactPayloadSchema>;
 export type QaArtifact = Infer<typeof qaArtifactSchema>;
+export type QaEvidenceNormalization = Infer<typeof qaEvidenceNormalizationSchema>;
 export type QaRequest = Infer<typeof qaRequestSchema>;
 export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
 export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;


### PR DESCRIPTION
Closes #154.

## Summary
- add deterministic `qa-evidence-normalizer` metadata and schema/type support
- insert normalized QA evidence collection ahead of `qa-analyst`
- normalize allowlisted validation commands and referenced artifact evidence for `qa-review`

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts agents/qa-analyst/src/index.test.ts`
- `pnpm exec vitest run packages/cli/src/release-preflight.test.ts --reporter=verbose`
- `pnpm exec vitest run packages/cli/src/index.test.ts --reporter=verbose`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo smoke: planning -> design -> implementation -> qa handoff

## Notes
- `pnpm test; echo EXIT:$?` still shows intermittent wrapper-level stalling after suite output, so I am not claiming a fresh clean full-suite exit for this branch.
- while validating, I reproduced `explain last-run` once selecting an older run, but could not reproduce it again after direct reruns; this PR does not change that path.