### PR TITLE
feat: ingest GitHub Actions evidence for workflow linkage

### DIFF
--- a/.changeset/github-actions-evidence-linkage.md
+++ b/.changeset/github-actions-evidence-linkage.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add deterministic local GitHub Actions evidence normalization for QA workflows and shared workflow-linkage contracts for later release-readiness use.

--- a/docs/GITHUB_INTEGRATION_MATURITY.md
+++ b/docs/GITHUB_INTEGRATION_MATURITY.md
@@ -39,6 +39,7 @@ Partially implemented now:
 - deterministic GitHub issue and PR reference normalization shared across lifecycle workflow inputs and artifacts
 - bounded local-to-GitHub status mapping primitives for later handoff and reporting work
 - deterministic GitHub handoff rendering for planning, design, QA, and release artifacts
+- deterministic ingestion of explicit local GitHub Actions/check-run evidence exports for QA workflows, using a shared normalization contract that later release workflows can reuse
 
 Not yet available:
 
@@ -53,8 +54,7 @@ Phase 2 should focus on these GitHub surfaces:
 
 1. issue and PR reference normalization across workflows
 2. bounded issue/PR comment/report handoff for planning, design, QA, and release outputs
-3. GitHub Actions evidence ingestion for QA and release workflows
-4. queue/status synchronization that remains subordinate to local workflow truth
+3. queue/status synchronization that remains subordinate to local workflow truth
 
 ## Non-Goals
 
@@ -109,5 +109,5 @@ This epic is now decomposed into:
 
 1. implemented: GitHub issue/PR reference and status normalization shared across lifecycle workflows
 2. implemented in part: bounded GitHub handoff rendering for planning, design, QA, and release artifacts
-3. next: GitHub Actions evidence ingestion for QA and release workflows
+3. implemented in part: deterministic GitHub Actions evidence ingestion for QA plus a shared normalization contract for later release workflows
 4. ongoing: support-matrix and policy guidance for GitHub-specific versus host-agnostic behavior

--- a/docs/TEST_QA_WORKFLOWS.md
+++ b/docs/TEST_QA_WORKFLOWS.md
@@ -33,13 +33,14 @@ Available now:
 - starter `qa-analyst` agent
 - `qa-report` lifecycle artifact emission
 - deterministic QA evidence normalization and allowlisted validation collection
+- deterministic ingestion of explicit local GitHub Actions/check-run evidence exports
 - audit bundle and lifecycle artifact infrastructure
 - release verification and package checks
 
 Not yet available:
 
 - additional QA workflow variants beyond `qa-review`
-- broader CI-hosted or external QA evidence ingestion
+- broader CI-hosted or network-backed QA evidence ingestion
 
 ## Recommended Initial Workflow Family
 
@@ -113,7 +114,7 @@ Deterministic responsibilities:
 
 - request validation
 - evidence collection from allowlisted local sources
-- normalization of known test outputs
+- normalization of known test outputs and explicit local GitHub Actions exports
 - artifact persistence and audit linkage
 
 Reasoning responsibilities:

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -780,6 +780,117 @@ describe("cli smoke flows", () => {
     expect(explanation.artifactKinds).toContain("qa-report");
   });
 
