### PR TITLE
feat: emit release readiness reports

### DIFF
--- a/.changeset/release-analyst-report.md
+++ b/.changeset/release-analyst-report.md
@@ -1,0 +1,5 @@
+---
+"@h9-foundry/agentforge-cli": patch
+---
+
+Emit a bounded `release-report` artifact from the local `release-readiness` workflow through the new `release-analyst` reasoning step.

--- a/agents/release-analyst/agent.manifest.json
+++ b/agents/release-analyst/agent.manifest.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "name": "release-analyst",
+  "displayName": "Release Analyst",
+  "category": "release",
+  "runtime": {
+    "minVersion": "0.1.0",
+    "kind": "reasoning"
+  },
+  "permissions": {
+    "model": true,
+    "network": false,
+    "tools": [],
+    "readPaths": ["**/*"],
+    "writePaths": []
+  },
+  "inputs": ["workflowInputs", "repo", "agentResults"],
+  "outputs": ["lifecycleArtifacts"],
+  "contextPolicy": {
+    "sections": ["workflowInputs", "repo", "agentResults"],
+    "minimalContext": true
+  },
+  "catalog": {
+    "domain": "release",
+    "supportLevel": "internal",
+    "maturity": "mvp",
+    "trustScope": "official-core-only"
+  },
+  "trust": {
+    "tier": "core",
+    "source": "official",
+    "reviewed": true
+  }
+}

--- a/agents/release-analyst/package.json
+++ b/agents/release-analyst/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@h9-foundry/agentforge-agent-release-analyst",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "agent.manifest.json"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@h9-foundry/agentforge-schemas": "workspace:*",
+    "@h9-foundry/agentforge-sdk": "workspace:*",
+    "@h9-foundry/agentforge-shared-types": "workspace:*"
+  }
+}

--- a/agents/release-analyst/src/index.test.ts
+++ b/agents/release-analyst/src/index.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+
+import { releaseAnalystAgent } from "./index.js";
+
+describe("release analyst agent", () => {
+  it("emits a release-report artifact from validated inputs", async () => {
+    const output = await releaseAnalystAgent.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-release",
+        workflow: "release-readiness",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: ["packages"],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          releaseRequest: {
+            releaseScope: "Prepare the next release candidate",
+            versionTargets: [{ name: "@h9-foundry/agentforge-cli", version: "0.7.0" }],
+            qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+            securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+            evidenceSources: [".agentops/runs/run-security/summary.md"],
+            constraints: ["Keep the workflow read-only"]
+          },
+          releaseIssueRefs: ["#150"],
+          releaseGithubRefs: [],
+          requestFile: ".agentops/requests/release.yaml"
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+              securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+              evidenceSources: [".agentops/runs/run-security/summary.md"],
+              constraints: ["Keep the workflow read-only"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.lifecycleArtifacts).toHaveLength(1);
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("release-report");
+    if (!artifact || artifact.artifactKind !== "release-report") {
+      throw new Error("Expected release-report artifact.");
+    }
+
+    expect(artifact.payload.releaseScope).toBe("Prepare the next release candidate");
+    expect(artifact.payload.readinessStatus).toBe("ready");
+    expect(artifact.payload.verificationChecks).toHaveLength(3);
+    expect(artifact.payload.publishingPlan[0]).toContain("QA and security evidence");
+  });
+});

