### PR TITLE
docs: promote security-review as official

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 | Architecture / design | Available now | `architecture-design-review` is an official local workflow that consumes a planning brief and emits a `design-record` artifact. |
 | Build / implementation | Available now | `implementation-proposal` is an official local workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
 | Review / test / QA | Available now | `pr-review` remains official, and `qa-review` is now an official local workflow that consumes an implementation proposal and emits a `qa-report` artifact without widening the default side-effect posture. |
-| Security / compliance / DevSecOps | Partial | Policy, trust, redaction, and audit exist; broader security workflows are planned. |
+| Security / compliance / DevSecOps | Available now | `security-review` is an official local workflow that consumes bounded local evidence, emits a `security-report` artifact, and keeps the default path read-only; broader security variants remain planned. |
 | Release / CI/CD | Partial | Release verification and package publishing exist; broader CI/CD workflow coverage is planned. |
 | Operate / incidents / observability handoff | Planned | Not implemented yet. |
 | Maintain / upgrades / docs hygiene | Partial | Release hygiene and dependency maintenance are present; dedicated workflows are planned. |

--- a/docs/SDLC_COVERAGE.md
+++ b/docs/SDLC_COVERAGE.md
@@ -14,7 +14,7 @@ This document describes lifecycle coverage across AgentForge using three honest 
 | Architecture / design | Available now | `architecture-design-review` is an official local workflow that validates `.agentops/requests/design.yaml`, requires a `planningBriefRef`, and emits a `design-record` artifact. | Expand deterministic impact inventory and downstream implementation/design review handoff. |
 | Build / implementation | Available now | `implementation-proposal` is an official local workflow that validates `.agentops/requests/implementation.yaml`, requires a `designRecordRef`, and emits an `implementation-proposal` artifact without widening the default side-effect posture. | Expand from proposal-only implementation planning into downstream QA, security review, and gated apply-capable follow-ons. |
 | Review / test / QA | Available now | `pr-review` remains available, and `qa-review` is now an official local workflow that validates `.agentops/requests/qa.yaml`, consumes an implementation proposal bundle, and emits a `qa-report` artifact with deterministic evidence normalization. | Broaden into additional QA variants such as regression triage and release-readiness QA. |
-| Security / compliance / DevSecOps | In progress | Policy, redaction, trust metadata, release trust, and audit exist. | Add richer security workflow coverage and security-specific adapters/evals. |
+| Security / compliance / DevSecOps | Available now | `security-review` is an official local workflow that validates `.agentops/requests/security.yaml`, consumes bounded local evidence, and emits a `security-report` artifact without widening the default side-effect posture. | Expand beyond `security-review` into additional security/DevSecOps variants, adapters, and evals. |
 | Release / CI/CD | In progress | Release verification, trusted publishing, package validation, and GitHub workflows exist. | Add broader release/CI workflow coverage beyond package publishing. |
 | Operate / incident response / observability handoff | Planned | No official workflow yet. | Add incident-handoff and operational context workflows. |
 | Maintain / upgrade / docs / dependency hygiene | In progress | Dependency and release hygiene exist through GitHub workflows and repo maintenance practices. | Add explicit maintenance workflows and docs hygiene automation. |
@@ -38,10 +38,12 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - `qa-review`
   - location: `.agentops/workflows/qa-review.yaml`
   - purpose: validate a QA request, consume an implementation proposal bundle, normalize bounded local evidence, and emit a `qa-report` lifecycle artifact
+- `security-review`
+  - location: `.agentops/workflows/security-review.yaml`
+  - purpose: validate a security request, consume bounded local evidence, and emit a `security-report` lifecycle artifact with deterministic evidence normalization and tighter policy handling
 
 ### In progress
 
-- security / DevSecOps
 - release / CI-CD
 - maintenance / dependency / docs hygiene
 
@@ -65,6 +67,7 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - `design-analyst`
 - `implementation-planner`
 - `qa-analyst`
+- `security-analyst`
 
 ### Planned expansion areas
 

--- a/docs/SECURITY_DEVSECOPS_WORKFLOWS.md
+++ b/docs/SECURITY_DEVSECOPS_WORKFLOWS.md
@@ -1,25 +1,25 @@
 # Security And DevSecOps Workflow Expansion
 
