### PR TITLE
Add security evidence normalization

### DIFF
--- a/.agentops/workflows/security-review.yaml
+++ b/.agentops/workflows/security-review.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: security-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: security-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: security
     kind: reasoning
     agent: security-analyst

--- a/.changeset/security-evidence-normalization.md
+++ b/.changeset/security-evidence-normalization.md
@@ -1,0 +1,8 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-policy-engine": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add deterministic security evidence normalization and stricter security-report redaction handling for `security-review`.

--- a/agents/security-analyst/src/index.ts
+++ b/agents/security-analyst/src/index.ts
@@ -104,12 +104,19 @@ export const securityAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const referencedArtifactKinds = asStringArray(intakeMetadata.referencedArtifactKinds);
-    const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
+    const evidenceMetadata = isRecord(stateSlice.agentResults?.evidence?.metadata) ? stateSlice.agentResults.evidence.metadata : {};
+    const referencedArtifactKinds = asStringArray(evidenceMetadata.referencedArtifactKinds).length > 0
+      ? asStringArray(evidenceMetadata.referencedArtifactKinds)
+      : asStringArray(intakeMetadata.referencedArtifactKinds);
+    const normalizedFocusAreas = asStringArray(evidenceMetadata.normalizedFocusAreas).length > 0
+      ? asStringArray(evidenceMetadata.normalizedFocusAreas)
+      : asStringArray(intakeMetadata.focusAreas);
     const normalizedConstraints = asStringArray(intakeMetadata.constraints);
     const evidenceSources =
-      asStringArray(intakeMetadata.evidenceSources).length > 0
-        ? asStringArray(intakeMetadata.evidenceSources)
+      asStringArray(evidenceMetadata.normalizedEvidenceSources).length > 0
+        ? asStringArray(evidenceMetadata.normalizedEvidenceSources)
+        : asStringArray(intakeMetadata.evidenceSources).length > 0
+          ? asStringArray(intakeMetadata.evidenceSources)
         : [...new Set([securityRequest.targetRef, ...securityRequest.evidenceSources])];
     const focusAreas = normalizedFocusAreas.length > 0 ? normalizedFocusAreas : securityRequest.focusAreas;
     const inferredSeverity = securityRequest.releaseContext === "blocking" ? "high" : securityRequest.releaseContext === "candidate" ? "medium" : "low";