+  it("ingests local GitHub Actions evidence exports during qa-review", async () => {
+    const root = createGitFixture("agentops-qa-actions-");
+
+    initProject(root);
+
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Validate QA linkage to exported GitHub Actions evidence",
+        "goals:",
+        "  - Produce one planning brief for the QA workflow",
+        "constraints:",
+        "  - Keep the workflow local-first",
+        "  - Keep the workflow read-only by default"
+      ].join("\n")
+    );
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "design.yaml"),
+      [
+        `planningBriefRef: .agentops/runs/${planningRun.runId}/bundle.json`,
+        "decisionTarget: Add bounded GitHub Actions evidence linkage",
+        "pathHints:",
+        "  - packages/cli",
+        "  - packages/schemas"
+      ].join("\n")
+    );
+    const designRun = await runLocalWorkflow("architecture-design-review", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        `designRecordRef: .agentops/runs/${designRun.runId}/bundle.json`,
+        "implementationGoal: Prepare deterministic GitHub Actions evidence ingestion",
+        "approvalMode: proposal-only",
+        "targetPaths:",
+        "  - packages/cli",
+        "validationCommands:",
+        "  - pnpm test",
+        "constraints:",
+        "  - Keep the default path read-only"
+      ].join("\n")
+    );
+    const implementationRun = await runLocalWorkflow("implementation-proposal", root);
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "evidence", "github-actions-ci.json"),
+      JSON.stringify(
+        {
+          repository: "H9-Foundry/fixture",
+          workflowName: "CI",
+          workflowRunId: 12345,
+          runAttempt: 1,
+          event: "pull_request",
+          headBranch: "main",
+          headSha: "abc123",
+          status: "completed",
+          conclusion: "failure",
+          htmlUrl: "https://github.com/H9-Foundry/fixture/actions/runs/12345",
+          jobs: [
+            {
+              name: "test",
+              status: "completed",
+              conclusion: "success",
+              htmlUrl: "https://github.com/H9-Foundry/fixture/actions/runs/12345/job/1"
+            },
+            {
+              name: "lint",
+              status: "completed",
+              conclusion: "failure",
+              htmlUrl: "https://github.com/H9-Foundry/fixture/actions/runs/12345/job/2"
+            }
+          ],
+          checkRuns: []
+        },
+        null,
+        2
+      )
+    );
+
+    writeFileSync(
+      join(root, ".agentops", "requests", "qa.yaml"),
+      [
+        `targetRef: .agentops/runs/${implementationRun.runId}/bundle.json`,
+        "evidenceSources:",
+        "  - .agentops/runs/" + implementationRun.runId + "/summary.md",
+        "  - .agentops/evidence/github-actions-ci.json",
+        "executedChecks:",
+        "  - pnpm test",
+        "focusAreas:",
+        "  - release-readiness",
+        "releaseContext: candidate"
+      ].join("\n")
+    );
+
+    const qaRun = await runLocalWorkflow("qa-review", root);
+    const bundle = readJson<{
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: { coverageGaps?: string[]; releaseImpact?: string };
+      }>;
+    }>(qaRun.jsonPath);
+
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("qa-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.coverageGaps).toContain(
+      "GitHub Actions evidence still reports a failing check that needs manual review: CI / lint"
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.releaseImpact).toContain(
+      "GitHub Actions evidence still shows failing checks: CI / lint."
+    );
+  });
+
   it("rejects underspecified qa-review requests before reasoning", async () => {
     const root = createGitFixture("agentops-qa-invalid-");
 

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -175,6 +175,48 @@ describe("builtin qa evidence normalizer", () => {
       )
     );
     writeFileSync(join(root, ".agentops", "runs", "run-impl", "summary.md"), "# summary\n");
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "evidence", "github-actions-ci.json"),
+      JSON.stringify(
+        {
+          repository: "H9-Foundry/fixture",
+          workflowName: "CI",
+          workflowRunId: 12345,
+          runAttempt: 1,
+          event: "pull_request",
+          headBranch: "main",
+          headSha: "abc123",
+          status: "completed",
+          conclusion: "failure",
+          htmlUrl: "https://github.com/H9-Foundry/fixture/actions/runs/12345",
+          jobs: [
+            {
+              name: "test",
+              status: "completed",
+              conclusion: "success",
+              htmlUrl: "https://github.com/H9-Foundry/fixture/actions/runs/12345/job/1"
+            },
+            {
+              name: "lint",
+              status: "completed",
+              conclusion: "failure",
+              htmlUrl: "https://github.com/H9-Foundry/fixture/actions/runs/12345/job/2"
+            }
+          ],
+          checkRuns: [
+            {
+              name: "validate-public-packages",
+              status: "completed",
+              conclusion: "success",
+              detailsUrl: "https://github.com/H9-Foundry/fixture/actions/runs/12345/job/3"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
     mkdirSync(join(root, "packages", "app"), { recursive: true });
     writeFileSync(
       join(root, "packages", "app", "package.json"),
@@ -208,7 +250,7 @@ describe("builtin qa evidence normalizer", () => {
         workflowInputs: {
           qaRequest: {
             targetRef: ".agentops/runs/run-impl/bundle.json",
-            evidenceSources: [".agentops/runs/run-impl/summary.md"],
+            evidenceSources: [".agentops/runs/run-impl/summary.md", ".agentops/evidence/github-actions-ci.json"],
             executedChecks: ["pnpm test"],
             focusAreas: ["coverage"],
             constraints: ["Keep QA evidence collection read-only"],
@@ -229,13 +271,19 @@ describe("builtin qa evidence normalizer", () => {
 
     expect(output.metadata?.normalizedEvidenceSources).toEqual([
       ".agentops/runs/run-impl/bundle.json",
-      ".agentops/runs/run-impl/summary.md"
+      ".agentops/runs/run-impl/summary.md",
+      ".agentops/evidence/github-actions-ci.json"
     ]);
     expect(output.metadata?.referencedArtifactKinds).toContain("implementation-proposal");
     expect(output.metadata?.allowedValidationCommands).toEqual(
       expect.arrayContaining([expect.objectContaining({ command: "pnpm test", classification: "approval_required" })])
     );
     expect(output.metadata?.unrecognizedExecutedChecks).toEqual([]);
+    const githubActionsMetadata = output.metadata?.githubActions as
+      | { workflowNames?: string[]; failingChecks?: string[] }
+      | undefined;
+    expect(githubActionsMetadata?.workflowNames).toEqual(["CI"]);
+    expect(githubActionsMetadata?.failingChecks).toEqual(["CI / lint"]);
   });
 });
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -5,6 +5,7 @@ import {
   agentManifestSchema,
   agentOutputSchema,
   designArtifactSchema,
+  githubActionsEvidenceSchema,
   implementationArtifactSchema,
   implementationInventorySchema,
   qaArtifactSchema,
@@ -19,6 +20,8 @@ import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 import type {
   DesignArtifact,
   DesignRequest,
+  GithubActionsEvidence,
+  GithubActionsEvidenceNormalization,
   GithubReference,
   ImplementationArtifact,
   ImplementationInventory,
@@ -215,6 +218,72 @@ function loadBundleArtifactPayloadPaths(bundlePath: string): string[] {
 
     return [];
   });
+}
+
+function loadGitHubActionsEvidence(bundlePath: string): GithubActionsEvidence | undefined {
+  if (!existsSync(bundlePath) || !bundlePath.endsWith(".json")) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(readFileSync(bundlePath, "utf8")) as unknown;
+  const candidate = isRecord(parsed) ? { ...parsed, sourcePath: parsed.sourcePath ?? bundlePath } : parsed;
+  const result = githubActionsEvidenceSchema.safeParse(candidate);
+  return result.success ? result.data : undefined;
+}
+
+function isFailingGitHubActionsConclusion(conclusion: string | undefined): boolean {
+  return Boolean(conclusion && !["success", "neutral", "skipped"].includes(conclusion));
+}
+
+function summarizeGitHubActionsFailures(evidence: GithubActionsEvidence): string[] {
+  const failedJobs = evidence.jobs
+    .filter((job) => job.status === "completed" && isFailingGitHubActionsConclusion(job.conclusion))
+    .map((job) => `${evidence.workflowName} / ${job.name}`);
+  const failedCheckRuns = evidence.checkRuns
+    .filter((checkRun) => checkRun.status === "completed" && isFailingGitHubActionsConclusion(checkRun.conclusion))
+    .map((checkRun) => `${evidence.workflowName} / ${checkRun.name}`);
+  const runLevelFailure =
+    failedJobs.length === 0 &&
+      failedCheckRuns.length === 0 &&
+      evidence.status === "completed" &&
+      isFailingGitHubActionsConclusion(evidence.conclusion)
+      ? [`${evidence.workflowName} / workflow-run`]
+      : [];
+
+  return [...failedJobs, ...failedCheckRuns, ...runLevelFailure];
+}
+
+function normalizeGitHubActionsEvidence(
+  repoRoot: string | undefined,
+  evidenceSources: readonly string[]
+): GithubActionsEvidenceNormalization {
+  const evidence = evidenceSources.flatMap((pathValue) => {
+    if (!repoRoot) {
+      return [];
+    }
+
+    const normalized = loadGitHubActionsEvidence(join(repoRoot, pathValue));
+    return normalized ? [normalized] : [];
+  });
+  const workflowNames = [...new Set(evidence.map((entry) => entry.workflowName))];
+  const failingChecks = [...new Set(evidence.flatMap((entry) => summarizeGitHubActionsFailures(entry)))];
+  const provenanceRefs = [
+    ...new Set(
+      evidence.flatMap((entry) => [
+        entry.sourcePath,
+        entry.htmlUrl,
+        ...entry.jobs.map((job) => job.htmlUrl),
+        ...entry.checkRuns.map((checkRun) => checkRun.detailsUrl)
+      ].filter((value): value is string => Boolean(value)))
+    )
+  ];
+
+  return {
+    evidence,
+    workflowNames,
+    failingChecks,
+    provenanceRefs
+  };
 }
 
 function derivePackageScope(pathValue: string): string | undefined {
@@ -1244,6 +1313,7 @@ const qaEvidenceNormalizationAgent: RuntimeAgent = {
     const allowlistedCommands = new Set(allowedValidationCommands.map((entry) => entry.command));
     const normalizedExecutedChecks = qaRequest.executedChecks.map(normalizeRequestedCommand);
     const unrecognizedExecutedChecks = normalizedExecutedChecks.filter((command) => !allowlistedCommands.has(command));
+    const githubActions = normalizeGitHubActionsEvidence(repoRoot, normalizedEvidenceSources);
     const normalization = qaEvidenceNormalizationSchema.parse({
       targetRef: qaRequest.targetRef,
       targetType,
@@ -1253,11 +1323,12 @@ const qaEvidenceNormalizationAgent: RuntimeAgent = {
       normalizedExecutedChecks,
       unrecognizedExecutedChecks,
       affectedPackages,
-      allowedValidationCommands
+      allowedValidationCommands,
+      githubActions
     });
 
     return agentOutputSchema.parse({
-      summary: `Normalized QA evidence across ${normalization.normalizedEvidenceSources.length} source(s) and ${normalization.allowedValidationCommands.length} allowlisted validation command(s).`,
+      summary: `Normalized QA evidence across ${normalization.normalizedEvidenceSources.length} source(s), ${normalization.allowedValidationCommands.length} allowlisted validation command(s), and ${normalization.githubActions.evidence.length} GitHub Actions evidence export(s).`,
       findings: [],
       proposedActions: [],
       lifecycleArtifacts: [],
@@ -1314,16 +1385,25 @@ const qaAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const evidenceMetadata = isRecord(stateSlice.agentResults?.evidence?.metadata) ? stateSlice.agentResults.evidence.metadata : {};
-    const normalizedEvidenceSources = asStringArray(evidenceMetadata.normalizedEvidenceSources);
-    const normalizedExecutedChecks = asStringArray(evidenceMetadata.normalizedExecutedChecks);
+    const evidenceMetadata = qaEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence = evidenceMetadata.success ? evidenceMetadata.data : undefined;
+    const normalizedEvidenceSources = normalizedEvidence?.normalizedEvidenceSources ?? [];
+    const normalizedExecutedChecks = normalizedEvidence?.normalizedExecutedChecks ?? [];
     const normalizedFocusAreas = asStringArray(intakeMetadata.focusAreas);
     const normalizedConstraints = asStringArray(intakeMetadata.constraints);
-    const missingEvidenceSources = asStringArray(evidenceMetadata.missingEvidenceSources);
-    const unrecognizedExecutedChecks = asStringArray(evidenceMetadata.unrecognizedExecutedChecks);
+    const missingEvidenceSources = normalizedEvidence?.missingEvidenceSources ?? [];
+    const unrecognizedExecutedChecks = normalizedEvidence?.unrecognizedExecutedChecks ?? [];
+    const normalizedGithubActions: GithubActionsEvidenceNormalization = normalizedEvidence
+      ? normalizedEvidence.githubActions
+      : {
+          evidence: [],
+          workflowNames: [],
+          failingChecks: [],
+          provenanceRefs: []
+        };
     const targetType =
-      typeof evidenceMetadata.targetType === "string"
-        ? evidenceMetadata.targetType
+      normalizedEvidence?.targetType
+        ? normalizedEvidence.targetType
         : typeof intakeMetadata.targetType === "string"
           ? intakeMetadata.targetType
           : "local-reference";
@@ -1362,14 +1442,26 @@ const qaAnalystAgent: RuntimeAgent = {
       ...missingEvidenceSources.map((pathValue) => `Referenced QA evidence is missing: ${pathValue}`),
       ...(focusAreas.includes("coverage") ? ["Coverage evidence still needs deterministic normalization before it can be promoted to an official QA signal."] : []),
       ...(executedChecks.length === 0 ? ["No executed validation checks were recorded in the request."] : []),
-      ...unrecognizedExecutedChecks.map((command) => `Executed check is outside the bounded allowlist and still needs manual interpretation: ${command}`)
+      ...unrecognizedExecutedChecks.map((command) => `Executed check is outside the bounded allowlist and still needs manual interpretation: ${command}`),
+      ...normalizedGithubActions.failingChecks.map(
+        (checkName) => `GitHub Actions evidence still reports a failing check that needs manual review: ${checkName}`
+      )
     ];
     const recommendedNextChecks = [
       ...executedChecks.map((command) => `Review the recorded output for \`${command}\` before promotion.`),
       ...focusAreas.map((focusArea) => `Confirm whether ${focusArea} needs additional deterministic QA evidence.`),
+      ...normalizedGithubActions.workflowNames.map(
+        (workflowName) => `Review the exported GitHub Actions evidence for workflow \`${workflowName}\` before promotion.`
+      ),
       ...(normalizedConstraints.length > 0 ? [`Keep QA follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
     ];
     const summary = `QA report prepared for ${qaRequest.targetRef}.`;
+    const releaseImpactBase =
+      qaRequest.releaseContext === "blocking"
+        ? "release-blocking QA findings require resolution before promotion."
+        : qaRequest.releaseContext === "candidate"
+          ? "candidate release still requires explicit QA review before promotion."
+          : "no release context was supplied; QA output remains advisory.";
     const qaReport = qaArtifactSchema.parse({
       ...buildArtifactEnvelopeBase(
         state,
@@ -1395,11 +1487,9 @@ const qaAnalystAgent: RuntimeAgent = {
             ? recommendedNextChecks
             : ["Capture additional bounded QA evidence before promotion."],
         releaseImpact:
-          qaRequest.releaseContext === "blocking"
-            ? "release-blocking QA findings require resolution before promotion."
-            : qaRequest.releaseContext === "candidate"
-              ? "candidate release still requires explicit QA review before promotion."
-              : "no release context was supplied; QA output remains advisory."
+          normalizedGithubActions.failingChecks.length > 0
+            ? `${releaseImpactBase} GitHub Actions evidence still shows failing checks: ${normalizedGithubActions.failingChecks.join(", ")}.`
+            : releaseImpactBase
       }
     });
 
@@ -1418,7 +1508,8 @@ const qaAnalystAgent: RuntimeAgent = {
           evidenceSources,
           executedChecks,
           focusAreas,
-          constraints: normalizedConstraints
+          constraints: normalizedConstraints,
+          githubActions: normalizedGithubActions
         },
         synthesizedAssessment: {
           releaseContext: qaRequest.releaseContext,

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -5,6 +5,8 @@ import {
   auditBundleSchema,
   designArtifactSchema,
   designRequestSchema,
+  githubActionsEvidenceNormalizationSchema,
+  githubActionsEvidenceSchema,
   githubHandoffSummarySchema,
   githubReferenceSchema,
   githubWorkflowStatusMappingSchema,
@@ -41,6 +43,10 @@ describe("schema fixtures", () => {
     expect(() => qaRequestSchema.parse(schemaFixtures.qaRequest)).not.toThrow();
     expect(() => securityRequestSchema.parse(schemaFixtures.securityRequest)).not.toThrow();
     expect(() => githubReferenceSchema.parse(schemaFixtures.githubReference)).not.toThrow();
+    expect(() => githubActionsEvidenceSchema.parse(schemaFixtures.githubActionsEvidence)).not.toThrow();
+    expect(() =>
+      githubActionsEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization.githubActions)
+    ).not.toThrow();
     expect(() => githubHandoffSummarySchema.parse(schemaFixtures.githubHandoffSummary)).not.toThrow();
     expect(() => githubWorkflowStatusMappingSchema.parse(schemaFixtures.githubWorkflowStatusMapping)).not.toThrow();
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
@@ -69,6 +75,8 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.qaRequest).toBeDefined();
     expect(jsonSchemas.securityRequest).toBeDefined();
     expect(jsonSchemas.githubReference).toBeDefined();
+    expect(jsonSchemas.githubActionsEvidence).toBeDefined();
+    expect(jsonSchemas.githubActionsEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.githubHandoffSummary).toBeDefined();
     expect(jsonSchemas.githubWorkflowStatusMapping).toBeDefined();
     expect(jsonSchemas.normalizedValidationCommand).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -28,6 +28,17 @@ export const lifecycleArtifactSourceTypeSchema = z.enum(["workflow-run", "manual
 export const lifecycleArtifactStatusSchema = z.enum(["draft", "complete", "superseded", "cancelled"]);
 export const githubReferenceKindSchema = z.enum(["issue", "pull_request"]);
 export const githubWorkflowStatusSchema = z.enum(["planned", "in_progress", "blocked", "completed", "failed"]);
+export const githubActionsRunStatusSchema = z.enum(["queued", "in_progress", "completed"]);
+export const githubActionsConclusionSchema = z.enum([
+  "success",
+  "failure",
+  "neutral",
+  "cancelled",
+  "skipped",
+  "timed_out",
+  "action_required",
+  "stale"
+]);
 export const catalogDomainSchema = z.enum([
   "foundation",
   "plan",
@@ -352,6 +363,45 @@ export const implementationInventorySchema = z.object({
   discoveredValidationCommands: z.array(normalizedValidationCommandSchema).default([])
 });
 
+export const githubActionsJobEvidenceSchema = z.object({
+  name: z.string().min(1),
+  status: githubActionsRunStatusSchema,
+  conclusion: githubActionsConclusionSchema.optional(),
+  htmlUrl: z.string().url().optional(),
+  startedAt: z.string().datetime().optional(),
+  completedAt: z.string().datetime().optional()
+});
+
+export const githubActionsCheckRunEvidenceSchema = z.object({
+  name: z.string().min(1),
+  status: githubActionsRunStatusSchema,
+  conclusion: githubActionsConclusionSchema.optional(),
+  detailsUrl: z.string().url().optional()
+});
+
+export const githubActionsEvidenceSchema = z.object({
+  sourcePath: z.string().min(1).optional(),
+  repository: z.string().min(1),
+  workflowName: z.string().min(1),
+  workflowRunId: z.number().int().positive(),
+  runAttempt: z.number().int().positive().default(1),
+  event: z.string().min(1).optional(),
+  headBranch: z.string().min(1).optional(),
+  headSha: z.string().min(1).optional(),
+  status: githubActionsRunStatusSchema,
+  conclusion: githubActionsConclusionSchema.optional(),
+  htmlUrl: z.string().url(),
+  jobs: z.array(githubActionsJobEvidenceSchema).default([]),
+  checkRuns: z.array(githubActionsCheckRunEvidenceSchema).default([])
+});
+
+export const githubActionsEvidenceNormalizationSchema = z.object({
+  evidence: z.array(githubActionsEvidenceSchema).default([]),
+  workflowNames: z.array(z.string().min(1)).default([]),
+  failingChecks: z.array(z.string().min(1)).default([]),
+  provenanceRefs: z.array(z.string().min(1)).default([])
+});
+
 export const qaEvidenceNormalizationSchema = z.object({
   targetRef: z.string().min(1),
   targetType: z.enum(["artifact-bundle", "validation-output", "local-reference"]),
@@ -361,7 +411,13 @@ export const qaEvidenceNormalizationSchema = z.object({
   normalizedExecutedChecks: z.array(z.string().min(1)).default([]),
   unrecognizedExecutedChecks: z.array(z.string().min(1)).default([]),
   affectedPackages: z.array(z.string().min(1)).default([]),
-  allowedValidationCommands: z.array(normalizedValidationCommandSchema).default([])
+  allowedValidationCommands: z.array(normalizedValidationCommandSchema).default([]),
+  githubActions: githubActionsEvidenceNormalizationSchema.default({
+    evidence: [],
+    workflowNames: [],
+    failingChecks: [],
+    provenanceRefs: []
+  })
 });
 
 export const securityEvidenceNormalizationSchema = z.object({
@@ -743,6 +799,10 @@ export const schemaRegistry = {
   auditProvenance: auditProvenanceSchema,
   auditRedaction: auditRedactionSchema,
   githubReference: githubReferenceSchema,
+  githubActionsJobEvidence: githubActionsJobEvidenceSchema,
+  githubActionsCheckRunEvidence: githubActionsCheckRunEvidenceSchema,
+  githubActionsEvidence: githubActionsEvidenceSchema,
+  githubActionsEvidenceNormalization: githubActionsEvidenceNormalizationSchema,
   githubHandoffSection: githubHandoffSectionSchema,
   githubHandoffSummary: githubHandoffSummarySchema,
   githubWorkflowStatusMapping: githubWorkflowStatusMappingSchema,
@@ -1095,6 +1155,42 @@ const githubWorkflowStatusMappingFixture = {
   reason: "Successful local workflow runs map to completed GitHub handoff status."
 } as const;
 
+const githubActionsEvidenceFixture = {
+  sourcePath: ".agentops/evidence/github-actions-ci.json",
+  repository: "H9-Foundry/AgentForge",
+  workflowName: "CI",
+  workflowRunId: 123456789,
+  runAttempt: 1,
+  event: "pull_request",
+  headBranch: "main",
+  headSha: "caf36447a49fc6e9fc308c34b98424958237aa1e",
+  status: "completed",
+  conclusion: "failure",
+  htmlUrl: "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789",
+  jobs: [
+    {
+      name: "test",
+      status: "completed",
+      conclusion: "success",
+      htmlUrl: "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789/job/1"
+    },
+    {
+      name: "lint",
+      status: "completed",
+      conclusion: "failure",
+      htmlUrl: "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789/job/2"
+    }
+  ],
+  checkRuns: [
+    {
+      name: "validate-public-packages",
+      status: "completed",
+      conclusion: "success",
+      detailsUrl: "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789/job/3"
+    }
+  ]
+} as const;
+
 const githubHandoffSummaryFixture = {
   artifactKind: "planning-brief",
   workflow: "planning-discovery",
@@ -1153,7 +1249,19 @@ const qaEvidenceNormalizationFixture = {
       classification: "approval_required",
       reason: "Discovered from a bounded repository script; execution would still require approval."
     }
-  ]
+  ],
+  githubActions: {
+    evidence: [githubActionsEvidenceFixture],
+    workflowNames: ["CI"],
+    failingChecks: ["CI / lint"],
+    provenanceRefs: [
+      ".agentops/evidence/github-actions-ci.json",
+      "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789",
+      "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789/job/1",
+      "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789/job/2",
+      "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789/job/3"
+    ]
+  }
 } as const;
 
 const securityEvidenceNormalizationFixture = {
@@ -1282,6 +1390,7 @@ export const schemaFixtures = {
   qaRequest: qaRequestFixture,
   securityRequest: securityRequestFixture,
   githubReference: githubReferenceFixture,
+  githubActionsEvidence: githubActionsEvidenceFixture,
   githubHandoffSummary: githubHandoffSummaryFixture,
   githubWorkflowStatusMapping: githubWorkflowStatusMappingFixture,
   normalizedValidationCommand: normalizedValidationCommandFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -25,6 +25,10 @@ import {
   designRequestSchema,
   effectivePolicySnapshotSchema,
   findingSchema,
+  githubActionsCheckRunEvidenceSchema,
+  githubActionsEvidenceNormalizationSchema,
+  githubActionsEvidenceSchema,
+  githubActionsJobEvidenceSchema,
   githubHandoffSectionSchema,
   githubHandoffSummarySchema,
   githubReferenceSchema,
@@ -74,6 +78,10 @@ export type AuditEntry = Infer<typeof auditEntrySchema>;
 export type AuditComponent = Infer<typeof auditComponentSchema>;
 export type AuditProvenance = Infer<typeof auditProvenanceSchema>;
 export type AuditRedaction = Infer<typeof auditRedactionSchema>;
+export type GithubActionsJobEvidence = Infer<typeof githubActionsJobEvidenceSchema>;
+export type GithubActionsCheckRunEvidence = Infer<typeof githubActionsCheckRunEvidenceSchema>;
+export type GithubActionsEvidence = Infer<typeof githubActionsEvidenceSchema>;
+export type GithubActionsEvidenceNormalization = Infer<typeof githubActionsEvidenceNormalizationSchema>;
 export type GithubHandoffSection = Infer<typeof githubHandoffSectionSchema>;
 export type GithubHandoffSummary = Infer<typeof githubHandoffSummarySchema>;
 export type GithubReference = Infer<typeof githubReferenceSchema>;


### PR DESCRIPTION
## Summary
- add shared GitHub Actions evidence contracts for deterministic local workflow linkage
- ingest explicit local GitHub Actions/check-run exports in the QA evidence normalizer and surface failing checks in `qa-report`
- update GitHub and QA workflow docs to reflect local exported Actions evidence support without adding any network-backed GitHub dependency

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts; echo EXIT:$?`
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo evaluator flow covering `planning-discovery`, `architecture-design-review`, `implementation-proposal`, and `qa-review` with a local GitHub Actions evidence export

Closes #156