### PR TITLE
Add security analyst report emission

### DIFF
--- a/.agentops/workflows/security-review.yaml
+++ b/.agentops/workflows/security-review.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: security-intake
     outputs_to: agentResults.intake
+  - id: security
+    kind: reasoning
+    agent: security-analyst
+    outputs_to: agentResults.security
   - id: report
     kind: report
     outputs_to: reports.final

--- a/.changeset/security-report-artifact.md
+++ b/.changeset/security-report-artifact.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add the bounded `security-analyst` workflow stage and first `security-report` lifecycle artifact for `security-review`.

--- a/agents/security-analyst/agent.manifest.json
+++ b/agents/security-analyst/agent.manifest.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "name": "security-analyst",
+  "displayName": "Security Analyst",
+  "category": "security",
+  "runtime": {
+    "minVersion": "0.1.0",
+    "kind": "reasoning"
+  },
+  "permissions": {
+    "model": true,
+    "network": false,
+    "tools": [],
+    "readPaths": ["**/*"],
+    "writePaths": []
+  },
+  "inputs": ["workflowInputs", "repo", "changes", "agentResults"],
+  "outputs": ["lifecycleArtifacts"],
+  "contextPolicy": {
+    "sections": ["workflowInputs", "repo", "changes", "agentResults"],
+    "minimalContext": true
+  },
+  "catalog": {
+    "domain": "security",
+    "supportLevel": "internal",
+    "maturity": "mvp",
+    "trustScope": "official-core-only"
+  },
+  "trust": {
+    "tier": "core",
+    "source": "official",
+    "reviewed": true
+  }
+}

--- a/agents/security-analyst/package.json
+++ b/agents/security-analyst/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@h9-foundry/agentforge-agent-security-analyst",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "agent.manifest.json"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@h9-foundry/agentforge-schemas": "workspace:*",
+    "@h9-foundry/agentforge-sdk": "workspace:*",
+    "@h9-foundry/agentforge-shared-types": "workspace:*"
+  }
+}

--- a/agents/security-analyst/src/index.test.ts
+++ b/agents/security-analyst/src/index.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { securityAnalystAgent } from "./index.js";
+
+describe("security analyst agent", () => {
+  it("emits a security-report artifact from validated inputs", async () => {
+    const output = await securityAnalystAgent.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-security",
+        workflow: "security-review",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: ["packages"],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          securityRequest: {
+            targetRef: ".agentops/runs/run-impl/bundle.json",
+            evidenceSources: [".agentops/runs/run-impl/summary.md"],
+            focusAreas: ["dependency-risk"],
+            constraints: ["Keep the workflow read-only"],
+            releaseContext: "candidate"
+          },
+          requestFile: ".agentops/requests/security.yaml"
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              targetRef: ".agentops/runs/run-impl/bundle.json",
+              evidenceSources: [".agentops/runs/run-impl/bundle.json", ".agentops/runs/run-impl/summary.md"],
+              focusAreas: ["dependency-risk"],
+              constraints: ["Keep the workflow read-only"],
+              referencedArtifactKinds: ["implementation-proposal"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.lifecycleArtifacts).toHaveLength(1);
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("security-report");
+    expect(artifact && artifact.artifactKind === "security-report").toBe(true);
+    if (!artifact || artifact.artifactKind !== "security-report") {
+      throw new Error("Expected security-report artifact.");
+    }
+
+    expect(artifact.payload.targetRef).toBe(".agentops/runs/run-impl/bundle.json");
+    expect(artifact.payload.evidenceSources).toContain(".agentops/runs/run-impl/summary.md");
+    expect(artifact.payload.severitySummary).toContain("highest severity: medium");
+  });
+});

