### PR TITLE
Promote qa-review as official

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 | Plan / intake / discovery | Available now | `planning-discovery` is an official local workflow that emits a `planning-brief` artifact. |
 | Architecture / design | Available now | `architecture-design-review` is an official local workflow that consumes a planning brief and emits a `design-record` artifact. |
 | Build / implementation | Available now | `implementation-proposal` is an official local workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
-| Review / test / QA | Available now | The `pr-review` wedge covers review, security audit, and proposed test-generation outputs. |
+| Review / test / QA | Available now | `pr-review` remains official, and `qa-review` is now an official local workflow that consumes an implementation proposal and emits a `qa-report` artifact without widening the default side-effect posture. |
 | Security / compliance / DevSecOps | Partial | Policy, trust, redaction, and audit exist; broader security workflows are planned. |
 | Release / CI/CD | Partial | Release verification and package publishing exist; broader CI/CD workflow coverage is planned. |
 | Operate / incidents / observability handoff | Planned | Not implemented yet. |

--- a/docs/SDLC_COVERAGE.md
+++ b/docs/SDLC_COVERAGE.md
@@ -13,7 +13,7 @@ This document describes lifecycle coverage across AgentForge using three honest 
 | Plan / intake / discovery | Available now | `planning-discovery` is an official local workflow that validates `.agentops/requests/planning.yaml` and emits a `planning-brief` artifact. | Harden the planning workflow with richer request fixtures, policy overlays, and follow-on implementation workflow handoff. |
 | Architecture / design | Available now | `architecture-design-review` is an official local workflow that validates `.agentops/requests/design.yaml`, requires a `planningBriefRef`, and emits a `design-record` artifact. | Expand deterministic impact inventory and downstream implementation/design review handoff. |
 | Build / implementation | Available now | `implementation-proposal` is an official local workflow that validates `.agentops/requests/implementation.yaml`, requires a `designRecordRef`, and emits an `implementation-proposal` artifact without widening the default side-effect posture. | Expand from proposal-only implementation planning into downstream QA, security review, and gated apply-capable follow-ons. |
-| Review / test / QA | Available now | `pr-review` workflow with context, security audit, code review, and proposed test generation. | Broaden into dedicated review/test/QA workflow variants. |
+| Review / test / QA | Available now | `pr-review` remains available, and `qa-review` is now an official local workflow that validates `.agentops/requests/qa.yaml`, consumes an implementation proposal bundle, and emits a `qa-report` artifact with deterministic evidence normalization. | Broaden into additional QA variants such as regression triage and release-readiness QA. |
 | Security / compliance / DevSecOps | In progress | Policy, redaction, trust metadata, release trust, and audit exist. | Add richer security workflow coverage and security-specific adapters/evals. |
 | Release / CI/CD | In progress | Release verification, trusted publishing, package validation, and GitHub workflows exist. | Add broader release/CI workflow coverage beyond package publishing. |
 | Operate / incident response / observability handoff | Planned | No official workflow yet. | Add incident-handoff and operational context workflows. |
@@ -35,6 +35,9 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - `implementation-proposal`
   - location: `.agentops/workflows/implementation-proposal.yaml`
   - purpose: validate an implementation request, consume a design record, and emit an `implementation-proposal` lifecycle artifact
+- `qa-review`
+  - location: `.agentops/workflows/qa-review.yaml`
+  - purpose: validate a QA request, consume an implementation proposal bundle, normalize bounded local evidence, and emit a `qa-report` lifecycle artifact
 
 ### In progress
 
@@ -44,7 +47,7 @@ This document describes lifecycle coverage across AgentForge using three honest 
 
 ### Planned
 
-- dedicated test/QA
+- additional QA variants beyond `qa-review`
 - security/DevSecOps
 - release/CI-CD
 - operations/incident handoff
@@ -61,6 +64,7 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - `planning-analyst`
 - `design-analyst`
 - `implementation-planner`
+- `qa-analyst`
 
 ### Planned expansion areas
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -19,7 +19,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `planning-discovery` | Official | CLI-first planning and intake workflow that emits a `planning-brief` artifact. |
 | `architecture-design-review` | Official | CLI-first design workflow that consumes a planning brief and emits a `design-record` artifact. |
 | `implementation-proposal` | Official | CLI-first implementation workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
