### PR TITLE
chore: version public AgentForge packages for 0.7.0

### DIFF
--- a/.changeset/explain-last-run-latest-fix.md
+++ b/.changeset/explain-last-run-latest-fix.md
@@ -1,5 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
----
-
-Fix `explain last-run` so it deterministically selects the newest completed run bundle instead of relying on unstable run-directory name ordering.

--- a/.changeset/qa-evidence-normalization.md
+++ b/.changeset/qa-evidence-normalization.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Normalize bounded QA evidence deterministically and wire `qa-review` to consume allowlisted validation evidence before QA reasoning.

--- a/.changeset/qa-report-emission.md
+++ b/.changeset/qa-report-emission.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add the bounded `qa-analyst` starter agent and emit `qa-report` lifecycle artifacts for `qa-review`.

--- a/.changeset/security-evidence-normalization.md
+++ b/.changeset/security-evidence-normalization.md
@@ -1,8 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
-"@h9-foundry/agentforge-policy-engine": patch
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Add deterministic security evidence normalization and stricter security-report redaction handling for `security-review`.

--- a/.changeset/security-report-artifact.md
+++ b/.changeset/security-report-artifact.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Add the bounded `security-analyst` workflow stage and first `security-report` lifecycle artifact for `security-review`.

--- a/.changeset/security-review-intake.md
+++ b/.changeset/security-review-intake.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add the bounded `security-review` request contract and official workflow asset.

--- a/agents/design-analyst/CHANGELOG.md
+++ b/agents/design-analyst/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @h9-foundry/agentforge-agent-design-analyst
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+  - @h9-foundry/agentforge-sdk@0.7.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/agents/design-analyst/package.json
+++ b/agents/design-analyst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-design-analyst",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/agents/implementation-planner/CHANGELOG.md
+++ b/agents/implementation-planner/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @h9-foundry/agentforge-agent-implementation-planner
 
+## 0.1.2
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+  - @h9-foundry/agentforge-sdk@0.7.0
+
 ## 0.1.1
 
 ### Patch Changes

--- a/agents/implementation-planner/package.json
+++ b/agents/implementation-planner/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-implementation-planner",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/agents/planning-analyst/CHANGELOG.md
+++ b/agents/planning-analyst/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @h9-foundry/agentforge-agent-planning-analyst
 
+## 0.1.3
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+  - @h9-foundry/agentforge-sdk@0.7.0
+
 ## 0.1.2
 
 ### Patch Changes

--- a/agents/planning-analyst/package.json
+++ b/agents/planning-analyst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-planning-analyst",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/agents/qa-analyst/CHANGELOG.md
+++ b/agents/qa-analyst/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @h9-foundry/agentforge-agent-qa-analyst
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+  - @h9-foundry/agentforge-sdk@0.7.0

--- a/agents/qa-analyst/package.json
+++ b/agents/qa-analyst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-qa-analyst",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/agents/security-analyst/CHANGELOG.md
+++ b/agents/security-analyst/CHANGELOG.md
@@ -1,0 +1,14 @@
+# @h9-foundry/agentforge-agent-security-analyst
+
+## 0.1.1
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+  - @h9-foundry/agentforge-sdk@0.7.0

--- a/agents/security-analyst/package.json
+++ b/agents/security-analyst/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-agent-security-analyst",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @h9-foundry/agentforge-audit
 
+## 0.7.0
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-shared-types@0.7.0
+
 ## 0.6.0
 
 ### Patch Changes

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-audit",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @h9-foundry/agentforge-cli
 