@@ -144,16 +151,33 @@ export const securityAnalystAgent: RuntimeAgent = {
       ...(normalizedConstraints.length > 0 ? [`Keep security follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
     ];
     const followUpWork = [
+      ...asStringArray(evidenceMetadata.securitySignals),
       ...(referencedArtifactKinds.length > 0
         ? [`Confirm the security posture for referenced artifacts: ${referencedArtifactKinds.join(", ")}.`]
         : []),
-      "Add deterministic security evidence normalization before broadening the workflow surface."
+      "Use deterministic security evidence normalization outputs before broadening the workflow surface."
     ];
     const summary = `Security report prepared for ${securityRequest.targetRef}.`;
     const securityReport = securityArtifactSchema.parse({
-      ...buildArtifactEnvelopeBase(state, summary, [requestFile ?? ".agentops/requests/security.yaml", securityRequest.targetRef, ...securityRequest.evidenceSources]),
+      ...buildArtifactEnvelopeBase(
+        state,
+        summary,
+        [
+          requestFile ?? ".agentops/requests/security.yaml",
+          ...(
+            asStringArray(evidenceMetadata.provenanceRefs).length > 0
+              ? asStringArray(evidenceMetadata.provenanceRefs)
+              : [securityRequest.targetRef, ...securityRequest.evidenceSources]
+          )
+        ]
+      ),
       artifactKind: "security-report",
       lifecycleDomain: "security",
+      redaction: {
+        applied: true,
+        strategyVersion: "1.0.0",
+        categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key", "security-sensitive"]
+      },
       payload: {
         targetRef: securityRequest.targetRef,
         evidenceSources,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -263,6 +263,10 @@ nodes:
     kind: deterministic
     agent: security-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: security-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: security
     kind: reasoning
     agent: security-analyst

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -383,3 +383,72 @@ describe("builtin security analyst agent", () => {
     expect(artifact.payload.releaseImpact).toContain("candidate release");
   });
 });
+
+describe("builtin security evidence normalizer", () => {
+  it("normalizes bounded security evidence with provenance and affected package hints", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentforge-security-evidence-"));
+    mkdirSync(join(root, ".agentops", "runs", "run-impl"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "runs", "run-impl", "bundle.json"),
+      JSON.stringify(
+        {
+          lifecycleArtifacts: [
+            {
+              artifactKind: "implementation-proposal",
+              payload: {
+                affectedPaths: ["packages/app/src/index.ts", "packages/runtime/src/index.ts"]
+              }
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(root, ".agentops", "runs", "run-impl", "summary.md"), "# summary\n");
+
+    const agent = createBuiltinAgentRegistry().get("security-evidence-normalizer");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        repo: {
+          root,
+          name: "fixture-root",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        workflowInputs: {
+          securityRequest: {
+            targetRef: ".agentops/runs/run-impl/bundle.json",
+            evidenceSources: [".agentops/runs/run-impl/summary.md"],
+            focusAreas: ["dependency-risk", "release-readiness"],
+            constraints: ["Keep the workflow read-only"],
+            releaseContext: "candidate"
+          }
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              targetType: "artifact-bundle"
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.metadata?.normalizedEvidenceSources).toEqual([
+      ".agentops/runs/run-impl/bundle.json",
+      ".agentops/runs/run-impl/summary.md"
+    ]);
+    expect(output.metadata?.referencedArtifactKinds).toEqual(["implementation-proposal"]);
+    expect(output.metadata?.affectedPackages).toEqual(["packages/app", "packages/runtime"]);
+    expect(output.metadata?.provenanceRefs).toContain(".agentops/runs/run-impl/bundle.json#implementation-proposal");
+  });
+});

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -11,6 +11,7 @@ import {
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
   securityArtifactSchema,
+  securityEvidenceNormalizationSchema,
   securityRequestSchema,
   planningArtifactSchema
 } from "@h9-foundry/agentforge-schemas";
@@ -28,6 +29,7 @@ import type {
   QaEvidenceNormalization,
   QaRequest,
   SecurityArtifact,
+  SecurityEvidenceNormalization,
   SecurityRequest,
   WorkflowStateEnvelope
 } from "@h9-foundry/agentforge-shared-types";
@@ -184,6 +186,34 @@ function loadBundleArtifactKinds(bundlePath: string): string[] {
   return parsed.lifecycleArtifacts
     .map((artifact) => (isRecord(artifact) && typeof artifact.artifactKind === "string" ? artifact.artifactKind : undefined))
     .filter((artifactKind): artifactKind is string => Boolean(artifactKind));
+}
+
+function loadBundleArtifactPayloadPaths(bundlePath: string): string[] {
+  if (!existsSync(bundlePath)) {
+    return [];
+  }
+
+  const parsed = JSON.parse(readFileSync(bundlePath, "utf8")) as unknown;
+  if (!isRecord(parsed) || !Array.isArray(parsed.lifecycleArtifacts)) {
+    return [];
+  }
+
+  return parsed.lifecycleArtifacts.flatMap((artifact) => {
+    if (!isRecord(artifact) || !isRecord(artifact.payload)) {
+      return [];
+    }
+
+    const payload = artifact.payload as Record<string, unknown>;
+    if (Array.isArray(payload.affectedPaths)) {
+      return asStringArray(payload.affectedPaths);
+    }
+
+    if (Array.isArray(payload.evidenceSources)) {
+      return asStringArray(payload.evidenceSources);
+    }
+
+    return [];
+  });
 }
 
 function derivePackageScope(pathValue: string): string | undefined {
@@ -854,6 +884,105 @@ const securityIntakeAgent: RuntimeAgent = {
   }
 };
 
+const securityEvidenceNormalizationAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "security-evidence-normalizer",
+    displayName: "Security Evidence Normalizer",
+    category: "security",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**", "**/*.json", "**/*.md", "**/package.json"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "agentResults"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "security",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const securityRequest = getWorkflowInput<SecurityRequest>(stateSlice, "securityRequest");
+    if (!securityRequest) {
+      throw new Error("security-review requires validated security request inputs before evidence normalization.");
+    }
+
+    const repoRoot = stateSlice.repo?.root;
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const targetType = typeof intakeMetadata.targetType === "string" && intakeMetadata.targetType === "artifact-bundle"
+      ? "artifact-bundle"
+      : "local-reference";
+    const targetPath = repoRoot ? join(repoRoot, securityRequest.targetRef) : securityRequest.targetRef;
+    if (repoRoot && !existsSync(targetPath)) {
+      throw new Error(`Security target reference not found: ${securityRequest.targetRef}`);
+    }
+
+    const referencedArtifactKinds = targetType === "artifact-bundle" ? loadBundleArtifactKinds(targetPath) : [];
+    const normalizedEvidenceSources = [...new Set([securityRequest.targetRef, ...securityRequest.evidenceSources])];
+    const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
+    if (missingEvidenceSources.length > 0) {
+      throw new Error(`Security evidence source not found: ${missingEvidenceSources[0]}`);
+    }
+
+    const normalizedFocusAreas = securityRequest.focusAreas.length > 0 ? [...new Set(securityRequest.focusAreas)] : ["general-review"];
+    const affectedPackages =
+      targetType === "artifact-bundle"
+        ? [...new Set(loadBundleArtifactPayloadPaths(targetPath).map(derivePackageScope).filter((value): value is string => Boolean(value)))]
+        : [];
+    const securitySignals = [
+      ...(referencedArtifactKinds.length > 0 ? [`Referenced artifact kinds: ${referencedArtifactKinds.join(", ")}`] : []),
+      ...(affectedPackages.length > 0 ? [`Affected packages inferred from bounded artifact payloads: ${affectedPackages.join(", ")}`] : []),
+      ...(normalizedFocusAreas.length > 0 ? [`Requested focus areas: ${normalizedFocusAreas.join(", ")}`] : []),
+      "Security evidence collection remains local, read-only, and bounded to validated references."
+    ];
+    const provenanceRefs = [
+      securityRequest.targetRef,
+      ...securityRequest.evidenceSources,
+      ...referencedArtifactKinds.map((artifactKind) => `${securityRequest.targetRef}#${artifactKind}`)
+    ];
+    const normalization = securityEvidenceNormalizationSchema.parse({
+      targetRef: securityRequest.targetRef,
+      targetType,
+      referencedArtifactKinds,
+      normalizedEvidenceSources,
+      missingEvidenceSources: [],
+      normalizedFocusAreas,
+      securitySignals,
+      provenanceRefs: [...new Set(provenanceRefs)],
+      affectedPackages
+    });
+
+    return agentOutputSchema.parse({
+      summary: `Normalized security evidence for ${securityRequest.targetRef}.`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: normalization satisfies SecurityEvidenceNormalization
+    });
+  }
+};
+
 const securityAnalystAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -898,12 +1027,18 @@ const securityAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const referencedArtifactKinds = asStringArray(intakeMetadata.referencedArtifactKinds);