-| test / QA | Planned | The current `pr-review` flow touches QA, but there is no dedicated official QA workflow yet. |
+| `qa-review` | Official | Dedicated QA workflow that consumes an implementation proposal and emits a `qa-report` artifact with deterministic evidence normalization ahead of reasoning. |
 | security / DevSecOps | Planned | Security controls exist, but not a broader official security workflow family. |
 | release / CI-CD | Planned | Release automation exists, but not as a broader official SDLC workflow family. |
 | operations / incident handoff | Planned | Roadmap item only. |
@@ -33,6 +33,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `planning-analyst` | Official | Starter planning agent for `planning-discovery`. |
 | `design-analyst` | Official | Starter design agent for `architecture-design-review`. |
 | `implementation-planner` | Official | Starter implementation agent for `implementation-proposal`. |
+| `qa-analyst` | Official | Starter QA agent for `qa-review`. |
 | `security-audit` | Official | Current starter agent. |
 | `code-review` | Official | Current starter agent. |
 | `test-generation` | Official | Current starter agent. |
@@ -82,7 +83,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | --- | --- | --- |
 | planning/design on the AgentForge repo | Official | Covered by `planning-discovery` and `architecture-design-review` with lifecycle artifact output. |
 | implementation planning on the AgentForge repo | Official | Covered by `implementation-proposal` with deterministic inventory and proposal-only output. |
-| PR review and QA on the AgentForge repo | Official | Covered by the current `pr-review` wedge and audit outputs. |
+| PR review and QA on the AgentForge repo | Official | Covered by `pr-review` for repository review and `qa-review` for dedicated QA handoff and `qa-report` artifacts. |
 | release/readiness verification on the AgentForge repo | Official | Covered by `release guide`, `release check`, and `release verify`. |
 | autonomous implementation on the AgentForge repo | Planned | Not an official supported mode yet. |
 

--- a/docs/TEST_QA_WORKFLOWS.md
+++ b/docs/TEST_QA_WORKFLOWS.md
@@ -1,10 +1,8 @@
 # Test And QA Workflow Expansion
 