+## 0.7.0
+
+### Minor Changes
+
+- b0f9b53: Normalize bounded QA evidence deterministically and wire `qa-review` to consume allowlisted validation evidence before QA reasoning.
+- df17a9c: Add the bounded `qa-analyst` starter agent and emit `qa-report` lifecycle artifacts for `qa-review`.
+- 65b7ee1: Add the bounded `security-review` request contract and official workflow asset.
+
+### Patch Changes
+
+- ce0f10f: Fix `explain last-run` so it deterministically selects the newest completed run bundle instead of relying on unstable run-directory name ordering.
+- 9c1d8d0: Add deterministic security evidence normalization and stricter security-report redaction handling for `security-review`.
+- bdae136: Add the bounded `security-analyst` workflow stage and first `security-report` lifecycle artifact for `security-review`.
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+  - @h9-foundry/agentforge-policy-engine@0.7.0
+  - @h9-foundry/agentforge-context-engine@0.7.0
+  - @h9-foundry/agentforge-runtime@0.7.0
+  - @h9-foundry/agentforge-audit@0.7.0
+  - @h9-foundry/agentforge-sdk@0.7.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/context-engine/CHANGELOG.md
+++ b/packages/context-engine/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @h9-foundry/agentforge-context-engine
 
+## 0.7.0
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+
 ## 0.6.0
 
 ### Patch Changes

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Repository and execution context collection for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/policy-engine/CHANGELOG.md
+++ b/packages/policy-engine/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @h9-foundry/agentforge-policy-engine
 
+## 0.7.0
+
+### Patch Changes
+
+- 9c1d8d0: Add deterministic security evidence normalization and stricter security-report redaction handling for `security-review`.
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+
 ## 0.6.0
 
 ### Patch Changes

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @h9-foundry/agentforge-runtime
 
+## 0.7.0
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+  - @h9-foundry/agentforge-shared-types@0.7.0
+  - @h9-foundry/agentforge-policy-engine@0.7.0
+  - @h9-foundry/agentforge-audit@0.7.0
+  - @h9-foundry/agentforge-sdk@0.7.0
+
 ## 0.6.0
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @h9-foundry/agentforge-schemas
 
+## 0.7.0
+
+### Minor Changes
+
+- b0f9b53: Normalize bounded QA evidence deterministically and wire `qa-review` to consume allowlisted validation evidence before QA reasoning.
+- df17a9c: Add the bounded `qa-analyst` starter agent and emit `qa-report` lifecycle artifacts for `qa-review`.
+- 65b7ee1: Add the bounded `security-review` request contract and official workflow asset.
+
+### Patch Changes
+
+- 9c1d8d0: Add deterministic security evidence normalization and stricter security-report redaction handling for `security-review`.
+- bdae136: Add the bounded `security-analyst` workflow stage and first `security-report` lifecycle artifact for `security-review`.
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @h9-foundry/agentforge-sdk
 
+## 0.7.0
+
+### Patch Changes
+
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-shared-types@0.7.0
+
 ## 0.6.0
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @h9-foundry/agentforge-shared-types
 
+## 0.7.0
+
+### Minor Changes
+
+- b0f9b53: Normalize bounded QA evidence deterministically and wire `qa-review` to consume allowlisted validation evidence before QA reasoning.
+- df17a9c: Add the bounded `qa-analyst` starter agent and emit `qa-report` lifecycle artifacts for `qa-review`.
+- 65b7ee1: Add the bounded `security-review` request contract and official workflow asset.
+
+### Patch Changes
+
+- 9c1d8d0: Add deterministic security evidence normalization and stricter security-report redaction handling for `security-review`.
+- bdae136: Add the bounded `security-analyst` workflow stage and first `security-report` lifecycle artifact for `security-review`.
+- Updated dependencies [b0f9b53]
+- Updated dependencies [df17a9c]
+- Updated dependencies [9c1d8d0]
+- Updated dependencies [bdae136]
+- Updated dependencies [65b7ee1]
+  - @h9-foundry/agentforge-schemas@0.7.0
+
 ## 0.6.0
 
 ### Minor Changes

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
   "license": "MIT",
   "author": "H9 Foundry",


### PR DESCRIPTION
## Summary
- apply the pending Changesets version updates from current `main`
- cut the `0.7.0` public package set including QA and security workflow work plus the `explain last-run` fix
- replace the stuck bot-generated release PR with a human-owned equivalent against the current base

## Validation
- `node packages/cli/dist/bin.js release verify --json`