--- a/agents/security-analyst/src/index.ts
+++ b/agents/security-analyst/src/index.ts
@@ -1,0 +1,200 @@
+import { agentManifestSchema, agentOutputSchema, securityArtifactSchema } from "@h9-foundry/agentforge-schemas";
+import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
+import type { SecurityArtifact, SecurityRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: string): T | undefined {
+  if (!isRecord(stateSlice.workflowInputs)) {
+    return undefined;
+  }
+
+  return stateSlice.workflowInputs[key] as T | undefined;
+}
+
+function buildArtifactEnvelopeBase(state: WorkflowStateEnvelope, summary: string, inputRefs: readonly string[]) {
+  return {
+    schemaVersion: state.version,
+    workflow: {
+      name: state.workflow,
+      displayName: "Security Review"
+    },
+    source: {
+      sourceType: "workflow-run" as const,
+      runId: state.runId,
+      inputRefs: [...inputRefs],
+      issueRefs: []
+    },
+    status: "complete" as const,
+    generatedAt: new Date().toISOString(),
+    repo: {
+      root: state.repo.root,
+      name: state.repo.name,
+      branch: state.repo.branch
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" as const : "local" as const,
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
+    },
+    auditLink: {
+      entryIds: [],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary
+  };
+}
+
+export const manifest = agentManifestSchema.parse({
+  version: 1,
+  name: "security-analyst",
+  displayName: "Security Analyst",
+  category: "security",
+  runtime: {
+    minVersion: "0.1.0",
+    kind: "reasoning"
+  },
+  permissions: {
+    model: true,
+    network: false,
+    tools: [],
+    readPaths: ["**/*"],
+    writePaths: []
+  },
+  inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+  outputs: ["lifecycleArtifacts"],
+  contextPolicy: {
+    sections: ["workflowInputs", "repo", "changes", "agentResults"],
+    minimalContext: true
+  },
+  catalog: {
+    domain: "security",
+    supportLevel: "internal",
+    maturity: "mvp",
+    trustScope: "official-core-only"
+  },
+  trust: {
+    tier: "core",
+    source: "official",
+    reviewed: true
+  }
+});
+
+export const securityAnalystAgent: RuntimeAgent = {
+  manifest,
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const securityRequest = getWorkflowInput<SecurityRequest>(stateSlice, "securityRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!securityRequest) {
+      throw new Error("security-review requires validated security inputs before security analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const referencedArtifactKinds = asStringArray(intakeMetadata.referencedArtifactKinds);
+    const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
+    const normalizedConstraints = asStringArray(intakeMetadata.constraints);
+    const evidenceSources =
+      asStringArray(intakeMetadata.evidenceSources).length > 0
+        ? asStringArray(intakeMetadata.evidenceSources)
+        : [...new Set([securityRequest.targetRef, ...securityRequest.evidenceSources])];
+    const focusAreas = normalizedFocusAreas.length > 0 ? normalizedFocusAreas : securityRequest.focusAreas;
+    const inferredSeverity = securityRequest.releaseContext === "blocking" ? "high" : securityRequest.releaseContext === "candidate" ? "medium" : "low";
+    const findings =
+      focusAreas.length > 0
+        ? focusAreas.map((focusArea, index) => ({
+            id: `security-finding-${index + 1}`,
+            title: `Inspect ${focusArea} evidence before promotion`,
+            summary: `Security review flagged ${focusArea} for bounded follow-up on ${securityRequest.targetRef}.`,
+            severity: inferredSeverity,
+            rationale:
+              "The MVP security workflow synthesizes a structured report from validated references before deterministic evidence normalization lands.",
+            confidence: 0.76,
+            location: securityRequest.targetRef,
+            tags: ["security", focusArea]
+          }))
+        : [
+            {
+              id: "security-finding-1",
+              title: "Inspect referenced security evidence before promotion",
+              summary: `Security review requires bounded interpretation of the referenced evidence for ${securityRequest.targetRef}.`,
+              severity: inferredSeverity,
+              rationale:
+                "The current security workflow is read-only and request-driven, so findings remain tied to validated local references rather than automatic scanning.",
+              confidence: 0.72,
+              location: securityRequest.targetRef,
+              tags: ["security", "evidence"]
+            }
+          ];
+    const mitigations = [
+      ...focusAreas.map((focusArea) => `Review ${focusArea} evidence and document the release impact before promotion.`),
+      ...(normalizedConstraints.length > 0 ? [`Keep security follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
+    ];
+    const followUpWork = [
+      ...(referencedArtifactKinds.length > 0
+        ? [`Confirm the security posture for referenced artifacts: ${referencedArtifactKinds.join(", ")}.`]
+        : []),
+      "Add deterministic security evidence normalization before broadening the workflow surface."
+    ];
+    const summary = `Security report prepared for ${securityRequest.targetRef}.`;
+    const securityReport = securityArtifactSchema.parse({
+      ...buildArtifactEnvelopeBase(state, summary, [requestFile ?? ".agentops/requests/security.yaml", securityRequest.targetRef, ...securityRequest.evidenceSources]),
+      artifactKind: "security-report",
+      lifecycleDomain: "security",
+      payload: {
+        targetRef: securityRequest.targetRef,
+        evidenceSources,
+        findings,
+        severitySummary: `highest severity: ${inferredSeverity}; ${findings.length} synthesized security finding(s).`,
+        mitigations:
+          mitigations.length > 0
+            ? mitigations
+            : ["Review the referenced security evidence before promoting this workflow output."],
+        releaseImpact:
+          securityRequest.releaseContext === "blocking"
+            ? "release-blocking security findings require resolution before promotion."
+            : securityRequest.releaseContext === "candidate"
+              ? "candidate release requires explicit security review before promotion."
+              : "no release context was supplied; security output remains advisory.",
+        followUpWork
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [securityReport satisfies SecurityArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.76,
+      metadata: {
+        deterministicInputs: {
+          targetRef: securityRequest.targetRef,
+          evidenceSources,
+          focusAreas,
+          constraints: normalizedConstraints,
+          referencedArtifactKinds
+        },
+        synthesizedAssessment: {
+          severitySummary: securityReport.payload.severitySummary,
+          mitigations: securityReport.payload.mitigations,
+          followUpWork: securityReport.payload.followUpWork
+        }
+      }
+    });
+  }
+};

--- a/agents/security-analyst/tsconfig.json
+++ b/agents/security-analyst/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../../packages/schemas" }, { "path": "../../packages/sdk" }, { "path": "../../packages/shared-types" }]
+}

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -892,9 +892,10 @@ describe("cli smoke flows", () => {
 
     expect(securityRun.status).toBe("success");
     expect(securityRun.findings).toBe(0);
-    expect(securityRun.artifactKinds).toEqual([]);
+    expect(securityRun.artifactKinds).toContain("security-report");
 
-    const bundle = readJson<{ workflow: string }>(securityRun.jsonPath);
+    const bundle = readJson<{ workflow: string; lifecycleArtifacts: Array<{ artifactKind: string }> }>(securityRun.jsonPath);
     expect(bundle.workflow).toBe("security-review");
+    expect(bundle.lifecycleArtifacts.some((artifact) => artifact.artifactKind === "security-report")).toBe(true);
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -263,6 +263,10 @@ nodes:
     kind: deterministic
     agent: security-intake
     outputs_to: agentResults.intake
+  - id: security
+    kind: reasoning
+    agent: security-analyst
+    outputs_to: agentResults.security
   - id: report
     kind: report
     outputs_to: reports.final

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -299,3 +299,87 @@ describe("builtin security intake agent", () => {
     ]);
   });
 });
+
+describe("builtin security analyst agent", () => {
+  it("emits a security-report artifact from bounded security inputs", async () => {
+    const agent = createBuiltinAgentRegistry().get("security-analyst");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-security",
+        workflow: "security-review",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: [],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          securityRequest: {
+            targetRef: ".agentops/runs/run-impl/bundle.json",
+            evidenceSources: [".agentops/runs/run-impl/summary.md"],
+            focusAreas: ["dependency-risk"],
+            constraints: ["Keep the workflow read-only"],
+            releaseContext: "candidate"
+          },
+          requestFile: ".agentops/requests/security.yaml"
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              targetRef: ".agentops/runs/run-impl/bundle.json",
+              evidenceSources: [".agentops/runs/run-impl/bundle.json", ".agentops/runs/run-impl/summary.md"],
+              focusAreas: ["dependency-risk"],
+              constraints: ["Keep the workflow read-only"],
+              referencedArtifactKinds: ["implementation-proposal"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.lifecycleArtifacts).toHaveLength(1);
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("security-report");
+    expect(artifact && artifact.artifactKind === "security-report").toBe(true);
+    if (!artifact || artifact.artifactKind !== "security-report") {
+      throw new Error("Expected security-report artifact.");
+    }
+
+    expect(artifact.payload.findings).toHaveLength(1);
+    expect(artifact.payload.releaseImpact).toContain("candidate release");
+  });
+});

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -10,6 +10,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  securityArtifactSchema,
   securityRequestSchema,
   planningArtifactSchema
 } from "@h9-foundry/agentforge-schemas";
@@ -26,6 +27,7 @@ import type {
   QaArtifact,
   QaEvidenceNormalization,
   QaRequest,
+  SecurityArtifact,
   SecurityRequest,
   WorkflowStateEnvelope
 } from "@h9-foundry/agentforge-shared-types";
@@ -204,6 +206,52 @@ function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: st
   }
 
   return stateSlice.workflowInputs[key] as T | undefined;
+}
+
+function buildLifecycleArtifactEnvelopeBase(
+  state: WorkflowStateEnvelope,
+  displayName: string,
+  summary: string,
+  inputRefs: readonly string[],
+  issueRefs: readonly string[] = []
+) {
+  return {
+    schemaVersion: state.version,
+    workflow: {
+      name: state.workflow,
+      displayName
+    },
+    source: {
+      sourceType: "workflow-run" as const,
+      runId: state.runId,
+      inputRefs: [...inputRefs],
+      issueRefs: [...issueRefs]
+    },
+    status: "complete" as const,
+    generatedAt: new Date().toISOString(),
+    repo: {
+      root: state.repo.root,
+      name: state.repo.name,
+      branch: state.repo.branch
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" as const : "local" as const,
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
+    },
+    auditLink: {
+      entryIds: [],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary
+  };
 }
 
 function buildArtifactEnvelopeBase(
@@ -801,6 +849,150 @@ const securityIntakeAgent: RuntimeAgent = {
         }),
         targetType,
         referencedArtifactKinds
+      }
+    });
+  }
+};
+
+const securityAnalystAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "security-analyst",
+    displayName: "Security Analyst",
+    category: "security",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "reasoning"
+    },
+    permissions: {
+      model: true,
+      network: false,
+      tools: [],
+      readPaths: ["**/*"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+    outputs: ["lifecycleArtifacts"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "changes", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "security",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const securityRequest = getWorkflowInput<SecurityRequest>(stateSlice, "securityRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!securityRequest) {
+      throw new Error("security-review requires validated security inputs before security analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const referencedArtifactKinds = asStringArray(intakeMetadata.referencedArtifactKinds);
+    const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
+    const normalizedConstraints = asStringArray(intakeMetadata.constraints);
+    const evidenceSources =
+      asStringArray(intakeMetadata.evidenceSources).length > 0
+        ? asStringArray(intakeMetadata.evidenceSources)
+        : [...new Set([securityRequest.targetRef, ...securityRequest.evidenceSources])];
+    const focusAreas = normalizedFocusAreas.length > 0 ? normalizedFocusAreas : securityRequest.focusAreas;
+    const inferredSeverity = securityRequest.releaseContext === "blocking" ? "high" : securityRequest.releaseContext === "candidate" ? "medium" : "low";
+    const findings =
+      focusAreas.length > 0
+        ? focusAreas.map((focusArea, index) => ({
+            id: `security-finding-${index + 1}`,
+            title: `Inspect ${focusArea} evidence before promotion`,
+            summary: `Security review flagged ${focusArea} for bounded follow-up on ${securityRequest.targetRef}.`,
+            severity: inferredSeverity,
+            rationale:
+              "The MVP security workflow synthesizes a structured report from validated references before deterministic evidence normalization lands.",
+            confidence: 0.76,
+            location: securityRequest.targetRef,
+            tags: ["security", focusArea]
+          }))
+        : [
+            {
+              id: "security-finding-1",
+              title: "Inspect referenced security evidence before promotion",
+              summary: `Security review requires bounded interpretation of the referenced evidence for ${securityRequest.targetRef}.`,
+              severity: inferredSeverity,
+              rationale:
+                "The current security workflow is read-only and request-driven, so findings remain tied to validated local references rather than automatic scanning.",
+              confidence: 0.72,
+              location: securityRequest.targetRef,
+              tags: ["security", "evidence"]
+            }
+          ];
+    const mitigations = [
+      ...focusAreas.map((focusArea) => `Review ${focusArea} evidence and document the release impact before promotion.`),
+      ...(normalizedConstraints.length > 0 ? [`Keep security follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
+    ];
+    const followUpWork = [
+      ...(referencedArtifactKinds.length > 0
+        ? [`Confirm the security posture for referenced artifacts: ${referencedArtifactKinds.join(", ")}.`]
+        : []),
+      "Add deterministic security evidence normalization before broadening the workflow surface."
+    ];
+    const summary = `Security report prepared for ${securityRequest.targetRef}.`;
+    const securityReport = securityArtifactSchema.parse({
+      ...buildLifecycleArtifactEnvelopeBase(
+        state,
+        "Security Review",
+        summary,
+        [requestFile ?? ".agentops/requests/security.yaml", securityRequest.targetRef, ...securityRequest.evidenceSources]
+      ),
+      artifactKind: "security-report",
+      lifecycleDomain: "security",
+      payload: {
+        targetRef: securityRequest.targetRef,
+        evidenceSources,
+        findings,
+        severitySummary: `highest severity: ${inferredSeverity}; ${findings.length} synthesized security finding(s).`,
+        mitigations:
+          mitigations.length > 0
+            ? mitigations
+            : ["Review the referenced security evidence before promoting this workflow output."],
+        releaseImpact:
+          securityRequest.releaseContext === "blocking"
+            ? "release-blocking security findings require resolution before promotion."
+            : securityRequest.releaseContext === "candidate"
+              ? "candidate release requires explicit security review before promotion."
+              : "no release context was supplied; security output remains advisory.",
+        followUpWork
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [securityReport satisfies SecurityArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.76,
+      metadata: {
+        deterministicInputs: {
+          targetRef: securityRequest.targetRef,
+          evidenceSources,
+          focusAreas,
+          constraints: normalizedConstraints,
+          referencedArtifactKinds
+        },
+        synthesizedAssessment: {
+          severitySummary: securityReport.payload.severitySummary,
+          mitigations: securityReport.payload.mitigations,
+          followUpWork: securityReport.payload.followUpWork
+        }
       }
     });
   }
@@ -1732,6 +1924,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["implementation-intake", implementationIntakeAgent],
     ["qa-intake", qaIntakeAgent],
     ["security-intake", securityIntakeAgent],
+    ["security-analyst", securityAnalystAgent],
     ["qa-evidence-normalizer", qaEvidenceNormalizationAgent],
     ["qa-analyst", qaAnalystAgent],
     ["implementation-inventory", implementationInventoryAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -16,6 +16,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  securityArtifactSchema,
   securityRequestSchema,
   planningRequestSchema,
   planningArtifactSchema,
@@ -67,6 +68,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.designArtifact).toBeDefined();
     expect(jsonSchemas.implementationArtifact).toBeDefined();
     expect(jsonSchemas.qaArtifact).toBeDefined();
+    expect(jsonSchemas.securityArtifact).toBeDefined();
     expect(jsonSchemas.reviewArtifact).toBeDefined();
     expect(jsonSchemas.releaseArtifact).toBeDefined();
     expect(jsonSchemas.maintenanceArtifact).toBeDefined();
@@ -154,6 +156,7 @@ describe("schema fixtures", () => {
     expect(() => designArtifactSchema.parse(schemaFixtures.designArtifact)).not.toThrow();
     expect(() => implementationArtifactSchema.parse(schemaFixtures.implementationArtifact)).not.toThrow();
     expect(() => qaArtifactSchema.parse(schemaFixtures.qaArtifact)).not.toThrow();
+    expect(() => securityArtifactSchema.parse(schemaFixtures.securityArtifact)).not.toThrow();
     expect(() => reviewArtifactSchema.parse(schemaFixtures.reviewArtifact)).not.toThrow();
     expect(() => releaseArtifactSchema.parse(schemaFixtures.releaseArtifact)).not.toThrow();
     expect(() => maintenanceArtifactSchema.parse(schemaFixtures.maintenanceArtifact)).not.toThrow();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -18,11 +18,12 @@ export const lifecycleArtifactKindSchema = z.enum([
   "design-record",
   "implementation-proposal",
   "qa-report",
+  "security-report",
   "review-report",
   "release-report",
   "maintenance-report"
 ]);
-export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "test", "review", "release", "maintain"]);
+export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "test", "security", "review", "release", "maintain"]);
 export const lifecycleArtifactSourceTypeSchema = z.enum(["workflow-run", "manual-input", "imported"]);
 export const lifecycleArtifactStatusSchema = z.enum(["draft", "complete", "superseded", "cancelled"]);
 export const catalogDomainSchema = z.enum([
@@ -538,6 +539,16 @@ export const qaArtifactPayloadSchema = z.object({
   releaseImpact: z.string().min(1)
 });
 
+export const securityArtifactPayloadSchema = z.object({
+  targetRef: z.string().min(1),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  findings: z.array(findingSchema).default([]),
+  severitySummary: z.string().min(1),
+  mitigations: z.array(z.string().min(1)).default([]),
+  releaseImpact: z.string().min(1),
+  followUpWork: z.array(z.string().min(1)).default([])
+});
+
 export const implementationArtifactPayloadSchema = z.object({
   designRecordRef: z.string().min(1),
   implementationGoal: z.string().min(1),
@@ -609,6 +620,12 @@ export const qaArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   payload: qaArtifactPayloadSchema
 });
 
+export const securityArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("security-report"),
+  lifecycleDomain: z.literal("security"),
+  payload: securityArtifactPayloadSchema
+});
+
 export const reviewArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   artifactKind: z.literal("review-report"),
   lifecycleDomain: z.literal("review"),
@@ -632,6 +649,7 @@ export const lifecycleArtifactSchema = z.discriminatedUnion("artifactKind", [
   designArtifactSchema,
   implementationArtifactSchema,
   qaArtifactSchema,
+  securityArtifactSchema,
   reviewArtifactSchema,
   releaseArtifactSchema,
   maintenanceArtifactSchema
@@ -681,6 +699,7 @@ export const schemaRegistry = {
   designArtifactPayload: designArtifactPayloadSchema,
   implementationArtifactPayload: implementationArtifactPayloadSchema,
   qaArtifactPayload: qaArtifactPayloadSchema,
+  securityArtifactPayload: securityArtifactPayloadSchema,
   reviewArtifactPayload: reviewArtifactPayloadSchema,
   releaseVerificationCheck: releaseVerificationCheckSchema,
   releaseVersionTarget: releaseVersionTargetSchema,
@@ -690,6 +709,7 @@ export const schemaRegistry = {
   designArtifact: designArtifactSchema,
   implementationArtifact: implementationArtifactSchema,
   qaArtifact: qaArtifactSchema,
+  securityArtifact: securityArtifactSchema,
   reviewArtifact: reviewArtifactSchema,
   releaseArtifact: releaseArtifactSchema,
   maintenanceArtifact: maintenanceArtifactSchema,
@@ -846,6 +866,34 @@ const qaArtifactFixture = {
     coverageGaps: ["Coverage evidence was referenced but not normalized into a deterministic summary."],
     recommendedNextChecks: ["Review the referenced validation output before promotion.", "Confirm release-risk expectations with the owning maintainer."],
     releaseImpact: "candidate release requires QA follow-up before promotion."
+  }
+} as const;
+
+const securityArtifactFixture = {
+  ...lifecycleArtifactFixtureBase,
+  artifactKind: "security-report",
+  lifecycleDomain: "security",
+  summary: "Security report for the bounded implementation proposal handoff.",
+  payload: {
+    targetRef: ".agentops/runs/run-790/bundle.json",
+    evidenceSources: [".agentops/runs/run-790/summary.md"],
+    findings: [
+      {
+        id: "security-finding-1",
+        title: "Dependency risk still needs bounded interpretation",
+        summary: "The security workflow synthesized a dependency-risk concern from validated references.",
+        severity: "medium",
+        rationale:
+          "This slice emits a structured security report from validated evidence references before deterministic evidence normalization lands.",
+        confidence: 0.78,
+        location: ".agentops/requests/security.yaml",
+        tags: ["security", "dependency-risk"]
+      }
+    ],
+    severitySummary: "highest severity: medium; 1 synthesized security finding.",
+    mitigations: ["Review dependency-risk evidence before release promotion."],
+    releaseImpact: "candidate release requires explicit security review before promotion.",
+    followUpWork: ["Add deterministic security evidence normalization before broader promotion."]
   }
 } as const;
 
@@ -1109,6 +1157,7 @@ export const schemaFixtures = {
   designArtifact: designArtifactFixture,
   implementationArtifact: implementationArtifactFixture,
   qaArtifact: qaArtifactFixture,
+  securityArtifact: securityArtifactFixture,
   reviewArtifact: reviewArtifactFixture,
   releaseArtifact: releaseArtifactFixture,
   maintenanceArtifact: maintenanceArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -14,6 +14,7 @@ import type {
   QaArtifact,
   QaEvidenceNormalization,
   QaRequest,
+  SecurityArtifact,
   SecurityRequest,
   ReleaseArtifact,
   ReleaseVerificationCheck,
@@ -31,6 +32,8 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<ImplementationArtifact["lifecycleDomain"]>().toEqualTypeOf<"build">();
     expectTypeOf<QaArtifact["artifactKind"]>().toEqualTypeOf<"qa-report">();
     expectTypeOf<QaArtifact["lifecycleDomain"]>().toEqualTypeOf<"test">();
+    expectTypeOf<SecurityArtifact["artifactKind"]>().toEqualTypeOf<"security-report">();
+    expectTypeOf<SecurityArtifact["lifecycleDomain"]>().toEqualTypeOf<"security">();
     expectTypeOf<ReviewArtifact["artifactKind"]>().toEqualTypeOf<"review-report">();
     expectTypeOf<ReviewArtifact["lifecycleDomain"]>().toEqualTypeOf<"review">();
     expectTypeOf<ReleaseArtifact["artifactKind"]>().toEqualTypeOf<"release-report">();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -37,6 +37,8 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  securityArtifactPayloadSchema,
+  securityArtifactSchema,
   securityRequestSchema,
   planningRequestSchema,
   planningArtifactPayloadSchema,
@@ -88,6 +90,8 @@ export type QaArtifactPayload = Infer<typeof qaArtifactPayloadSchema>;
 export type QaArtifact = Infer<typeof qaArtifactSchema>;
 export type QaEvidenceNormalization = Infer<typeof qaEvidenceNormalizationSchema>;
 export type QaRequest = Infer<typeof qaRequestSchema>;
+export type SecurityArtifactPayload = Infer<typeof securityArtifactPayloadSchema>;
+export type SecurityArtifact = Infer<typeof securityArtifactSchema>;
 export type SecurityRequest = Infer<typeof securityRequestSchema>;
 export type ReviewArtifactPayload = Infer<typeof reviewArtifactPayloadSchema>;
 export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-types
 
+  agents/security-analyst:
+    dependencies:
+      '@h9-foundry/agentforge-schemas':
+        specifier: workspace:*
+        version: link:../../packages/schemas
+      '@h9-foundry/agentforge-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@h9-foundry/agentforge-shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
+
   agents/security-audit:
     dependencies:
       '@h9-foundry/agentforge-schemas':


### PR DESCRIPTION
Closes #148.

## Summary
- add the `security-analyst` starter agent package and built-in runtime registration
- add the first `security-report` lifecycle artifact family and emit it from `security-review`
- keep the workflow read-only and bounded, leaving deterministic security evidence normalization to `#155`

## Changes
- add `security-report` schema and shared type exports
- extend `security-review` workflow assets/templates with a reasoning `security-analyst` step
- add focused tests for schema unions, built-in agents, the new agent package, and CLI `security-review` execution
- add a changeset for the CLI/schema/shared-type surface updates

## Validation
- `pnpm typecheck`
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts agents/security-analyst/src/index.test.ts; echo EXIT:$?`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- `explain last-run --json` intermittently selected an older run during validation; that is tracked separately in #191 and is intentionally not folded into this slice.