### PR TITLE
Add security-review intake workflow

### DIFF
--- a/.agentops/workflows/security-review.yaml
+++ b/.agentops/workflows/security-review.yaml
@@ -1,0 +1,17 @@
+version: 1
+name: security-review
+description: Validate a bounded security request while preserving the default local security posture.
+trigger: manual
+catalog:
+  domain: security
+  supportLevel: official
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: security-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final

--- a/.changeset/security-review-intake.md
+++ b/.changeset/security-review-intake.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add the bounded `security-review` request contract and official workflow asset.

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
 
+import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
+import { schemaFixtures } from "@h9-foundry/agentforge-schemas";
 
 import { explainLastRun, initProject, runLocalWorkflow, scanProject } from "./index.js";
 
@@ -33,6 +35,27 @@ function createGitFixture(prefix: string): string {
   execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "init"], { cwd: root });
   writeFileSync(join(root, "src.ts"), "export const value = 2;\n");
   return root;
+}
+
+function createFixtureRepo(): string {
+  return createGitFixture("agentops-cli-");
+}
+
+function initializeWorkspace(root: string, options?: { trackerIssue?: number }): void {
+  void options;
+  initProject(root);
+}
+
+function ensureRequestsDir(root: string): void {
+  mkdirSync(join(root, ".agentops", "requests"), { recursive: true });
+}
+
+function writeYamlFile(filePath: string, value: unknown): void {
+  writeFileSync(filePath, yaml.dump(value));
+}
+
+function readJson<T>(filePath: string): T {
+  return JSON.parse(readFileSync(filePath, "utf8")) as T;
 }
 
 let builtCli = false;