--- a/agents/release-analyst/src/index.ts
+++ b/agents/release-analyst/src/index.ts
@@ -1,0 +1,221 @@
+import { agentManifestSchema, agentOutputSchema, releaseArtifactSchema } from "@h9-foundry/agentforge-schemas";
+import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
+import type { GithubReference, ReleaseArtifact, ReleaseRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: string): T | undefined {
+  if (!isRecord(stateSlice.workflowInputs)) {
+    return undefined;
+  }
+
+  return stateSlice.workflowInputs[key] as T | undefined;
+}
+
+function buildArtifactEnvelopeBase(
+  state: WorkflowStateEnvelope,
+  summary: string,
+  inputRefs: readonly string[],
+  issueRefs: readonly string[],
+  githubRefs: readonly GithubReference[]
+) {
+  return {
+    schemaVersion: state.version,
+    workflow: {
+      name: state.workflow,
+      displayName: "Release Readiness"
+    },
+    source: {
+      sourceType: "workflow-run" as const,
+      runId: state.runId,
+      inputRefs: [...inputRefs],
+      issueRefs: [...issueRefs],
+      githubRefs: [...githubRefs]
+    },
+    status: "complete" as const,
+    generatedAt: new Date().toISOString(),
+    repo: {
+      root: state.repo.root,
+      name: state.repo.name,
+      branch: state.repo.branch
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" as const : "local" as const,
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
+    },
+    auditLink: {
+      entryIds: [],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary
+  };
+}
+
+export const manifest = agentManifestSchema.parse({
+  version: 1,
+  name: "release-analyst",
+  displayName: "Release Analyst",
+  category: "release",
+  runtime: {
+    minVersion: "0.1.0",
+    kind: "reasoning"
+  },
+  permissions: {
+    model: true,
+    network: false,
+    tools: [],
+    readPaths: ["**/*"],
+    writePaths: []
+  },
+  inputs: ["workflowInputs", "repo", "agentResults"],
+  outputs: ["lifecycleArtifacts"],
+  contextPolicy: {
+    sections: ["workflowInputs", "repo", "agentResults"],
+    minimalContext: true
+  },
+  catalog: {
+    domain: "release",
+    supportLevel: "internal",
+    maturity: "mvp",
+    trustScope: "official-core-only"
+  },
+  trust: {
+    tier: "core",
+    source: "official",
+    reviewed: true
+  }
+});
+
+export const releaseAnalystAgent: RuntimeAgent = {
+  manifest,
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const releaseRequest = getWorkflowInput<ReleaseRequest>(stateSlice, "releaseRequest");
+    const releaseIssueRefs = getWorkflowInput<string[]>(stateSlice, "releaseIssueRefs") ?? [];
+    const releaseGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "releaseGithubRefs") ?? [];
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!releaseRequest) {
+      throw new Error("release-readiness requires validated release inputs before release analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const qaReportRefs = asStringArray(intakeMetadata.qaReportRefs).length > 0
+      ? asStringArray(intakeMetadata.qaReportRefs)
+      : releaseRequest.qaReportRefs;
+    const securityReportRefs = asStringArray(intakeMetadata.securityReportRefs).length > 0
+      ? asStringArray(intakeMetadata.securityReportRefs)
+      : releaseRequest.securityReportRefs;
+    const evidenceSources = asStringArray(intakeMetadata.evidenceSources).length > 0
+      ? asStringArray(intakeMetadata.evidenceSources)
+      : releaseRequest.evidenceSources;
+    const constraints = asStringArray(intakeMetadata.constraints);
+    const allEvidenceRefs = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
+    const verificationChecks = [
+      {
+        name: "qa-report-refs",
+        status: qaReportRefs.length > 0 ? "passed" : "skipped",
+        detail: qaReportRefs.length > 0
+          ? `Using ${qaReportRefs.length} validated QA report reference(s).`
+          : "No QA report references were supplied."
+      },
+      {
+        name: "security-report-refs",
+        status: securityReportRefs.length > 0 ? "passed" : "skipped",
+        detail: securityReportRefs.length > 0
+          ? `Using ${securityReportRefs.length} validated security report reference(s).`
+          : "No security report references were supplied."
+      },
+      {
+        name: "local-release-evidence",
+        status: evidenceSources.length > 0 ? "passed" : "skipped",
+        detail: evidenceSources.length > 0
+          ? `Using ${evidenceSources.length} bounded local release evidence source(s).`
+          : "No additional local release evidence sources were supplied."
+      }
+    ] as const;
+    const readinessStatus =
+      qaReportRefs.length > 0 && securityReportRefs.length > 0
+        ? "ready"
+        : qaReportRefs.length > 0 || securityReportRefs.length > 0
+          ? "partial"
+          : "blocked";
+    const summary = `Release report prepared for ${releaseRequest.releaseScope}.`;
+    const publishingPlan = [
+      "Review the bounded QA and security evidence before invoking any publish or promotion step.",
+      "Run `agentforge release check --json` and `agentforge release verify --json` before any release cut.",
+      "Keep trusted publishing and tag or publish actions outside this default read-only workflow path."
+    ];
+    const rollbackNotes = [
+      "Use the release report to decide whether to pause or defer promotion before any publish step.",
+      "If readiness remains partial or blocked, keep the current version set unchanged and resolve evidence gaps first."
+    ];
+    const externalDependencies = [
+      ...(qaReportRefs.length > 0 ? ["Validated QA report inputs remain available for reviewer inspection."] : []),
+      ...(securityReportRefs.length > 0 ? ["Validated security report inputs remain available for reviewer inspection."] : [])
+    ];
+    const releaseReport = releaseArtifactSchema.parse({
+      ...buildArtifactEnvelopeBase(
+        state,
+        summary,
+        [requestFile ?? ".agentops/requests/release.yaml", ...allEvidenceRefs],
+        releaseIssueRefs,
+        releaseGithubRefs
+      ),
+      artifactKind: "release-report",
+      lifecycleDomain: "release",
+      payload: {
+        releaseScope: releaseRequest.releaseScope,
+        versionTargets: releaseRequest.versionTargets,
+        readinessStatus,
+        verificationChecks: verificationChecks.map((check) => ({ ...check })),
+        publishingPlan,
+        trustStatus: "trusted-publishing-reviewed-separately",
+        publishedPackages: [],
+        tagRefs: [],
+        provenanceRefs: allEvidenceRefs,
+        rollbackNotes,
+        externalDependencies
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [releaseReport satisfies ReleaseArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.77,
+      metadata: {
+        deterministicInputs: {
+          versionTargets: releaseRequest.versionTargets,
+          qaReportRefs,
+          securityReportRefs,
+          evidenceSources,
+          constraints
+        },
+        synthesizedAssessment: {
+          readinessStatus,
+          publishingPlan,
+          rollbackNotes
+        }
+      }
+    });
+  }
+};
+
+export default releaseAnalystAgent;

--- a/agents/release-analyst/tsconfig.json
+++ b/agents/release-analyst/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../../packages/schemas" }, { "path": "../../packages/sdk" }, { "path": "../../packages/shared-types" }]
+}

--- a/docs/RELEASE_CICD_WORKFLOWS.md
+++ b/docs/RELEASE_CICD_WORKFLOWS.md
@@ -35,10 +35,10 @@ Available now:
 - package/version verification
 - audit and lifecycle artifact infrastructure
 - bounded `release-readiness` request validation and workflow asset scaffolding
+- bounded `release-report` artifact emission from the local `release-readiness` workflow
 
 Not yet available:
 
-- a release-candidate lifecycle artifact emitted by the runtime
 - explicit CI evidence ingestion into a release workflow
 - support for broader host-agnostic pipeline orchestration
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1283,11 +1283,27 @@ describe("cli smoke flows", () => {
     const releaseRun = await runLocalWorkflow("release-readiness", root);
 
     expect(releaseRun.status).toBe("success");
-    expect(releaseRun.artifactCount).toBe(0);
+    expect(releaseRun.artifactKinds).toContain("release-report");
 
-    const bundle = readJson<{ workflow: string; lifecycleArtifacts: Array<{ artifactKind: string }> }>(releaseRun.jsonPath);
+    const bundle = readJson<{
+      workflow: string;
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: {
+          releaseScope?: string;
+          readinessStatus?: string;
+          verificationChecks?: Array<{ name: string; status: string }>;
+        };
+      }>;
+    }>(releaseRun.jsonPath);
     expect(bundle.workflow).toBe("release-readiness");
-    expect(bundle.lifecycleArtifacts).toHaveLength(0);
+    expect(bundle.lifecycleArtifacts).toHaveLength(1);
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("release-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.releaseScope).toBe("Prepare the 0.7.0 candidate for maintainer review");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.readinessStatus).toBe("ready");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.verificationChecks?.map((check) => check.name)).toEqual(
+      expect.arrayContaining(["qa-report-refs", "security-report-refs", "local-release-evidence"])
+    );
   });
 
   it("propagates normalized GitHub references through downstream lifecycle artifacts", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -295,6 +295,10 @@ nodes:
     kind: deterministic
     agent: release-intake
     outputs_to: agentResults.intake
+  - id: release
+    kind: reasoning
+    agent: release-analyst
+    outputs_to: agentResults.release
   - id: report
     kind: report
     outputs_to: reports.final

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -11,6 +11,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  releaseArtifactSchema,
   releaseRequestSchema,
   securityArtifactSchema,
   securityEvidenceNormalizationSchema,
@@ -33,6 +34,7 @@ import type {
   QaArtifact,
   QaEvidenceNormalization,
   QaRequest,
+  ReleaseArtifact,
   ReleaseRequest,
   SecurityArtifact,
   SecurityEvidenceNormalization,
@@ -1025,6 +1027,158 @@ const releaseIntakeAgent: RuntimeAgent = {
         releaseGithubRefs,
         evidenceSourceCount:
           releaseRequest.qaReportRefs.length + releaseRequest.securityReportRefs.length + releaseRequest.evidenceSources.length
+      }
+    });
+  }
+};
+
+const releaseAnalystAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "release-analyst",
+    displayName: "Release Analyst",
+    category: "release",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "reasoning"
+    },
+    permissions: {
+      model: true,
+      network: false,
+      tools: [],
+      readPaths: ["**/*"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "agentResults"],
+    outputs: ["lifecycleArtifacts"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "release",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const releaseRequest = getWorkflowInput<ReleaseRequest>(stateSlice, "releaseRequest");
+    const releaseIssueRefs = getWorkflowInput<string[]>(stateSlice, "releaseIssueRefs") ?? [];
+    const releaseGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "releaseGithubRefs") ?? [];
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!releaseRequest) {
+      throw new Error("release-readiness requires validated release inputs before release analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const qaReportRefs = asStringArray(intakeMetadata.qaReportRefs).length > 0
+      ? asStringArray(intakeMetadata.qaReportRefs)
+      : releaseRequest.qaReportRefs;
+    const securityReportRefs = asStringArray(intakeMetadata.securityReportRefs).length > 0
+      ? asStringArray(intakeMetadata.securityReportRefs)
+      : releaseRequest.securityReportRefs;
+    const evidenceSources = asStringArray(intakeMetadata.evidenceSources).length > 0
+      ? asStringArray(intakeMetadata.evidenceSources)
+      : releaseRequest.evidenceSources;
+    const constraints = asStringArray(intakeMetadata.constraints);
+    const allEvidenceRefs = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
+    const verificationChecks = [
+      {
+        name: "qa-report-refs",
+        status: qaReportRefs.length > 0 ? "passed" : "skipped",
+        detail: qaReportRefs.length > 0
+          ? `Using ${qaReportRefs.length} validated QA report reference(s).`
+          : "No QA report references were supplied."
+      },
+      {
+        name: "security-report-refs",
+        status: securityReportRefs.length > 0 ? "passed" : "skipped",
+        detail: securityReportRefs.length > 0
+          ? `Using ${securityReportRefs.length} validated security report reference(s).`
+          : "No security report references were supplied."
+      },
+      {
+        name: "local-release-evidence",
+        status: evidenceSources.length > 0 ? "passed" : "skipped",
+        detail: evidenceSources.length > 0
+          ? `Using ${evidenceSources.length} bounded local release evidence source(s).`
+          : "No additional local release evidence sources were supplied."
+      }
+    ] as const;
+    const readinessStatus =
+      qaReportRefs.length > 0 && securityReportRefs.length > 0
+        ? "ready"
+        : qaReportRefs.length > 0 || securityReportRefs.length > 0
+          ? "partial"
+          : "blocked";
+    const summary = `Release report prepared for ${releaseRequest.releaseScope}.`;
+    const publishingPlan = [
+      "Review the bounded QA and security evidence before invoking any publish or promotion step.",
+      "Run `agentforge release check --json` and `agentforge release verify --json` before any release cut.",
+      "Keep trusted publishing and tag or publish actions outside this default read-only workflow path."
+    ];
+    const rollbackNotes = [
+      "Use the release report to decide whether to pause or defer promotion before any publish step.",
+      "If readiness remains partial or blocked, keep the current version set unchanged and resolve evidence gaps first."
+    ];
+    const externalDependencies = [
+      ...(qaReportRefs.length > 0 ? ["Validated QA report inputs remain available for reviewer inspection."] : []),
+      ...(securityReportRefs.length > 0 ? ["Validated security report inputs remain available for reviewer inspection."] : [])
+    ];
+    const releaseReport = releaseArtifactSchema.parse({
+      ...buildLifecycleArtifactEnvelopeBase(
+        state,
+        "Release Readiness",
+        summary,
+        [requestFile ?? ".agentops/requests/release.yaml", ...allEvidenceRefs],
+        releaseIssueRefs,
+        releaseGithubRefs
+      ),
+      artifactKind: "release-report",
+      lifecycleDomain: "release",
+      payload: {
+        releaseScope: releaseRequest.releaseScope,
+        versionTargets: releaseRequest.versionTargets,
+        readinessStatus,
+        verificationChecks: verificationChecks.map((check) => ({ ...check })),
+        publishingPlan,
+        trustStatus: "trusted-publishing-reviewed-separately",
+        publishedPackages: [],
+        tagRefs: [],
+        provenanceRefs: allEvidenceRefs,
+        rollbackNotes,
+        externalDependencies
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [releaseReport satisfies ReleaseArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.77,
+      metadata: {
+        deterministicInputs: {
+          versionTargets: releaseRequest.versionTargets,
+          qaReportRefs,
+          securityReportRefs,
+          evidenceSources,
+          constraints
+        },
+        synthesizedAssessment: {
+          readinessStatus,
+          publishingPlan,
+          rollbackNotes
+        }
       }
     });
   }
@@ -2247,6 +2401,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["qa-intake", qaIntakeAgent],
     ["security-intake", securityIntakeAgent],
     ["release-intake", releaseIntakeAgent],
+    ["release-analyst", releaseAnalystAgent],
     ["security-evidence-normalizer", securityEvidenceNormalizationAgent],
     ["security-analyst", securityAnalystAgent],
     ["qa-evidence-normalizer", qaEvidenceNormalizationAgent],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,6 +150,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-types
 
+  agents/release-analyst:
+    dependencies:
+      '@h9-foundry/agentforge-schemas':
+        specifier: workspace:*
+        version: link:../../packages/schemas
+      '@h9-foundry/agentforge-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@h9-foundry/agentforge-shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
+
   agents/security-analyst:
     dependencies:
       '@h9-foundry/agentforge-schemas':


### PR DESCRIPTION
## Summary
- add the bounded `release-analyst` starter agent and official starter-agent package
- update `release-readiness` to emit a structured `release-report` lifecycle artifact
- keep release readiness read-only and separate from any publish or promotion orchestration

## Validation
- `pnpm exec vitest run agents/release-analyst/src/index.test.ts packages/cli/src/index.test.ts packages/shared-types/src/index.test.ts`
- `pnpm typecheck`
- `pnpm build:packages`
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm build`
- `node packages/cli/dist/bin.js run pr-review --json`

## Residual Risk
- `explain last-run --json` still reproduced as stale during validation, so #191 has been reopened and this PR does not promote the release family as official.

Closes #150