### PR TITLE
feat: render GitHub lifecycle handoff summaries

### DIFF
--- a/.changeset/github-handoff-rendering.md
+++ b/.changeset/github-handoff-rendering.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-audit": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add deterministic GitHub handoff rendering contracts and audit helpers for planning, design, QA, and release lifecycle artifacts.

--- a/docs/GITHUB_INTEGRATION_MATURITY.md
+++ b/docs/GITHUB_INTEGRATION_MATURITY.md
@@ -38,12 +38,13 @@ Partially implemented now:
 
 - deterministic GitHub issue and PR reference normalization shared across lifecycle workflow inputs and artifacts
 - bounded local-to-GitHub status mapping primitives for later handoff and reporting work
+- deterministic GitHub handoff rendering for planning, design, QA, and release artifacts
 
 Not yet available:
 
 - official GitHub-backed workflow adapters beyond the current narrow paths
 - explicit project/status-sync workflow surfaces
-- bounded GitHub handoff rendering or comment/report publication
+- automatic GitHub comment/report publication
 - GitHub Actions evidence ingestion for lifecycle workflows
 
 ## Near-Term Maturity Wedge
@@ -107,6 +108,6 @@ It should remain:
 This epic is now decomposed into:
 
 1. implemented: GitHub issue/PR reference and status normalization shared across lifecycle workflows
-2. next: bounded GitHub handoff/comment/report surfaces for planning, design, QA, and release artifacts
+2. implemented in part: bounded GitHub handoff rendering for planning, design, QA, and release artifacts
 3. next: GitHub Actions evidence ingestion for QA and release workflows
 4. ongoing: support-matrix and policy guidance for GitHub-specific versus host-agnostic behavior