-This document defines the design target for issue [#54](https://github.com/H9-Foundry/AgentForge/issues/54).
+This document defines the QA workflow family for issue [#54](https://github.com/H9-Foundry/AgentForge/issues/54) and records the status of the first official wedge.
 
-It describes the first dedicated QA workflow family AgentForge should add beyond the current `pr-review` wedge.
-
-It does **not** claim that these workflows are implemented or officially shipped today.
+It now describes the implemented `qa-review` wedge plus the follow-on QA variants that remain planned.
 
 ## Why This Exists
 
@@ -30,16 +28,18 @@ The first QA expansion should define a workflow family that:
 
 Available now:
 
-- one official `pr-review` workflow
-- starter `test-generation` agent
+- official `pr-review` workflow
+- official `qa-review` workflow
+- starter `qa-analyst` agent
+- `qa-report` lifecycle artifact emission
+- deterministic QA evidence normalization and allowlisted validation collection
 - audit bundle and lifecycle artifact infrastructure
 - release verification and package checks
 
 Not yet available:
 
-- a dedicated QA workflow asset
-- a dedicated QA artifact family implementation beyond the design contract
-- deterministic normalization of test evidence into QA-specific outputs
+- additional QA workflow variants beyond `qa-review`
+- broader CI-hosted or external QA evidence ingestion
 
 ## Recommended Initial Workflow Family
 
@@ -53,11 +53,11 @@ Later planned variants can include:
 - `regression-triage`
 - `release-readiness-qa`
 
-Only `qa-review` should be targeted for first implementation planning.
+`qa-review` is the first official QA wedge. Later variants should build on the same evidence and artifact contracts.
 
 ## User Jobs
 
-The first QA wedge should solve these jobs:
+The current QA wedge solves these jobs:
 
 1. gather deterministic evidence about validation surfaces for a bounded change
 2. summarize test gaps, risks, and recommended next checks
@@ -163,11 +163,16 @@ Adapter expectations:
 - local filesystem and shell evidence remain policy-bounded
 - future CI/test-result adapters must normalize into one QA evidence contract
 
-## Follow-On Implementation Slices
+## Implementation Status
 
-This epic should be decomposed into at least:
+Implemented on current `main`:
 
 1. QA request schema and official `qa-review` workflow asset
 2. `qa-analyst` starter agent and `qa-report` artifact emission
 3. deterministic test-output normalization and QA evidence ingestion
-4. policy/runtime wiring for QA-specific validation commands and evidence visibility
+
+Next QA family follow-ons:
+
+1. regression-triage
+2. release-readiness QA
+3. richer CI and external evidence ingestion through bounded adapters

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,10 +1,10 @@
 # Quickstart
 
-This quickstart walks through the current official AgentForge wedges: secure local repository review plus the planning-to-design-to-implementation lifecycle handoff, all with auditable outputs.
+This quickstart walks through the current official AgentForge wedges: secure local repository review plus the planning-to-design-to-implementation-to-QA lifecycle handoff, all with auditable outputs.
 
 ## Fastest Evaluator Path
 
-Use the published CLI if you want to try the current wedges without cloning the monorepo.
+Use the published CLI if you want to try the current published wedges without cloning the monorepo.
 
 ```bash
 mkdir agentforge-demo
@@ -92,8 +92,6 @@ The design bundle should include one `design-record` lifecycle artifact and rema
 
 ## Run The Official Implementation Workflow
 
-`implementation-proposal` is implemented on current `main`. Until the next npm release includes it, use the source-build path for this workflow even if you used the published CLI for the earlier evaluator steps.
-
 Create an implementation request that points at the prior design bundle:
 
 ```bash
@@ -111,14 +109,42 @@ constraints:
 EOF
 ```
 
-Run the official implementation wedge from the current repo build:
+Run the official implementation wedge:
 
 ```bash
-node packages/cli/dist/bin.js run implementation-proposal --json
-node packages/cli/dist/bin.js explain last-run --json
+npx @h9-foundry/agentforge-cli run implementation-proposal --json
+npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 The implementation bundle should include one `implementation-proposal` lifecycle artifact with deterministic affected-path inventory plus approval-required validation guidance. The default path remains read-only and proposal-only.
+
+## Run The Official QA Workflow
+
+`qa-review` is official on current `main`, but until the next npm release includes the latest QA slices you should run it from the source build even if you used the published CLI for the earlier evaluator steps.
+
+Create a QA request that points at the prior implementation bundle:
+
+```bash
+cat > .agentops/requests/qa.yaml <<'EOF'
+targetRef: .agentops/runs/<implementation-run-id>/bundle.json
+evidenceSources:
+  - .agentops/runs/<implementation-run-id>/summary.md
+executedChecks:
+  - pnpm test
+focusAreas:
+  - regression-risk
+releaseContext: candidate
+EOF
+```
+
+Run the official QA wedge from the current repo build:
+
+```bash
+node packages/cli/dist/bin.js run qa-review --json
+node packages/cli/dist/bin.js explain last-run --json
+```
+
+The QA bundle should include one `qa-report` lifecycle artifact with normalized evidence sources, normalized executed checks, coverage gaps, findings, and recommended next checks. The default path remains read-only and bounded to local evidence.
 
 ## Contributor And Source-Build Path
 
@@ -151,6 +177,7 @@ node packages/cli/dist/bin.js run pr-review
 node packages/cli/dist/bin.js run planning-discovery
 node packages/cli/dist/bin.js run architecture-design-review
 node packages/cli/dist/bin.js run implementation-proposal
+node packages/cli/dist/bin.js run qa-review
 ```
 
 ## Inspect The Latest Run


### PR DESCRIPTION
Updates the public docs now that `#140`, `#147`, and `#154` are merged on `main`.

## Summary
- mark `qa-review` as official in the README, quickstart, support matrix, and SDLC coverage
- add the current QA evaluator path to the quickstart
- update the QA workflow doc to reflect the implemented first wedge and the remaining planned follow-ons

## Validation
- `pnpm lint`
- `pnpm typecheck`
- repo/docs consistency check against the merged QA implementation on `main`

## Notes
- `qa-review` is official on current `main`
- the published npm evaluator path still needs the next release before the latest QA slices are available from `npx`, so the quickstart keeps that distinction explicit