### PR TITLE
fix: make explain last-run deterministic (#191)

### DIFF
--- a/.changeset/explain-last-run-latest-fix.md
+++ b/.changeset/explain-last-run-latest-fix.md
@@ -1,0 +1,5 @@
+---
+"@h9-foundry/agentforge-cli": patch
+---
+
+Fix `explain last-run` so it deterministically selects the newest completed run bundle instead of relying on unstable run-directory name ordering.

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -312,6 +312,65 @@ describe("cli smoke flows", () => {
     expect(explanation.jsonPath).toBe(join(completeRunRoot, "bundle.json"));
   });
 
+  it("prefers the newest completed bundle over lexicographically later manual run directories", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentops-cli-explain-order-"));
+    writeFileSync(join(root, "package.json"), '{"name":"fixture"}');
+    initProject(root);
+
+    const olderManualRunRoot = join(root, ".agentops", "runs", "run-review");
+    mkdirSync(olderManualRunRoot, { recursive: true });
+    writeFileSync(
+      join(olderManualRunRoot, "bundle.json"),
+      JSON.stringify(
+        {
+          runId: "run-review",
+          status: "success",
+          findings: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [],
+          entries: []
+        },
+        null,
+        2
+      )
+    );
+
+    const newerTimestampRunRoot = join(root, ".agentops", "runs", "2026-03-18-000001");
+    mkdirSync(newerTimestampRunRoot, { recursive: true });
+    writeFileSync(
+      join(newerTimestampRunRoot, "bundle.json"),
+      JSON.stringify(
+        {
+          runId: "2026-03-18-000001",
+          status: "success",
+          findings: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [],
+          entries: []
+        },
+        null,
+        2
+      )
+    );
+
+    const explanation = explainLastRun(root);
+    expect(explanation.runId).toBe("2026-03-18-000001");
+    expect(explanation.jsonPath).toBe(join(newerTimestampRunRoot, "bundle.json"));
+  });
+
+  it("selects the newest completed run after back-to-back workflow executions", async () => {
+    const root = createGitFixture("agentops-cli-explain-back-to-back-");
+    initProject(root);
+
+    const firstRun = await runLocalWorkflow("pr-review", root);
+    const secondRun = await runLocalWorkflow("pr-review", root);
+
+    const explanation = explainLastRun(root);
+    expect(explanation.runId).toBe(secondRun.runId);
+    expect(explanation.runId).not.toBe(firstRun.runId);
+    expect(explanation.jsonPath).toBe(secondRun.jsonPath);
+  });
+
   it("prints first-run guidance for the current wedge in plain-text mode", () => {
     const root = createGitFixture("agentops-cli-guidance-");
     ensureBuiltCli();

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import yaml from "js-yaml";
@@ -581,6 +581,43 @@ export interface LastRunExplanation {
   artifactKinds: string[];
 }
 
+function readLatestCompleteRunBundle(runsRoot: string): { runDir: string; bundle: Record<string, unknown> } | undefined {
+  if (!existsSync(runsRoot)) {
+    return undefined;
+  }
+
+  const candidates = readdirSync(runsRoot)
+    .map((entry) => {
+      const bundlePath = join(runsRoot, entry, "bundle.json");
+      if (!existsSync(bundlePath)) {
+        return undefined;
+      }
+
+      const stats = statSync(bundlePath);
+      const bundle = JSON.parse(readFileSync(bundlePath, "utf8")) as Record<string, unknown>;
+      const bundleRunId = typeof bundle.runId === "string" ? bundle.runId : entry;
+
+      return {
+        runDir: entry,
+        bundle,
+        bundleRunId,
+        completedAtMs: stats.mtimeMs
+      };
+    })
+    .filter((candidate): candidate is { runDir: string; bundle: Record<string, unknown>; bundleRunId: string; completedAtMs: number } =>
+      Boolean(candidate)
+    )
+    .sort((left, right) => {
+      if (left.completedAtMs !== right.completedAtMs) {
+        return right.completedAtMs - left.completedAtMs;
+      }
+
+      return right.bundleRunId.localeCompare(left.bundleRunId);
+    });
+
+  return candidates[0] ? { runDir: candidates[0].runDir, bundle: candidates[0].bundle } : undefined;
+}
+
 function loadAgentForgeConfig(root: string): AgentForgeConfig {
   const configPath = join(root, ".agentops", "agentops.yaml");
   if (!existsSync(configPath)) {
@@ -858,21 +895,20 @@ export function explainLastRun(cwd = process.cwd()): LastRunExplanation {
   const root = findWorkspaceRoot(cwd);
   const config = loadAgentForgeConfig(root);
   const runsRoot = join(root, config.runtime.runsPath);
-  const entries = existsSync(runsRoot) ? readdirSync(runsRoot).sort() : [];
-  const latest = [...entries].reverse().find((entry) => existsSync(join(runsRoot, entry, "bundle.json")));
+  const latest = readLatestCompleteRunBundle(runsRoot);
 
   if (!latest) {
     throw new Error("No complete recorded runs found.");
   }
 
-  const bundle = JSON.parse(readFileSync(join(runsRoot, latest, "bundle.json"), "utf8")) as Record<string, unknown>;
+  const bundle = latest.bundle;
   const findings = asArray(bundle.findings);
   const blockedPlugins = asArray(bundle.blockedPlugins);
   const lifecycleArtifacts = asArray(bundle.lifecycleArtifacts);
   const runEntries = asArray(bundle.entries);
 
   return {
-    runId: typeof bundle.runId === "string" ? bundle.runId : latest,
+    runId: typeof bundle.runId === "string" ? bundle.runId : latest.runDir,
     status: typeof bundle.status === "string" ? bundle.status : "unknown",
     findings: findings.length,
     blockedActions: runEntries.reduce<number>((total, entry) => {
@@ -883,8 +919,8 @@ export function explainLastRun(cwd = process.cwd()): LastRunExplanation {
       return total + asArray(entry.blockedActions).length;
     }, 0),
     blockedPlugins: blockedPlugins.length,
-    jsonPath: join(runsRoot, latest, "bundle.json"),
-    markdownPath: join(runsRoot, latest, "summary.md"),
+    jsonPath: join(runsRoot, latest.runDir, "bundle.json"),
+    markdownPath: join(runsRoot, latest.runDir, "summary.md"),
     artifactCount: lifecycleArtifacts.length,
     artifactKinds: lifecycleArtifacts
       .map((artifact) => (isRecord(artifact) && typeof artifact.artifactKind === "string" ? artifact.artifactKind : undefined))


### PR DESCRIPTION
## Summary
- select the newest completed run bundle by completion time instead of raw run-directory name ordering
- add focused regression coverage for back-to-back runs and lexicographically misleading manual run directories
- add a changeset for the CLI patch release

Closes #191

## Validation
- pnpm exec vitest run packages/cli/src/index.test.ts; echo EXIT:$?
- pnpm lint
- pnpm test; echo EXIT:$?
- pnpm typecheck
- pnpm build
- pnpm build:packages
- node packages/cli/dist/bin.js run pr-review --json
- node packages/cli/dist/bin.js explain last-run --json