--- a/packages/audit/src/index.test.ts
+++ b/packages/audit/src/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { schemaFixtures } from "@h9-foundry/agentforge-schemas";
+import type {
+  DesignArtifact,
+  PlanningArtifact,
+  QaArtifact,
+  ReleaseArtifact
+} from "@h9-foundry/agentforge-shared-types";
+
+import { renderGitHubHandoffSummary } from "./index.js";
+
+function cloneFixture<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+describe("renderGitHubHandoffSummary", () => {
+  it("renders a bounded planning handoff summary", () => {
+    const summary = renderGitHubHandoffSummary(cloneFixture(schemaFixtures.planningArtifact) as unknown as PlanningArtifact);
+
+    expect(summary.artifactKind).toBe("planning-brief");
+    expect(summary.githubStatus).toBe("completed");
+    expect(summary.issueRefs.map((entry) => entry.canonical)).toContain("H9-Foundry/AgentForge#78");
+    expect(summary.sections.some((section) => section.heading === "Recommended Next Steps")).toBe(true);
+    expect(summary.body).toContain("Planning And Discovery handoff");
+  });
+
+  it("renders a deterministic design handoff summary", () => {
+    const summary = renderGitHubHandoffSummary(cloneFixture(schemaFixtures.designArtifact) as unknown as DesignArtifact);
+
+    expect(summary.artifactKind).toBe("design-record");
+    expect(summary.sections.some((section) => section.heading === "Chosen Approach")).toBe(true);
+    expect(summary.sections.some((section) => section.heading === "Options Considered")).toBe(true);
+  });
+
+  it("renders a bounded QA handoff summary", () => {
+    const summary = renderGitHubHandoffSummary(cloneFixture(schemaFixtures.qaArtifact) as unknown as QaArtifact);
+
+    expect(summary.artifactKind).toBe("qa-report");
+    expect(summary.sections.some((section) => section.heading === "Findings")).toBe(true);
+    expect(summary.sections.some((section) => section.heading === "Coverage Gaps")).toBe(true);
+  });
+
+  it("renders a bounded release handoff summary with overrideable status mapping", () => {
+    const summary = renderGitHubHandoffSummary(cloneFixture(schemaFixtures.releaseArtifact) as unknown as ReleaseArtifact, {
+      statusMapping: {
+        workflow: "release-readiness",
+        localRunStatus: "partial",
+        githubStatus: "blocked",
+        reason: "Release verification is still blocked."
+      }
+    });
+
+    expect(summary.artifactKind).toBe("release-report");
+    expect(summary.githubStatus).toBe("blocked");
+    expect(summary.sections.some((section) => section.heading === "Verification Checks")).toBe(true);
+  });
+});

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -1,7 +1,163 @@
-import type { AuditBundle, AuditEntry, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type {
+  AuditBundle,
+  AuditEntry,
+  DesignArtifact,
+  GithubHandoffSection,
+  GithubHandoffSummary,
+  GithubReference,
+  GithubWorkflowStatusMapping,
+  PlanningArtifact,
+  QaArtifact,
+  ReleaseArtifact,
+  WorkflowStateEnvelope
+} from "@h9-foundry/agentforge-shared-types";
+
+type GitHubRenderableArtifact = PlanningArtifact | DesignArtifact | QaArtifact | ReleaseArtifact;
 
 export function createAuditEntry(entry: AuditEntry): AuditEntry {
   return entry;
+}
+
+function splitGitHubRefs(githubRefs: readonly GithubReference[]): { issueRefs: GithubReference[]; pullRequestRefs: GithubReference[] } {
+  return githubRefs.reduce(
+    (accumulator, githubRef) => {
+      if (githubRef.kind === "pull_request") {
+        accumulator.pullRequestRefs.push(githubRef);
+      } else {
+        accumulator.issueRefs.push(githubRef);
+      }
+
+      return accumulator;
+    },
+    { issueRefs: [] as GithubReference[], pullRequestRefs: [] as GithubReference[] }
+  );
+}
+
+function mapArtifactStatusToGitHubStatus(
+  artifactStatus: GitHubRenderableArtifact["status"],
+  statusMapping?: GithubWorkflowStatusMapping
+): GithubHandoffSummary["githubStatus"] {
+  if (statusMapping) {
+    return statusMapping.githubStatus;
+  }
+
+  if (artifactStatus === "complete") {
+    return "completed";
+  }
+
+  if (artifactStatus === "draft") {
+    return "in_progress";
+  }
+
+  return "blocked";
+}
+
+function renderPlanningSections(artifact: PlanningArtifact): GithubHandoffSection[] {
+  return [
+    { heading: "Summary", lines: [artifact.summary] },
+    { heading: "Objectives", lines: artifact.payload.objectives },
+    { heading: "Recommended Next Steps", lines: artifact.payload.recommendedNextSteps },
+    { heading: "Risks", lines: artifact.payload.risks ?? [] },
+    { heading: "Open Questions", lines: artifact.payload.openQuestions ?? [] }
+  ].filter((section) => section.lines.length > 0);
+}
+
+function renderDesignSections(artifact: DesignArtifact): GithubHandoffSection[] {
+  return [
+    { heading: "Summary", lines: [artifact.summary] },
+    { heading: "Chosen Approach", lines: [artifact.payload.chosenApproach] },
+    {
+      heading: "Options Considered",
+      lines: artifact.payload.optionsConsidered.map((option) => `${option.option}: ${option.summary}`)
+    },
+    { heading: "Trade-Offs", lines: artifact.payload.tradeOffs ?? [] },
+    { heading: "Risks", lines: artifact.payload.risks ?? [] },
+    { heading: "Follow-Up Work", lines: artifact.payload.followUpWork ?? [] }
+  ].filter((section) => section.lines.length > 0);
+}
+
+function renderQaSections(artifact: QaArtifact): GithubHandoffSection[] {
+  return [
+    { heading: "Summary", lines: [artifact.summary] },
+    {
+      heading: "Findings",
+      lines: artifact.payload.findings.map((finding) => `[${finding.severity}] ${finding.title}: ${finding.summary}`)
+    },
+    { heading: "Coverage Gaps", lines: artifact.payload.coverageGaps ?? [] },
+    { heading: "Recommended Next Checks", lines: artifact.payload.recommendedNextChecks ?? [] },
+    { heading: "Release Impact", lines: [artifact.payload.releaseImpact] }
+  ].filter((section) => section.lines.length > 0);
+}
+
+function renderReleaseSections(artifact: ReleaseArtifact): GithubHandoffSection[] {
+  return [
+    { heading: "Summary", lines: [artifact.summary] },
+    { heading: "Readiness Status", lines: [artifact.payload.readinessStatus] },
+    {
+      heading: "Verification Checks",
+      lines: artifact.payload.verificationChecks.map((check) => `${check.name}: ${check.status}${check.detail ? ` (${check.detail})` : ""}`)
+    },
+    { heading: "Publishing Plan", lines: artifact.payload.publishingPlan ?? [] },
+    { heading: "Rollback Notes", lines: artifact.payload.rollbackNotes ?? [] }
+  ].filter((section) => section.lines.length > 0);
+}
+
+function buildGitHubHandoffSections(artifact: GitHubRenderableArtifact): GithubHandoffSection[] {
+  switch (artifact.artifactKind) {
+    case "planning-brief":
+      return renderPlanningSections(artifact);
+    case "design-record":
+      return renderDesignSections(artifact);
+    case "qa-report":
+      return renderQaSections(artifact);
+    case "release-report":
+      return renderReleaseSections(artifact);
+  }
+}
+
+function buildHandoffTitle(artifact: GitHubRenderableArtifact, issueRefs: readonly GithubReference[], pullRequestRefs: readonly GithubReference[]): string {
+  const primaryRef = issueRefs[0] ?? pullRequestRefs[0];
+  if (!primaryRef) {
+    return `${artifact.workflow.displayName ?? artifact.workflow.name} handoff`;
+  }
+
+  return `${artifact.workflow.displayName ?? artifact.workflow.name} handoff for ${primaryRef.canonical}`;
+}
+
+function renderHandoffBody(artifact: GitHubRenderableArtifact, sections: readonly GithubHandoffSection[]): string {
+  const lines = [`${artifact.workflow.displayName ?? artifact.workflow.name} handoff for \`${artifact.workflow.name}\`.`, ""];
+
+  for (const section of sections) {
+    lines.push(`${section.heading}:`);
+    for (const line of section.lines) {
+      lines.push(`- ${line}`);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n").trimEnd();
+}
+
+export function renderGitHubHandoffSummary(
+  artifact: GitHubRenderableArtifact,
+  options?: { statusMapping?: GithubWorkflowStatusMapping }
+): GithubHandoffSummary {
+  const { issueRefs, pullRequestRefs } = splitGitHubRefs(artifact.source.githubRefs);
+  const sections = buildGitHubHandoffSections(artifact);
+  const summary = sections[0]?.lines[0] ?? artifact.summary;
+
+  return {
+    artifactKind: artifact.artifactKind,
+    workflow: artifact.workflow.name,
+    githubStatus: mapArtifactStatusToGitHubStatus(artifact.status, options?.statusMapping),
+    title: buildHandoffTitle(artifact, issueRefs, pullRequestRefs),
+    summary,
+    body: renderHandoffBody(artifact, sections),
+    issueRefs,
+    pullRequestRefs,
+    provenanceRefs: [...new Set([artifact.auditLink.bundlePath, ...artifact.source.inputRefs].filter((entry): entry is string => Boolean(entry)))],
+    sections
+  };
 }
 
 export function buildAuditBundle(

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   auditBundleSchema,
   designArtifactSchema,
   designRequestSchema,
+  githubHandoffSummarySchema,
   githubReferenceSchema,
   githubWorkflowStatusMappingSchema,
   getJsonSchemas,
@@ -40,6 +41,7 @@ describe("schema fixtures", () => {
     expect(() => qaRequestSchema.parse(schemaFixtures.qaRequest)).not.toThrow();
     expect(() => securityRequestSchema.parse(schemaFixtures.securityRequest)).not.toThrow();
     expect(() => githubReferenceSchema.parse(schemaFixtures.githubReference)).not.toThrow();
+    expect(() => githubHandoffSummarySchema.parse(schemaFixtures.githubHandoffSummary)).not.toThrow();
     expect(() => githubWorkflowStatusMappingSchema.parse(schemaFixtures.githubWorkflowStatusMapping)).not.toThrow();
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
@@ -67,6 +69,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.qaRequest).toBeDefined();
     expect(jsonSchemas.securityRequest).toBeDefined();
     expect(jsonSchemas.githubReference).toBeDefined();
+    expect(jsonSchemas.githubHandoffSummary).toBeDefined();
     expect(jsonSchemas.githubWorkflowStatusMapping).toBeDefined();
     expect(jsonSchemas.normalizedValidationCommand).toBeDefined();
     expect(jsonSchemas.implementationInventory).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -478,6 +478,26 @@ export const githubWorkflowStatusMappingSchema = z.object({
   reason: z.string().min(1)
 });
 
+export const githubHandoffArtifactKindSchema = z.enum(["planning-brief", "design-record", "qa-report", "release-report"]);
+
+export const githubHandoffSectionSchema = z.object({
+  heading: z.string().min(1),
+  lines: z.array(z.string().min(1)).default([])
+});
+
+export const githubHandoffSummarySchema = z.object({
+  artifactKind: githubHandoffArtifactKindSchema,
+  workflow: z.string().min(1),
+  githubStatus: githubWorkflowStatusSchema,
+  title: z.string().min(1),
+  summary: z.string().min(1),
+  body: z.string().min(1),
+  issueRefs: z.array(githubReferenceSchema).default([]),
+  pullRequestRefs: z.array(githubReferenceSchema).default([]),
+  provenanceRefs: z.array(z.string().min(1)).default([]),
+  sections: z.array(githubHandoffSectionSchema).default([])
+});
+
 export const lifecycleArtifactSourceReferenceSchema = z.object({
   sourceType: lifecycleArtifactSourceTypeSchema,
   runId: z.string().min(1).optional(),
@@ -723,6 +743,8 @@ export const schemaRegistry = {
   auditProvenance: auditProvenanceSchema,
   auditRedaction: auditRedactionSchema,
   githubReference: githubReferenceSchema,
+  githubHandoffSection: githubHandoffSectionSchema,
+  githubHandoffSummary: githubHandoffSummarySchema,
   githubWorkflowStatusMapping: githubWorkflowStatusMappingSchema,
   lifecycleArtifactWorkflowReference: lifecycleArtifactWorkflowReferenceSchema,
   lifecycleArtifactSourceReference: lifecycleArtifactSourceReferenceSchema,
@@ -1073,6 +1095,29 @@ const githubWorkflowStatusMappingFixture = {
   reason: "Successful local workflow runs map to completed GitHub handoff status."
 } as const;
 
+const githubHandoffSummaryFixture = {
+  artifactKind: "planning-brief",
+  workflow: "planning-discovery",
+  githubStatus: "completed",
+  title: "Planning handoff for H9-Foundry/AgentForge#78",
+  summary: "Planning brief scoped the next bounded workflow slice.",
+  body: [
+    "Planning handoff for `planning-discovery`.",
+    "",
+    "Summary:",
+    "- Planning brief scoped the next bounded workflow slice."
+  ].join("\n"),
+  issueRefs: [githubReferenceFixture],
+  pullRequestRefs: [],
+  provenanceRefs: [".agentops/runs/run-123/bundle.json", "docs/ROADMAP.md"],
+  sections: [
+    {
+      heading: "Summary",
+      lines: ["Planning brief scoped the next bounded workflow slice."]
+    }
+  ]
+} as const;
+
 const implementationInventoryFixture = {
   requestedTargetPaths: ["packages/cli", "packages/runtime"],
   resolvedAffectedPaths: ["packages/cli/src/index.ts", "packages/runtime/src/index.ts"],
@@ -1237,6 +1282,7 @@ export const schemaFixtures = {
   qaRequest: qaRequestFixture,
   securityRequest: securityRequestFixture,
   githubReference: githubReferenceFixture,
+  githubHandoffSummary: githubHandoffSummaryFixture,
   githubWorkflowStatusMapping: githubWorkflowStatusMappingFixture,
   normalizedValidationCommand: normalizedValidationCommandFixture,
   implementationInventory: implementationInventoryFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -25,6 +25,8 @@ import {
   designRequestSchema,
   effectivePolicySnapshotSchema,
   findingSchema,
+  githubHandoffSectionSchema,
+  githubHandoffSummarySchema,
   githubReferenceSchema,
   githubWorkflowStatusMappingSchema,
   implementationArtifactPayloadSchema,
@@ -72,6 +74,8 @@ export type AuditEntry = Infer<typeof auditEntrySchema>;
 export type AuditComponent = Infer<typeof auditComponentSchema>;
 export type AuditProvenance = Infer<typeof auditProvenanceSchema>;
 export type AuditRedaction = Infer<typeof auditRedactionSchema>;
+export type GithubHandoffSection = Infer<typeof githubHandoffSectionSchema>;
+export type GithubHandoffSummary = Infer<typeof githubHandoffSummarySchema>;
 export type GithubReference = Infer<typeof githubReferenceSchema>;
 export type GithubWorkflowStatusMapping = Infer<typeof githubWorkflowStatusMappingSchema>;
 export type LifecycleArtifactWorkflowReference = Infer<typeof lifecycleArtifactWorkflowReferenceSchema>;


### PR DESCRIPTION
## Summary
- add shared GitHub handoff-summary contracts for planning, design, QA, and release artifacts
- add deterministic audit rendering helpers that convert lifecycle artifacts into bounded GitHub-facing summaries
- update the GitHub integration maturity doc to reflect that rendering is implemented while publication remains out of scope

## Validation
- `pnpm exec vitest run packages/audit/src/index.test.ts packages/schemas/src/index.test.ts; echo EXIT:$?`
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

Closes #149