-    const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
+    const evidenceMetadata = securityEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence = evidenceMetadata.success ? evidenceMetadata.data : undefined;
+    const referencedArtifactKinds =
+      normalizedEvidence?.referencedArtifactKinds ?? asStringArray(intakeMetadata.referencedArtifactKinds);
+    const normalizedFocusAreas =
+      normalizedEvidence?.normalizedFocusAreas ?? asStringArray(intakeMetadata.focusAreas);
     const normalizedConstraints = asStringArray(intakeMetadata.constraints);
     const evidenceSources =
-      asStringArray(intakeMetadata.evidenceSources).length > 0
-        ? asStringArray(intakeMetadata.evidenceSources)
+      normalizedEvidence?.normalizedEvidenceSources && normalizedEvidence.normalizedEvidenceSources.length > 0
+        ? normalizedEvidence.normalizedEvidenceSources
+        : asStringArray(intakeMetadata.evidenceSources).length > 0
+          ? asStringArray(intakeMetadata.evidenceSources)
         : [...new Set([securityRequest.targetRef, ...securityRequest.evidenceSources])];
     const focusAreas = normalizedFocusAreas.length > 0 ? normalizedFocusAreas : securityRequest.focusAreas;
     const inferredSeverity = securityRequest.releaseContext === "blocking" ? "high" : securityRequest.releaseContext === "candidate" ? "medium" : "low";