@@ -718,5 +741,160 @@ describe("cli smoke flows", () => {
     );
 
     await expect(runLocalWorkflow("qa-review", root)).rejects.toThrow(/QA target reference not found/i);
+  });
+
+  it("fails security-review before reasoning when the request is missing", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root, { trackerIssue: 141 });
+
+    await expect(runLocalWorkflow("security-review", root)).rejects.toThrow("Missing security request");
+  });
+
+  it("rejects security-review when the referenced security target does not exist", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root, { trackerIssue: 141 });
+    ensureRequestsDir(root);
+    writeYamlFile(join(root, ".agentops", "requests", "security.yaml"), {
+      targetRef: ".agentops/runs/does-not-exist/bundle.json",
+      evidenceSources: [],
+      focusAreas: ["dependency-risk"],
+      constraints: ["Keep the workflow read-only"],
+      releaseContext: "candidate"
+    });
+
+    await expect(runLocalWorkflow("security-review", root)).rejects.toThrow(/security target reference not found/i);
+  });
+
+  it("rejects security-review when the referenced bundle lacks a supported lifecycle artifact", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root, { trackerIssue: 141 });
+    ensureRequestsDir(root);
+    const bundleDir = join(root, ".agentops", "runs", "run-review");
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(
+      join(bundleDir, "bundle.json"),
+      JSON.stringify(
+        {
+          version: "1.0.0",
+          runId: "run-review",
+          workflow: "pr-review",
+          startedAt: new Date().toISOString(),
+          finishedAt: new Date().toISOString(),
+          status: "success",
+          policy: {
+            version: 1,
+            environment: "local",
+            resolvedAt: new Date().toISOString(),
+            defaults: schemaFixtures.policyDocument.defaults,
+            paths: schemaFixtures.policyDocument.paths,
+            plugins: schemaFixtures.policyDocument.plugins,
+            tools: schemaFixtures.policyDocument.tools
+          },
+          entries: [],
+          findings: [],
+          proposedActions: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [schemaFixtures.reviewArtifact],
+          artifactPaths: {
+            json: ".agentops/runs/run-review/bundle.json",
+            markdown: ".agentops/runs/run-review/summary.md"
+          },
+          provenance: {
+            generatedBy: "agentforge-runtime",
+            schemaVersion: "1.0.0",
+            executionEnvironment: "local",
+            repoRoot: root
+          },
+          redaction: {
+            applied: true,
+            strategyVersion: "1.0.0",
+            categories: ["github-token"]
+          },
+          components: []
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(bundleDir, "summary.md"), "# summary\n");
+    writeYamlFile(join(root, ".agentops", "requests", "security.yaml"), {
+      targetRef: ".agentops/runs/run-review/bundle.json",
+      evidenceSources: [],
+      focusAreas: ["dependency-risk"],
+      constraints: ["Keep the workflow read-only"],
+      releaseContext: "candidate"
+    });
+
+    await expect(runLocalWorkflow("security-review", root)).rejects.toThrow(/does not contain a supported lifecycle artifact/i);
+  });
+
+  it("runs security-review after a valid implementation-proposal handoff", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root, { trackerIssue: 141 });
+    ensureRequestsDir(root);
+    const implementationBundleDir = join(root, ".agentops", "runs", "run-impl");
+    mkdirSync(implementationBundleDir, { recursive: true });
+    writeFileSync(
+      join(implementationBundleDir, "bundle.json"),
+      JSON.stringify(
+        {
+          version: "1.0.0",
+          runId: "run-impl",
+          workflow: "implementation-proposal",
+          startedAt: new Date().toISOString(),
+          finishedAt: new Date().toISOString(),
+          status: "success",
+          policy: {
+            version: 1,
+            environment: "local",
+            resolvedAt: new Date().toISOString(),
+            defaults: schemaFixtures.policyDocument.defaults,
+            paths: schemaFixtures.policyDocument.paths,
+            plugins: schemaFixtures.policyDocument.plugins,
+            tools: schemaFixtures.policyDocument.tools
+          },
+          entries: [],
+          findings: [],
+          proposedActions: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [schemaFixtures.implementationArtifact],
+          artifactPaths: {
+            json: ".agentops/runs/run-impl/bundle.json",
+            markdown: ".agentops/runs/run-impl/summary.md"
+          },
+          provenance: {
+            generatedBy: "agentforge-runtime",
+            schemaVersion: "1.0.0",
+            executionEnvironment: "local",
+            repoRoot: root
+          },
+          redaction: {
+            applied: true,
+            strategyVersion: "1.0.0",
+            categories: ["github-token"]
+          },
+          components: []
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(implementationBundleDir, "summary.md"), "# implementation summary\n");
+    writeYamlFile(join(root, ".agentops", "requests", "security.yaml"), {
+      targetRef: ".agentops/runs/run-impl/bundle.json",
+      evidenceSources: [".agentops/runs/run-impl/summary.md"],
+      focusAreas: ["dependency-risk"],
+      constraints: ["Keep the workflow read-only"],
+      releaseContext: "candidate"
+    });
+
+    const securityRun = await runLocalWorkflow("security-review", root);
+
+    expect(securityRun.status).toBe("success");
+    expect(securityRun.findings).toBe(0);
+    expect(securityRun.artifactKinds).toEqual([]);
+
+    const bundle = readJson<{ workflow: string }>(securityRun.jsonPath);
+    expect(bundle.workflow).toBe("security-review");
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -16,6 +16,7 @@ import {
   planningArtifactSchema,
   planningRequestSchema,
   qaRequestSchema,
+  securityRequestSchema,
   workflowDefinitionSchema
 } from "@h9-foundry/agentforge-schemas";
 import type {
@@ -28,6 +29,7 @@ import type {
   PlanningArtifact,
   PlanningRequest,
   QaRequest,
+  SecurityRequest,
   WorkflowDefinition
 } from "@h9-foundry/agentforge-shared-types";
 import type { RuntimeAgent, ToolAdapter } from "@h9-foundry/agentforge-sdk";
@@ -247,6 +249,25 @@ nodes:
     outputs_to: reports.final
 `;
 
+const securityWorkflowTemplate = `version: 1
+name: security-review
+description: Validate a bounded security request while preserving the default local security posture.
+trigger: manual
+catalog:
+  domain: security
+  supportLevel: official
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: security-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final
+`;
+
 function loadYaml(filePath: string): unknown {
   return yaml.load(readFileSync(filePath, "utf8"));
 }
@@ -300,7 +321,7 @@ function validateWorkflowLifecyclePosture(
   policyEngine: ReturnType<typeof createPolicyEngine>
 ): void {
   const domain = workflow.catalog?.domain;
-  if (domain !== "plan" && domain !== "design" && domain !== "build") {
+  if (domain !== "plan" && domain !== "design" && domain !== "build" && domain !== "security") {
     return;
   }
 
@@ -347,6 +368,16 @@ function loadDesignBundleArtifact(root: string, designRecordRef: string): Design
   }
 
   return designArtifactSchema.parse(designArtifact);
+}
+
+function loadLifecycleArtifactKinds(root: string, bundleRef: string): string[] {
+  const bundlePath = join(root, bundleRef);
+  if (!existsSync(bundlePath)) {
+    throw new Error(`Referenced bundle not found: ${bundleRef}`);
+  }
+
+  const bundle = auditBundleSchema.parse(JSON.parse(readFileSync(bundlePath, "utf8")) as unknown);
+  return bundle.lifecycleArtifacts.map((artifact) => artifact.artifactKind);
 }
 
 function prepareWorkflowInputs(
@@ -409,6 +440,35 @@ function prepareWorkflowInputs(
 
     return {
       qaRequest: qaRequest satisfies QaRequest,
+      requestFile: requestPath
+    };
+  }
+
+  if (workflow.name === "security-review") {
+    const requestPath = ".agentops/requests/security.yaml";
+    ensureReadablePath(policyEngine, requestPath, "security request");
+    const securityRequest = readYamlFile(join(root, requestPath), securityRequestSchema, "security request");
+    ensureReadablePath(policyEngine, securityRequest.targetRef, "security target reference");
+    if (!existsSync(join(root, securityRequest.targetRef))) {
+      throw new Error(`Security target reference not found: ${securityRequest.targetRef}`);
+    }
+    for (const evidenceSource of securityRequest.evidenceSources) {
+      ensureReadablePath(policyEngine, evidenceSource, "security evidence source");
+    }
+
+    const referencedArtifactKinds = securityRequest.targetRef.endsWith("bundle.json")
+      ? loadLifecycleArtifactKinds(root, securityRequest.targetRef)
+      : [];
+    const allowedSecurityTargets = new Set(["design-record", "implementation-proposal", "qa-report", "release-report"]);
+    if (securityRequest.targetRef.endsWith("bundle.json") && !referencedArtifactKinds.some((kind) => allowedSecurityTargets.has(kind))) {
+      throw new Error(
+        `Referenced security bundle does not contain a supported lifecycle artifact: ${securityRequest.targetRef}`
+      );
+    }
+
+    return {
+      securityRequest: securityRequest satisfies SecurityRequest,
+      securityTargetArtifactKinds: referencedArtifactKinds,
       requestFile: requestPath
     };
   }
@@ -580,6 +640,10 @@ function ensureInitFiles(root: string): string[] {
     {
       path: join(workflowsDir, "qa-review.yaml"),
       contents: qaWorkflowTemplate
+    },
+    {
+      path: join(workflowsDir, "security-review.yaml"),
+      contents: securityWorkflowTemplate
     }
   ];
 

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -238,3 +238,64 @@ describe("builtin qa evidence normalizer", () => {
     expect(output.metadata?.unrecognizedExecutedChecks).toEqual([]);
   });
 });
+
+describe("builtin security intake agent", () => {
+  it("records bounded security request metadata and referenced artifact kinds", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentforge-security-intake-"));
+    mkdirSync(join(root, ".agentops", "runs", "run-impl"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "runs", "run-impl", "bundle.json"),
+      JSON.stringify(
+        {
+          lifecycleArtifacts: [
+            {
+              artifactKind: "implementation-proposal"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(root, ".agentops", "runs", "run-impl", "summary.md"), "# summary\n");
+
+    const agent = createBuiltinAgentRegistry().get("security-intake");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        repo: {
+          root,
+          name: "fixture-root",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        workflowInputs: {
+          securityRequest: {
+            targetRef: ".agentops/runs/run-impl/bundle.json",
+            evidenceSources: [".agentops/runs/run-impl/summary.md"],
+            focusAreas: ["dependency-risk"],
+            constraints: ["Keep the workflow read-only"],
+            releaseContext: "candidate"
+          },
+          securityTargetArtifactKinds: ["implementation-proposal"],
+          requestFile: ".agentops/requests/security.yaml"
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.summary).toContain(".agentops/requests/security.yaml");
+    expect(output.metadata?.targetType).toBe("artifact-bundle");
+    expect(output.metadata?.referencedArtifactKinds).toEqual(["implementation-proposal"]);
+    expect(output.metadata?.evidenceSources).toEqual([
+      ".agentops/runs/run-impl/bundle.json",
+      ".agentops/runs/run-impl/summary.md"
+    ]);
+  });
+});

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -10,6 +10,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  securityRequestSchema,
   planningArtifactSchema
 } from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
@@ -25,6 +26,7 @@ import type {
   QaArtifact,
   QaEvidenceNormalization,
   QaRequest,
+  SecurityRequest,
   WorkflowStateEnvelope
 } from "@h9-foundry/agentforge-shared-types";
 
@@ -734,6 +736,71 @@ const qaIntakeAgent: RuntimeAgent = {
           evidenceSources: [...new Set([qaRequest.targetRef, ...qaRequest.evidenceSources])]
         }),
         targetType
+      }
+    });
+  }
+};
+
+const securityIntakeAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "security-intake",
+    displayName: "Security Intake",
+    category: "security",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "context"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "security",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const securityRequest = getWorkflowInput<SecurityRequest>(stateSlice, "securityRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    const referencedArtifactKinds = getWorkflowInput<string[]>(stateSlice, "securityTargetArtifactKinds") ?? [];
+    if (!securityRequest) {
+      throw new Error("security-review requires a validated security request before runtime execution.");
+    }
+
+    const targetType = securityRequest.targetRef.endsWith("bundle.json") ? "artifact-bundle" : "local-reference";
+
+    return agentOutputSchema.parse({
+      summary: `Loaded security request from ${requestFile ?? ".agentops/requests/security.yaml"} targeting ${securityRequest.targetRef}.`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: {
+        ...securityRequestSchema.parse({
+          ...securityRequest,
+          evidenceSources: [...new Set([securityRequest.targetRef, ...securityRequest.evidenceSources])]
+        }),
+        targetType,
+        referencedArtifactKinds
       }
     });
   }
@@ -1664,6 +1731,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["design-inventory", designInventoryAgent],
     ["implementation-intake", implementationIntakeAgent],
     ["qa-intake", qaIntakeAgent],
+    ["security-intake", securityIntakeAgent],
     ["qa-evidence-normalizer", qaEvidenceNormalizationAgent],
     ["qa-analyst", qaAnalystAgent],
     ["implementation-inventory", implementationInventoryAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -16,6 +16,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  securityRequestSchema,
   planningRequestSchema,
   planningArtifactSchema,
   releaseArtifactSchema,
@@ -33,6 +34,7 @@ describe("schema fixtures", () => {
     expect(() => designRequestSchema.parse(schemaFixtures.designRequest)).not.toThrow();
     expect(() => implementationRequestSchema.parse(schemaFixtures.implementationRequest)).not.toThrow();
     expect(() => qaRequestSchema.parse(schemaFixtures.qaRequest)).not.toThrow();
+    expect(() => securityRequestSchema.parse(schemaFixtures.securityRequest)).not.toThrow();
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
     expect(() => qaEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization)).not.toThrow();
@@ -56,6 +58,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.designRequest).toBeDefined();
     expect(jsonSchemas.implementationRequest).toBeDefined();
     expect(jsonSchemas.qaRequest).toBeDefined();
+    expect(jsonSchemas.securityRequest).toBeDefined();
     expect(jsonSchemas.normalizedValidationCommand).toBeDefined();
     expect(jsonSchemas.implementationInventory).toBeDefined();
     expect(jsonSchemas.qaEvidenceNormalization).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -324,6 +324,14 @@ export const qaRequestSchema = z.object({
   releaseContext: z.enum(["none", "candidate", "blocking"]).default("none")
 });
 
+export const securityRequestSchema = z.object({
+  targetRef: z.string().min(1),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  focusAreas: z.array(z.string().min(1)).default([]),
+  constraints: z.array(z.string().min(1)).default([]),
+  releaseContext: z.enum(["none", "candidate", "blocking"]).default("none")
+});
+
 export const normalizedValidationCommandSchema = z.object({
   command: z.string().min(1),
   source: z.enum(["request", "package-script", "workspace-script"]),
@@ -694,6 +702,7 @@ export const schemaRegistry = {
   designRequest: designRequestSchema,
   implementationRequest: implementationRequestSchema,
   qaRequest: qaRequestSchema,
+  securityRequest: securityRequestSchema,
   normalizedValidationCommand: normalizedValidationCommandSchema,
   implementationInventory: implementationInventorySchema,
   qaEvidenceNormalization: qaEvidenceNormalizationSchema,
@@ -932,6 +941,14 @@ const qaRequestFixture = {
   releaseContext: "candidate"
 } as const;
 
+const securityRequestFixture = {
+  targetRef: ".agentops/runs/run-790/bundle.json",
+  evidenceSources: [".agentops/runs/run-790/summary.md"],
+  focusAreas: ["dependency-risk", "release-readiness"],
+  constraints: ["Keep security evidence collection read-only"],
+  releaseContext: "candidate"
+} as const;
+
 const normalizedValidationCommandFixture = {
   command: "pnpm test",
   source: "request",
@@ -1083,6 +1100,7 @@ export const schemaFixtures = {
   },
   implementationRequest: implementationRequestFixture,
   qaRequest: qaRequestFixture,
+  securityRequest: securityRequestFixture,
   normalizedValidationCommand: normalizedValidationCommandFixture,
   implementationInventory: implementationInventoryFixture,
   qaEvidenceNormalization: qaEvidenceNormalizationFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -14,6 +14,7 @@ import type {
   QaArtifact,
   QaEvidenceNormalization,
   QaRequest,
+  SecurityRequest,
   ReleaseArtifact,
   ReleaseVerificationCheck,
   ReleaseVersionTarget,
@@ -50,6 +51,7 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
     expectTypeOf<QaRequest["targetRef"]>().toEqualTypeOf<string>();
+    expectTypeOf<SecurityRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<QaEvidenceNormalization["targetType"]>().toEqualTypeOf<
       "artifact-bundle" | "validation-output" | "local-reference"
     >();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -37,6 +37,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  securityRequestSchema,
   planningRequestSchema,
   planningArtifactPayloadSchema,
   planningArtifactSchema,
@@ -87,6 +88,7 @@ export type QaArtifactPayload = Infer<typeof qaArtifactPayloadSchema>;
 export type QaArtifact = Infer<typeof qaArtifactSchema>;
 export type QaEvidenceNormalization = Infer<typeof qaEvidenceNormalizationSchema>;
 export type QaRequest = Infer<typeof qaRequestSchema>;
+export type SecurityRequest = Infer<typeof securityRequestSchema>;
 export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
 export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;
 export type NormalizedValidationCommand = Infer<typeof normalizedValidationCommandSchema>;


### PR DESCRIPTION
Closes #141.

## Summary
- add the bounded `securityRequest` schema and shared type export
- add deterministic `security-intake` handling and the official `security-review` workflow asset
- reject missing or unsupported security target bundles before any reasoning stage exists

## Validation
- `pnpm typecheck`
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- this PR intentionally does not add `security-analyst` or `security-report`; those remain in `#148`
- `pnpm test; echo EXIT:$?` still shows intermittent wrapper-level ambiguity, so I am carrying the focused passing suites plus standard build/smoke gates rather than claiming a fresh clean full-suite exit for this branch
- `explain last-run --json` selected the latest run correctly on follow-up direct checks during this slice, but I am not expanding evaluator-path claims from this PR