-This document defines the design target for issue [#55](https://github.com/H9-Foundry/AgentForge/issues/55).
+This document defines the security workflow expansion for issue [#55](https://github.com/H9-Foundry/AgentForge/issues/55).
 
-It describes how AgentForge should grow security workflows beyond the current security posture and starter audit behavior.
+It now records the implemented `security-review` wedge and the remaining planned growth beyond that initial workflow.
 
-It does **not** claim that these workflows are implemented or officially shipped today.
+It does **not** claim that the broader security family is fully implemented today.
 
 ## Why This Exists
 
-AgentForge already has strong policy, redaction, and release-trust controls, but it does not yet expose a first-class security workflow family.
+AgentForge already has strong policy, redaction, and release-trust controls, and it now exposes one first-class security workflow wedge.
 
-Without explicit security workflows:
+Before `security-review`, the repo lacked:
 
 - security review intent is mixed into generic review paths
 - compliance and DevSecOps use cases have no bounded workflow wedge
 - security-specific evidence and findings are not normalized separately
 - future supply-chain and release-hardening work lacks a clear upstream workflow model
 
-## Design Goal
+## Current Goal
 
-The first security expansion should define a workflow family that:
+The current security expansion should:
 
 - keeps the current security posture as a hard baseline
 - adds explicit workflows for bounded security review and evidence collection
@@ -34,16 +34,19 @@ Available now:
 - lifecycle artifact sanitization and audit linkage
 - starter `security-audit` agent
 - release verification and trusted publishing
+- official `security-review` workflow asset
+- starter `security-analyst`
+- `security-report` lifecycle artifact emission
+- deterministic security evidence normalization and security-domain policy handling
 
 Not yet available:
 
-- official security workflow assets
-- dedicated security lifecycle artifacts beyond design targets
 - explicit DevSecOps evidence adapters or compliance-oriented workflows
+- additional official security variants beyond `security-review`
 
 ## Recommended Initial Workflow Family
 
-Phase 2 should define one first official wedge:
+The first official security wedge is now:
 
 - `security-review`
 
@@ -53,7 +56,7 @@ Later planned variants can include:
 - `compliance-evidence-assembly`
 - `supply-chain-verification`
 
-Only `security-review` should be targeted for first implementation planning.
+Only `security-review` is implemented today. The later variants remain planned.
 
 ## User Jobs
 
@@ -156,12 +159,20 @@ Adapter expectations:
 - dependency and advisory ingestion must remain explicit and policy-aware
 - future compliance evidence adapters must preserve redaction and auditability
 
-## Follow-On Implementation Slices
+## Implemented Initial Slices
 
-This epic should be decomposed into at least:
+Completed:
 
 1. security request schema and official `security-review` workflow asset
 2. `security-analyst` starter agent and `security-report` artifact emission
 3. deterministic local security evidence collection and normalization
 4. security-domain policy wiring for evidence visibility, redaction, and escalation posture
 
+## Remaining Planned Expansion
+
+The broader security/DevSecOps family still needs:
+
+1. additional security variants such as dependency-risk review and compliance evidence assembly
+2. richer explicit evidence adapters beyond bounded local security evidence
+3. workflow-level GitHub and CI handoff integration
+4. eval and benchmark coverage for security-specific workflow quality

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -20,7 +20,8 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `architecture-design-review` | Official | CLI-first design workflow that consumes a planning brief and emits a `design-record` artifact. |
 | `implementation-proposal` | Official | CLI-first implementation workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
 | `qa-review` | Official | Dedicated QA workflow that consumes an implementation proposal and emits a `qa-report` artifact with deterministic evidence normalization ahead of reasoning. |
-| security / DevSecOps | Planned | Security controls exist, but not a broader official security workflow family. |
+| `security-review` | Official | Dedicated security workflow that consumes bounded local evidence, emits a `security-report` artifact, and keeps the default path read-only with tighter policy handling. |
+| security / DevSecOps extensions | Planned | Additional security variants beyond `security-review` are not implemented yet. |
 | release / CI-CD | Planned | Release automation exists, but not as a broader official SDLC workflow family. |
 | operations / incident handoff | Planned | Roadmap item only. |
 | maintenance / dependency/docs hygiene | Planned | Roadmap item only. |
@@ -34,6 +35,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `design-analyst` | Official | Starter design agent for `architecture-design-review`. |
 | `implementation-planner` | Official | Starter implementation agent for `implementation-proposal`. |
 | `qa-analyst` | Official | Starter QA agent for `qa-review`. |
+| `security-analyst` | Official | Starter security agent for `security-review`. |
 | `security-audit` | Official | Current starter agent. |
 | `code-review` | Official | Current starter agent. |
 | `test-generation` | Official | Current starter agent. |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -146,6 +146,34 @@ node packages/cli/dist/bin.js explain last-run --json
 
 The QA bundle should include one `qa-report` lifecycle artifact with normalized evidence sources, normalized executed checks, coverage gaps, findings, and recommended next checks. The default path remains read-only and bounded to local evidence.
 
+## Run The Official Security Workflow
+
+`security-review` is official on current `main`, but until the next npm release includes the latest security slices you should run it from the source build even if you used the published CLI for the earlier evaluator steps.
+
+Create a security request that points at the prior QA or implementation bundle:
+
+```bash
+cat > .agentops/requests/security.yaml <<'EOF'
+targetRef: .agentops/runs/<qa-or-implementation-run-id>/bundle.json
+evidenceSources:
+  - .agentops/runs/<qa-or-implementation-run-id>/summary.md
+focusAreas:
+  - dependency-risk
+  - release-candidate-review
+severityThreshold: medium
+releaseContext: candidate
+EOF
+```
+
+Run the official security wedge from the current repo build:
+
+```bash
+node packages/cli/dist/bin.js run security-review --json
+node packages/cli/dist/bin.js explain last-run --json
+```
+
+The security bundle should include one `security-report` lifecycle artifact with normalized security evidence provenance, findings, severity summary, mitigations, release impact, and follow-up work. The default path remains read-only and more restrictive than the generic review wedges.
+
 ## Contributor And Source-Build Path
 
 If you want to work on AgentForge itself, build the monorepo locally:
@@ -178,6 +206,7 @@ node packages/cli/dist/bin.js run planning-discovery
 node packages/cli/dist/bin.js run architecture-design-review
 node packages/cli/dist/bin.js run implementation-proposal
 node packages/cli/dist/bin.js run qa-review
+node packages/cli/dist/bin.js run security-review
 ```
 
 ## Inspect The Latest Run


### PR DESCRIPTION
## Summary
- promote `security-review` as an official workflow in the public docs and support matrix
- add the source-build evaluator path for `security-review` to quickstart
- update the security workflow expansion doc so it records the implemented initial wedge and the remaining planned expansion honestly

## Validation
- source-build evaluator flow on `main` for planning, design, implementation, and `security-review`
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`