@@ -938,10 +1073,11 @@ const securityAnalystAgent: RuntimeAgent = {
       ...(normalizedConstraints.length > 0 ? [`Keep security follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
     ];
     const followUpWork = [
+      ...(normalizedEvidence?.securitySignals ?? []),
       ...(referencedArtifactKinds.length > 0
         ? [`Confirm the security posture for referenced artifacts: ${referencedArtifactKinds.join(", ")}.`]
         : []),
-      "Add deterministic security evidence normalization before broadening the workflow surface."
+      "Use deterministic security evidence normalization outputs before broadening the workflow surface."
     ];
     const summary = `Security report prepared for ${securityRequest.targetRef}.`;
     const securityReport = securityArtifactSchema.parse({
@@ -949,10 +1085,18 @@ const securityAnalystAgent: RuntimeAgent = {
         state,
         "Security Review",
         summary,
-        [requestFile ?? ".agentops/requests/security.yaml", securityRequest.targetRef, ...securityRequest.evidenceSources]
+        [
+          requestFile ?? ".agentops/requests/security.yaml",
+          ...(normalizedEvidence?.provenanceRefs ?? [securityRequest.targetRef, ...securityRequest.evidenceSources])
+        ]
       ),
       artifactKind: "security-report",
       lifecycleDomain: "security",
+      redaction: {
+        applied: true,
+        strategyVersion: "1.0.0",
+        categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key", "security-sensitive"]
+      },
       payload: {
         targetRef: securityRequest.targetRef,
         evidenceSources,
@@ -986,7 +1130,8 @@ const securityAnalystAgent: RuntimeAgent = {
           evidenceSources,
           focusAreas,
           constraints: normalizedConstraints,
-          referencedArtifactKinds
+          referencedArtifactKinds,
+          normalizedEvidence: normalizedEvidence ?? null
         },
         synthesizedAssessment: {
           severitySummary: securityReport.payload.severitySummary,
@@ -1924,6 +2069,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["implementation-intake", implementationIntakeAgent],
     ["qa-intake", qaIntakeAgent],
     ["security-intake", securityIntakeAgent],
+    ["security-evidence-normalizer", securityEvidenceNormalizationAgent],
     ["security-analyst", securityAnalystAgent],
     ["qa-evidence-normalizer", qaEvidenceNormalizationAgent],
     ["qa-analyst", qaAnalystAgent],

--- a/packages/policy-engine/src/index.test.ts
+++ b/packages/policy-engine/src/index.test.ts
@@ -208,4 +208,52 @@ describe("policy engine", () => {
     expect(sanitized.payload.recommendedNextSteps[0]).toContain("[REDACTED_API_KEY]");
     expect(sanitized.payload.linkedIssues).toEqual(planningArtifact.payload.linkedIssues);
   });
+
+  it("marks security-report artifacts as security-sensitive during sanitization", () => {
+    const engine = createPolicyEngine(
+      {
+        version: 1,
+        environment: "local",
+        resolvedAt: new Date().toISOString(),
+        defaults: {
+          executionMode: "inspect",
+          modelAccess: false,
+          network: "deny",
+          writes: "approval_required"
+        },
+        paths: {
+          allowedRead: ["**/*"],
+          allowedWrite: [".agentops/runs/**", "tests/**"],
+          blocked: [".env*", "secrets/**"]
+        },
+        plugins: {
+          allowedTiers: ["core", "verified"],
+          allowedSources: ["official", "local"],
+          requireReviewed: true
+        },
+        tools: {
+          "filesystem.read-file": { effect: "allow" }
+        }
+      },
+      "/repo"
+    );
+
+    const securityArtifact = lifecycleArtifactSchema.parse(JSON.parse(JSON.stringify(schemaFixtures.securityArtifact)));
+    expect(securityArtifact.artifactKind).toBe("security-report");
+    if (securityArtifact.artifactKind !== "security-report") {
+      throw new Error("Expected security artifact fixture");
+    }
+
+    const sanitized = engine.sanitizeLifecycleArtifact({
+      ...securityArtifact,
+      summary: "summary token=ghp_1234567890ABCDE"
+    });
+
+    expect(sanitized.summary).toContain("[REDACTED_TOKEN]");
+    expect(sanitized.artifactKind).toBe("security-report");
+    if (sanitized.artifactKind !== "security-report") {
+      throw new Error("Expected sanitized security artifact");
+    }
+    expect(sanitized.redaction.categories).toContain("security-sensitive");
+  });
 });

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -284,7 +284,18 @@ export function createPolicyEngine(policy: EffectivePolicySnapshot, repoRoot: st
   }
 
   function sanitizeLifecycleArtifact(artifact: LifecycleArtifact): LifecycleArtifact {
-    return lifecycleArtifactSchema.parse(sanitizeUnknown(artifact, redactSecrets));
+    const sanitized = lifecycleArtifactSchema.parse(sanitizeUnknown(artifact, redactSecrets));
+    if (sanitized.artifactKind !== "security-report") {
+      return sanitized;
+    }
+
+    return lifecycleArtifactSchema.parse({
+      ...sanitized,
+      redaction: {
+        ...sanitized.redaction,
+        categories: Array.from(new Set([...sanitized.redaction.categories, "security-sensitive"]))
+      }
+    });
   }
 
   return {

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -17,6 +17,7 @@ import {
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
   securityArtifactSchema,
+  securityEvidenceNormalizationSchema,
   securityRequestSchema,
   planningRequestSchema,
   planningArtifactSchema,
@@ -39,6 +40,7 @@ describe("schema fixtures", () => {
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
     expect(() => qaEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization)).not.toThrow();
+    expect(() => securityEvidenceNormalizationSchema.parse(schemaFixtures.securityEvidenceNormalization)).not.toThrow();
   });
 
   it("rejects invalid manifests", () => {
@@ -63,6 +65,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.normalizedValidationCommand).toBeDefined();
     expect(jsonSchemas.implementationInventory).toBeDefined();
     expect(jsonSchemas.qaEvidenceNormalization).toBeDefined();
+    expect(jsonSchemas.securityEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
     expect(jsonSchemas.planningArtifact).toBeDefined();
     expect(jsonSchemas.designArtifact).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -362,6 +362,18 @@ export const qaEvidenceNormalizationSchema = z.object({
   allowedValidationCommands: z.array(normalizedValidationCommandSchema).default([])
 });
 
+export const securityEvidenceNormalizationSchema = z.object({
+  targetRef: z.string().min(1),
+  targetType: z.enum(["artifact-bundle", "local-reference"]),
+  referencedArtifactKinds: z.array(z.string().min(1)).default([]),
+  normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
+  missingEvidenceSources: z.array(z.string().min(1)).default([]),
+  normalizedFocusAreas: z.array(z.string().min(1)).default([]),
+  securitySignals: z.array(z.string().min(1)).default([]),
+  provenanceRefs: z.array(z.string().min(1)).default([]),
+  affectedPackages: z.array(z.string().min(1)).default([])
+});
+
 export const repoMetadataSchema = z.object({
   root: z.string().min(1),
   name: z.string().min(1),
@@ -726,6 +738,7 @@ export const schemaRegistry = {
   normalizedValidationCommand: normalizedValidationCommandSchema,
   implementationInventory: implementationInventorySchema,
   qaEvidenceNormalization: qaEvidenceNormalizationSchema,
+  securityEvidenceNormalization: securityEvidenceNormalizationSchema,
   policyDocument: policyDocumentSchema,
   effectivePolicySnapshot: effectivePolicySnapshotSchema,
   workflowDefinition: workflowDefinitionSchema,
@@ -893,7 +906,7 @@ const securityArtifactFixture = {
     severitySummary: "highest severity: medium; 1 synthesized security finding.",
     mitigations: ["Review dependency-risk evidence before release promotion."],
     releaseImpact: "candidate release requires explicit security review before promotion.",
-    followUpWork: ["Add deterministic security evidence normalization before broader promotion."]
+    followUpWork: ["Use deterministic security evidence normalization outputs before broader promotion."]
   }
 } as const;
 
@@ -1042,6 +1055,24 @@ const qaEvidenceNormalizationFixture = {
   ]
 } as const;
 
+const securityEvidenceNormalizationFixture = {
+  targetRef: ".agentops/runs/run-790/bundle.json",
+  targetType: "artifact-bundle",
+  referencedArtifactKinds: ["implementation-proposal"],
+  normalizedEvidenceSources: [".agentops/runs/run-790/bundle.json", ".agentops/runs/run-790/summary.md"],
+  missingEvidenceSources: [],
+  normalizedFocusAreas: ["dependency-risk", "release-readiness"],
+  securitySignals: [
+    "Referenced artifact kinds: implementation-proposal",
+    "Affected packages inferred from bounded artifact payloads: packages/cli, packages/runtime"
+  ],
+  provenanceRefs: [
+    ".agentops/runs/run-790/bundle.json#implementation-proposal",
+    ".agentops/runs/run-790/summary.md"
+  ],
+  affectedPackages: ["packages/cli", "packages/runtime"]
+} as const;
+
 export const schemaFixtures = {
   finding: {
     id: "finding-1",
@@ -1152,6 +1183,7 @@ export const schemaFixtures = {
   normalizedValidationCommand: normalizedValidationCommandFixture,
   implementationInventory: implementationInventoryFixture,
   qaEvidenceNormalization: qaEvidenceNormalizationFixture,
+  securityEvidenceNormalization: securityEvidenceNormalizationFixture,
   lifecycleArtifactEnvelope: planningArtifactFixture,
   planningArtifact: planningArtifactFixture,
   designArtifact: designArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -15,6 +15,7 @@ import type {
   QaEvidenceNormalization,
   QaRequest,
   SecurityArtifact,
+  SecurityEvidenceNormalization,
   SecurityRequest,
   ReleaseArtifact,
   ReleaseVerificationCheck,
@@ -58,6 +59,7 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<QaEvidenceNormalization["targetType"]>().toEqualTypeOf<
       "artifact-bundle" | "validation-output" | "local-reference"
     >();
+    expectTypeOf<SecurityEvidenceNormalization["targetType"]>().toEqualTypeOf<"artifact-bundle" | "local-reference">();
     expectTypeOf<ImplementationInventory["resolvedAffectedPaths"]>().toEqualTypeOf<string[]>();
     expectTypeOf<NormalizedValidationCommand["classification"]>().toEqualTypeOf<
       "allow" | "approval_required" | "deny"

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -37,6 +37,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  securityEvidenceNormalizationSchema,
   securityArtifactPayloadSchema,
   securityArtifactSchema,
   securityRequestSchema,
@@ -90,6 +91,7 @@ export type QaArtifactPayload = Infer<typeof qaArtifactPayloadSchema>;
 export type QaArtifact = Infer<typeof qaArtifactSchema>;
 export type QaEvidenceNormalization = Infer<typeof qaEvidenceNormalizationSchema>;
 export type QaRequest = Infer<typeof qaRequestSchema>;
+export type SecurityEvidenceNormalization = Infer<typeof securityEvidenceNormalizationSchema>;
 export type SecurityArtifactPayload = Infer<typeof securityArtifactPayloadSchema>;
 export type SecurityArtifact = Infer<typeof securityArtifactSchema>;
 export type SecurityRequest = Infer<typeof securityRequestSchema>;


### PR DESCRIPTION
Closes #155.

## Summary
- add deterministic `security-evidence-normalizer` handling for `security-review`
- carry normalized security evidence provenance into the `security-report` artifact
- make policy sanitization mark `security-report` payloads as security-sensitive without widening execution

## Changes
- add `securityEvidenceNormalization` schema and shared type exports
- extend `security-review` workflow assets/templates with a deterministic evidence node
- update built-in `security-analyst` handling to consume normalized evidence and provenance
- strengthen policy-engine lifecycle-artifact sanitization for `security-report`
- add focused tests for the schema, built-in normalizer, policy-engine redaction handling, and CLI workflow execution

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/policy-engine/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts agents/security-analyst/src/index.test.ts; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- `explain last-run --json` still intermittently selects an older run during smoke validation; that remains tracked separately in #191.