### PR TITLE
feat: normalize release readiness state

### DIFF
--- a/.agentops/workflows/release-readiness.yaml
+++ b/.agentops/workflows/release-readiness.yaml
@@ -12,6 +12,14 @@ nodes:
     kind: deterministic
     agent: release-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: release-evidence-normalizer
+    outputs_to: agentResults.evidence
+  - id: release
+    kind: reasoning
+    agent: release-analyst
+    outputs_to: agentResults.release
   - id: report
     kind: report
     outputs_to: reports.final

--- a/.changeset/release-state-normalization.md
+++ b/.changeset/release-state-normalization.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add deterministic release-state normalization and approval-classified publish or promotion mediation for the local `release-readiness` workflow.

--- a/agents/release-analyst/src/index.test.ts
+++ b/agents/release-analyst/src/index.test.ts
@@ -65,6 +65,44 @@ describe("release analyst agent", () => {
               evidenceSources: [".agentops/runs/run-security/summary.md"],
               constraints: ["Keep the workflow read-only"]
             }
+          },
+          evidence: {
+            metadata: {
+              qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+              securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+              normalizedEvidenceSources: [
+                ".agentops/runs/run-qa/bundle.json",
+                ".agentops/runs/run-security/bundle.json",
+                ".agentops/runs/run-security/summary.md"
+              ],
+              missingEvidenceSources: [],
+              versionResolutions: [
+                {
+                  name: "@h9-foundry/agentforge-cli",
+                  targetVersion: "0.7.0",
+                  currentVersion: "0.6.0",
+                  status: "pending-version-bump"
+                }
+              ],
+              localReadinessChecks: [
+                { name: "qa-report-refs", status: "passed", detail: "Using 1 validated QA report reference(s)." },
+                { name: "security-report-refs", status: "passed", detail: "Using 1 validated security report reference(s)." },
+                { name: "workspace-version-targets", status: "passed", detail: "Resolved 1 workspace version target(s)." }
+              ],
+              readinessStatus: "ready",
+              approvalRecommendations: [
+                {
+                  action: "publish-packages",
+                  classification: "approval_required",
+                  reason: "Package publication remains outside the default read-only workflow path and needs explicit release approval."
+                }
+              ],
+              provenanceRefs: [
+                ".agentops/runs/run-qa/bundle.json",
+                ".agentops/runs/run-security/bundle.json",
+                "packages/cli/package.json"
+              ]
+            }
           }
         }
       } as never,
@@ -82,6 +120,13 @@ describe("release analyst agent", () => {
     expect(artifact.payload.releaseScope).toBe("Prepare the next release candidate");
     expect(artifact.payload.readinessStatus).toBe("ready");
     expect(artifact.payload.verificationChecks).toHaveLength(3);
-    expect(artifact.payload.publishingPlan[0]).toContain("QA and security evidence");
+    expect(artifact.payload.versionResolutions).toEqual([
+      expect.objectContaining({ name: "@h9-foundry/agentforge-cli", status: "pending-version-bump" })
+    ]);
+    expect(artifact.payload.approvalRecommendations).toEqual([
+      expect.objectContaining({ action: "publish-packages", classification: "approval_required" })
+    ]);
+    expect(artifact.payload.publishingPlan[0]).toContain("workspace version target");
+    expect(artifact.payload.publishingPlan[1]).toContain("QA and security evidence");
   });
 });

--- a/agents/release-analyst/src/index.ts
+++ b/agents/release-analyst/src/index.ts
@@ -1,6 +1,17 @@
-import { agentManifestSchema, agentOutputSchema, releaseArtifactSchema } from "@h9-foundry/agentforge-schemas";
+import {
+  agentManifestSchema,
+  agentOutputSchema,
+  releaseApprovalRecommendationSchema,
+  releaseArtifactSchema,
+  releaseEvidenceNormalizationSchema
+} from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
-import type { GithubReference, ReleaseArtifact, ReleaseRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type {
+  GithubReference,
+  ReleaseArtifact,
+  ReleaseRequest,
+  WorkflowStateEnvelope
+} from "@h9-foundry/agentforge-shared-types";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -113,18 +124,27 @@ export const releaseAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const qaReportRefs = asStringArray(intakeMetadata.qaReportRefs).length > 0
+    const evidenceMetadata = releaseEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence = evidenceMetadata.success ? evidenceMetadata.data : undefined;
+    const qaReportRefs = normalizedEvidence?.qaReportRefs && normalizedEvidence.qaReportRefs.length > 0
+      ? normalizedEvidence.qaReportRefs
+      : asStringArray(intakeMetadata.qaReportRefs).length > 0
       ? asStringArray(intakeMetadata.qaReportRefs)
       : releaseRequest.qaReportRefs;
-    const securityReportRefs = asStringArray(intakeMetadata.securityReportRefs).length > 0
+    const securityReportRefs = normalizedEvidence?.securityReportRefs && normalizedEvidence.securityReportRefs.length > 0
+      ? normalizedEvidence.securityReportRefs
+      : asStringArray(intakeMetadata.securityReportRefs).length > 0
       ? asStringArray(intakeMetadata.securityReportRefs)
       : releaseRequest.securityReportRefs;
-    const evidenceSources = asStringArray(intakeMetadata.evidenceSources).length > 0
+    const evidenceSources = normalizedEvidence?.normalizedEvidenceSources && normalizedEvidence.normalizedEvidenceSources.length > 0
+      ? normalizedEvidence.normalizedEvidenceSources
+      : asStringArray(intakeMetadata.evidenceSources).length > 0
       ? asStringArray(intakeMetadata.evidenceSources)
       : releaseRequest.evidenceSources;
     const constraints = asStringArray(intakeMetadata.constraints);
     const allEvidenceRefs = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
-    const verificationChecks = [
+    const versionResolutions = normalizedEvidence?.versionResolutions ?? [];
+    const verificationChecks = normalizedEvidence?.localReadinessChecks ?? [
       {
         name: "qa-report-refs",
         status: qaReportRefs.length > 0 ? "passed" : "skipped",
@@ -147,16 +167,32 @@ export const releaseAnalystAgent: RuntimeAgent = {
           : "No additional local release evidence sources were supplied."
       }
     ] as const;
-    const readinessStatus =
-      qaReportRefs.length > 0 && securityReportRefs.length > 0
+    const readinessStatus = normalizedEvidence?.readinessStatus ??
+      (qaReportRefs.length > 0 && securityReportRefs.length > 0
         ? "ready"
         : qaReportRefs.length > 0 || securityReportRefs.length > 0
           ? "partial"
-          : "blocked";
+          : "blocked");
+    const approvalRecommendations = normalizedEvidence?.approvalRecommendations ?? [
+      {
+        action: "publish-packages",
+        classification: readinessStatus === "ready" ? "approval_required" : "deny",
+        reason:
+          readinessStatus === "ready"
+            ? "Package publication remains outside the default read-only workflow path and needs explicit release approval."
+            : "Keep package publication blocked until bounded release evidence is complete and normalized."
+      }
+    ];
     const summary = `Release report prepared for ${releaseRequest.releaseScope}.`;
     const publishingPlan = [
+      ...(versionResolutions.length > 0
+        ? [`Resolved ${versionResolutions.length} workspace version target(s) before any publish or promotion step.`]
+        : []),
       "Review the bounded QA and security evidence before invoking any publish or promotion step.",
       "Run `agentforge release check --json` and `agentforge release verify --json` before any release cut.",
+      ...approvalRecommendations.map(
+        (recommendation) => `${recommendation.action}: ${recommendation.classification.replaceAll("_", " ")} (${recommendation.reason})`
+      ),
       "Keep trusted publishing and tag or publish actions outside this default read-only workflow path."
     ];
     const rollbackNotes = [
@@ -182,6 +218,10 @@ export const releaseAnalystAgent: RuntimeAgent = {
         versionTargets: releaseRequest.versionTargets,
         readinessStatus,
         verificationChecks: verificationChecks.map((check) => ({ ...check })),
+        versionResolutions,
+        approvalRecommendations: approvalRecommendations.map((recommendation) =>
+          releaseApprovalRecommendationSchema.parse(recommendation)
+        ),
         publishingPlan,
         trustStatus: "trusted-publishing-reviewed-separately",
         publishedPackages: [],
@@ -206,10 +246,12 @@ export const releaseAnalystAgent: RuntimeAgent = {
           qaReportRefs,
           securityReportRefs,
           evidenceSources,
-          constraints
+          constraints,
+          normalizedEvidence: normalizedEvidence ?? null
         },
         synthesizedAssessment: {
           readinessStatus,
+          approvalRecommendations,
           publishingPlan,
           rollbackNotes
         }

--- a/docs/RELEASE_CICD_WORKFLOWS.md
+++ b/docs/RELEASE_CICD_WORKFLOWS.md
@@ -36,6 +36,8 @@ Available now:
 - audit and lifecycle artifact infrastructure
 - bounded `release-readiness` request validation and workflow asset scaffolding
 - bounded `release-report` artifact emission from the local `release-readiness` workflow
+- deterministic release-state normalization across bounded local evidence, QA/security report refs, and workspace version targets
+- approval-classified publish or promotion follow-on recommendations that remain read-only by default
 
 Not yet available:
 
@@ -82,7 +84,7 @@ This expansion should not:
 - trigger: `manual`
 - primary lifecycle domain: `release`
 - support level at the intake-only implementation slice: `partial`
-- official promotion only after `release-report` emission and deterministic release-state normalization land
+- official promotion only after the evaluator path is stable and the workflow is documented against the published npm surface
 - maturity at first implementation: `mvp`
 
 ### Entry Model

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1172,6 +1172,19 @@ describe("cli smoke flows", () => {
     const root = createFixtureRepo();
     initializeWorkspace(root);
     ensureRequestsDir(root);
+    mkdirSync(join(root, "packages", "cli"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "cli", "package.json"),
+      JSON.stringify(
+        {
+          name: "@h9-foundry/agentforge-cli",
+          version: "0.6.0",
+          type: "module"
+        },
+        null,
+        2
+      )
+    );
 
     const qaBundleDir = join(root, ".agentops", "runs", "run-qa");
     mkdirSync(qaBundleDir, { recursive: true });
@@ -1292,6 +1305,8 @@ describe("cli smoke flows", () => {
         payload?: {
           releaseScope?: string;
           readinessStatus?: string;
+          versionResolutions?: Array<{ name: string; status: string }>;
+          approvalRecommendations?: Array<{ action: string; classification: string }>;
           verificationChecks?: Array<{ name: string; status: string }>;
         };
       }>;
@@ -1301,8 +1316,14 @@ describe("cli smoke flows", () => {
     expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("release-report");
     expect(bundle.lifecycleArtifacts[0]?.payload?.releaseScope).toBe("Prepare the 0.7.0 candidate for maintainer review");
     expect(bundle.lifecycleArtifacts[0]?.payload?.readinessStatus).toBe("ready");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.versionResolutions).toEqual([
+      expect.objectContaining({ name: "@h9-foundry/agentforge-cli", status: "pending-version-bump" })
+    ]);
+    expect(bundle.lifecycleArtifacts[0]?.payload?.approvalRecommendations).toEqual(
+      expect.arrayContaining([expect.objectContaining({ action: "publish-packages", classification: "approval_required" })])
+    );
     expect(bundle.lifecycleArtifacts[0]?.payload?.verificationChecks?.map((check) => check.name)).toEqual(
-      expect.arrayContaining(["qa-report-refs", "security-report-refs", "local-release-evidence"])
+      expect.arrayContaining(["qa-report-refs", "security-report-refs", "local-release-evidence", "workspace-version-targets"])
     );
   });
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -295,6 +295,10 @@ nodes:
     kind: deterministic
     agent: release-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: release-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: release
     kind: reasoning
     agent: release-analyst

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -500,3 +500,112 @@ describe("builtin security evidence normalizer", () => {
     expect(output.metadata?.provenanceRefs).toContain(".agentops/runs/run-impl/bundle.json#implementation-proposal");
   });
 });
+
+describe("builtin release evidence normalizer", () => {
+  it("normalizes bounded release evidence, workspace version targets, and approval-gated follow-on actions", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentforge-release-evidence-"));
+    mkdirSync(join(root, ".agentops", "runs", "run-qa"), { recursive: true });
+    mkdirSync(join(root, ".agentops", "runs", "run-security"), { recursive: true });
+    mkdirSync(join(root, "packages", "cli"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "cli", "package.json"),
+      JSON.stringify(
+        {
+          name: "@h9-foundry/agentforge-cli",
+          version: "0.6.0"
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(
+      join(root, ".agentops", "runs", "run-qa", "bundle.json"),
+      JSON.stringify(
+        {
+          lifecycleArtifacts: [
+            {
+              artifactKind: "qa-report"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(root, ".agentops", "runs", "run-qa", "summary.md"), "# qa summary\n");
+    writeFileSync(
+      join(root, ".agentops", "runs", "run-security", "bundle.json"),
+      JSON.stringify(
+        {
+          lifecycleArtifacts: [
+            {
+              artifactKind: "security-report"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(root, ".agentops", "runs", "run-security", "summary.md"), "# security summary\n");
+
+    const agent = createBuiltinAgentRegistry().get("release-evidence-normalizer");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        repo: {
+          root,
+          name: "fixture-root",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        workflowInputs: {
+          releaseRequest: {
+            releaseScope: "Prepare the next release candidate",
+            versionTargets: [{ name: "@h9-foundry/agentforge-cli", version: "0.7.0" }],
+            qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+            securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+            evidenceSources: [".agentops/runs/run-security/summary.md"],
+            constraints: ["Keep the workflow read-only"]
+          }
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+              securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+              evidenceSources: [".agentops/runs/run-security/summary.md"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.metadata?.normalizedEvidenceSources).toEqual([
+      ".agentops/runs/run-qa/bundle.json",
+      ".agentops/runs/run-security/bundle.json",
+      ".agentops/runs/run-security/summary.md"
+    ]);
+    expect(output.metadata?.versionResolutions).toEqual([
+      expect.objectContaining({
+        name: "@h9-foundry/agentforge-cli",
+        currentVersion: "0.6.0",
+        targetVersion: "0.7.0",
+        status: "pending-version-bump"
+      })
+    ]);
+    expect(output.metadata?.approvalRecommendations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ action: "publish-packages", classification: "approval_required" }),
+        expect.objectContaining({ action: "promote-release", classification: "approval_required" })
+      ])
+    );
+  });
+});

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -11,7 +11,9 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  releaseApprovalRecommendationSchema,
   releaseArtifactSchema,
+  releaseEvidenceNormalizationSchema,
   releaseRequestSchema,
   securityArtifactSchema,
   securityEvidenceNormalizationSchema,
@@ -35,6 +37,7 @@ import type {
   QaEvidenceNormalization,
   QaRequest,
   ReleaseArtifact,
+  ReleaseEvidenceNormalization,
   ReleaseRequest,
   SecurityArtifact,
   SecurityEvidenceNormalization,
@@ -121,6 +124,43 @@ function parsePackageScripts(packageJsonPath: string): Record<string, string> {
   return Object.fromEntries(
     Object.entries(parsed.scripts).filter((entry): entry is [string, string] => typeof entry[1] === "string")
   );
+}
+
+interface WorkspacePackageResolution {
+  readonly currentVersion?: string;
+  readonly manifestPath?: string;
+}
+
+function resolveWorkspacePackage(root: string | undefined, packageName: string): WorkspacePackageResolution {
+  if (!root) {
+    return {};
+  }
+
+  for (const topLevel of ["packages", "agents", "adapters"]) {
+    const scopeRoot = join(root, topLevel);
+    if (!existsSync(scopeRoot)) {
+      continue;
+    }
+
+    for (const entry of readdirSync(scopeRoot)) {
+      const manifestPath = join(scopeRoot, entry, "package.json");
+      if (!existsSync(manifestPath)) {
+        continue;
+      }
+
+      const parsed = JSON.parse(readFileSync(manifestPath, "utf8")) as unknown;
+      if (!isRecord(parsed) || parsed.name !== packageName || typeof parsed.version !== "string") {
+        continue;
+      }
+
+      return {
+        currentVersion: parsed.version,
+        manifestPath
+      };
+    }
+  }
+
+  return {};
 }
 
 const allowedValidationScriptNames = new Set(["test", "lint", "typecheck", "build", "build:packages", "release:verify"]);
@@ -1032,6 +1072,183 @@ const releaseIntakeAgent: RuntimeAgent = {
   }
 };
 
+const releaseEvidenceNormalizationAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "release-evidence-normalizer",
+    displayName: "Release Evidence Normalizer",
+    category: "release",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**", "**/*.json", "**/*.md", "**/package.json"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "agentResults"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "release",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const releaseRequest = getWorkflowInput<ReleaseRequest>(stateSlice, "releaseRequest");
+    if (!releaseRequest) {
+      throw new Error("release-readiness requires validated release request inputs before evidence normalization.");
+    }
+
+    const repoRoot = stateSlice.repo?.root;
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const qaReportRefs = asStringArray(intakeMetadata.qaReportRefs).length > 0
+      ? asStringArray(intakeMetadata.qaReportRefs)
+      : releaseRequest.qaReportRefs;
+    const securityReportRefs = asStringArray(intakeMetadata.securityReportRefs).length > 0
+      ? asStringArray(intakeMetadata.securityReportRefs)
+      : releaseRequest.securityReportRefs;
+    const evidenceSources = asStringArray(intakeMetadata.evidenceSources).length > 0
+      ? asStringArray(intakeMetadata.evidenceSources)
+      : releaseRequest.evidenceSources;
+    const normalizedEvidenceSources = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
+    const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
+    if (missingEvidenceSources.length > 0) {
+      throw new Error(`Release evidence source not found: ${missingEvidenceSources[0]}`);
+    }
+
+    const versionResolutions = releaseRequest.versionTargets.map((target) => {
+      const resolved = resolveWorkspacePackage(repoRoot, target.name);
+      return {
+        name: target.name,
+        targetVersion: target.version,
+        currentVersion: resolved.currentVersion,
+        status:
+          !resolved.currentVersion
+            ? "package-missing"
+            : resolved.currentVersion === target.version
+              ? "matches-target"
+              : "pending-version-bump",
+        manifestPath: resolved.manifestPath
+      };
+    });
+    const missingPackages = versionResolutions.filter((entry) => entry.status === "package-missing").map((entry) => entry.name);
+    const versionCheckStatus = missingPackages.length === 0 ? "passed" : "failed";
+    const baseReadinessStatus =
+      qaReportRefs.length > 0 && securityReportRefs.length > 0
+        ? "ready"
+        : qaReportRefs.length > 0 || securityReportRefs.length > 0
+          ? "partial"
+          : "blocked";
+    const readinessStatus = missingPackages.length > 0 ? "blocked" : baseReadinessStatus;
+
+    const localReadinessChecks = [
+      {
+        name: "qa-report-refs",
+        status: qaReportRefs.length > 0 ? "passed" : "skipped",
+        detail: qaReportRefs.length > 0
+          ? `Using ${qaReportRefs.length} validated QA report reference(s).`
+          : "No QA report references were supplied."
+      },
+      {
+        name: "security-report-refs",
+        status: securityReportRefs.length > 0 ? "passed" : "skipped",
+        detail: securityReportRefs.length > 0
+          ? `Using ${securityReportRefs.length} validated security report reference(s).`
+          : "No security report references were supplied."
+      },
+      {
+        name: "local-release-evidence",
+        status: evidenceSources.length > 0 ? "passed" : "skipped",
+        detail: evidenceSources.length > 0
+          ? `Using ${evidenceSources.length} bounded local release evidence source(s).`
+          : "No additional local release evidence sources were supplied."
+      },
+      {
+        name: "workspace-version-targets",
+        status: versionCheckStatus,
+        detail:
+          missingPackages.length === 0
+            ? `Resolved ${versionResolutions.length} workspace version target(s).`
+            : `Missing workspace package metadata for: ${missingPackages.join(", ")}.`
+      }
+    ] as const;
+
+    const approvalRecommendations = [
+      {
+        action: "publish-packages",
+        classification: readinessStatus === "ready" ? "approval_required" : "deny",
+        reason:
+          readinessStatus === "ready"
+            ? "Package publication remains outside the default read-only workflow path and needs explicit release approval."
+            : "Keep package publication blocked until bounded release evidence is complete and normalized."
+      },
+      {
+        action: "create-release-tag",
+        classification: readinessStatus === "ready" ? "approval_required" : "deny",
+        reason:
+          readinessStatus === "ready"
+            ? "Tag creation is a release-significant side effect and remains approval-gated."
+            : "Do not create release tags while readiness remains partial or blocked."
+      },
+      {
+        action: "promote-release",
+        classification: readinessStatus === "ready" ? "approval_required" : "deny",
+        reason:
+          readinessStatus === "ready"
+            ? "Promotion remains a release-significant side effect and requires explicit maintainer approval."
+            : "Keep release promotion blocked until bounded QA and security evidence is complete."
+      }
+    ];
+    const provenanceRefs = [
+      ...normalizedEvidenceSources,
+      ...versionResolutions
+        .map((entry) => entry.manifestPath)
+        .filter((value): value is string => Boolean(value))
+    ];
+    const normalization = releaseEvidenceNormalizationSchema.parse({
+      qaReportRefs,
+      securityReportRefs,
+      normalizedEvidenceSources,
+      missingEvidenceSources: [],
+      versionResolutions: versionResolutions.map((entry) => ({
+        name: entry.name,
+        targetVersion: entry.targetVersion,
+        currentVersion: entry.currentVersion,
+        status: entry.status
+      })),
+      localReadinessChecks,
+      readinessStatus,
+      approvalRecommendations,
+      provenanceRefs: [...new Set(provenanceRefs)]
+    });
+
+    return agentOutputSchema.parse({
+      summary: `Normalized release evidence across ${normalization.normalizedEvidenceSources.length} source(s) and ${normalization.versionResolutions.length} version target(s).`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: normalization satisfies ReleaseEvidenceNormalization
+    });
+  }
+};
+
 const releaseAnalystAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -1078,18 +1295,27 @@ const releaseAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const qaReportRefs = asStringArray(intakeMetadata.qaReportRefs).length > 0
+    const evidenceMetadata = releaseEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence = evidenceMetadata.success ? evidenceMetadata.data : undefined;
+    const qaReportRefs = normalizedEvidence?.qaReportRefs && normalizedEvidence.qaReportRefs.length > 0
+      ? normalizedEvidence.qaReportRefs
+      : asStringArray(intakeMetadata.qaReportRefs).length > 0
       ? asStringArray(intakeMetadata.qaReportRefs)
       : releaseRequest.qaReportRefs;
-    const securityReportRefs = asStringArray(intakeMetadata.securityReportRefs).length > 0
+    const securityReportRefs = normalizedEvidence?.securityReportRefs && normalizedEvidence.securityReportRefs.length > 0
+      ? normalizedEvidence.securityReportRefs
+      : asStringArray(intakeMetadata.securityReportRefs).length > 0
       ? asStringArray(intakeMetadata.securityReportRefs)
       : releaseRequest.securityReportRefs;
-    const evidenceSources = asStringArray(intakeMetadata.evidenceSources).length > 0
+    const evidenceSources = normalizedEvidence?.normalizedEvidenceSources && normalizedEvidence.normalizedEvidenceSources.length > 0
+      ? normalizedEvidence.normalizedEvidenceSources
+      : asStringArray(intakeMetadata.evidenceSources).length > 0
       ? asStringArray(intakeMetadata.evidenceSources)
       : releaseRequest.evidenceSources;
     const constraints = asStringArray(intakeMetadata.constraints);
     const allEvidenceRefs = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
-    const verificationChecks = [
+    const versionResolutions = normalizedEvidence?.versionResolutions ?? [];
+    const verificationChecks = normalizedEvidence?.localReadinessChecks ?? [
       {
         name: "qa-report-refs",
         status: qaReportRefs.length > 0 ? "passed" : "skipped",
@@ -1111,17 +1337,33 @@ const releaseAnalystAgent: RuntimeAgent = {
           ? `Using ${evidenceSources.length} bounded local release evidence source(s).`
           : "No additional local release evidence sources were supplied."
       }
-    ] as const;
-    const readinessStatus =
-      qaReportRefs.length > 0 && securityReportRefs.length > 0
+    ];
+    const readinessStatus = normalizedEvidence?.readinessStatus ??
+      (qaReportRefs.length > 0 && securityReportRefs.length > 0
         ? "ready"
         : qaReportRefs.length > 0 || securityReportRefs.length > 0
           ? "partial"
-          : "blocked";
+          : "blocked");
+    const approvalRecommendations = normalizedEvidence?.approvalRecommendations ?? [
+      {
+        action: "publish-packages",
+        classification: readinessStatus === "ready" ? "approval_required" : "deny",
+        reason:
+          readinessStatus === "ready"
+            ? "Package publication remains outside the default read-only workflow path and needs explicit release approval."
+            : "Keep package publication blocked until bounded release evidence is complete and normalized."
+      }
+    ];
     const summary = `Release report prepared for ${releaseRequest.releaseScope}.`;
     const publishingPlan = [
+      ...(versionResolutions.length > 0
+        ? [`Resolved ${versionResolutions.length} workspace version target(s) before any publish or promotion step.`]
+        : []),
       "Review the bounded QA and security evidence before invoking any publish or promotion step.",
       "Run `agentforge release check --json` and `agentforge release verify --json` before any release cut.",
+      ...approvalRecommendations.map(
+        (recommendation) => `${recommendation.action}: ${recommendation.classification.replaceAll("_", " ")} (${recommendation.reason})`
+      ),
       "Keep trusted publishing and tag or publish actions outside this default read-only workflow path."
     ];
     const rollbackNotes = [
@@ -1148,6 +1390,10 @@ const releaseAnalystAgent: RuntimeAgent = {
         versionTargets: releaseRequest.versionTargets,
         readinessStatus,
         verificationChecks: verificationChecks.map((check) => ({ ...check })),
+        versionResolutions,
+        approvalRecommendations: approvalRecommendations.map((recommendation) =>
+          releaseApprovalRecommendationSchema.parse(recommendation)
+        ),
         publishingPlan,
         trustStatus: "trusted-publishing-reviewed-separately",
         publishedPackages: [],
@@ -1172,10 +1418,12 @@ const releaseAnalystAgent: RuntimeAgent = {
           qaReportRefs,
           securityReportRefs,
           evidenceSources,
-          constraints
+          constraints,
+          normalizedEvidence: normalizedEvidence ?? null
         },
         synthesizedAssessment: {
           readinessStatus,
+          approvalRecommendations,
           publishingPlan,
           rollbackNotes
         }
@@ -2401,6 +2649,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["qa-intake", qaIntakeAgent],
     ["security-intake", securityIntakeAgent],
     ["release-intake", releaseIntakeAgent],
+    ["release-evidence-normalizer", releaseEvidenceNormalizationAgent],
     ["release-analyst", releaseAnalystAgent],
     ["security-evidence-normalizer", securityEvidenceNormalizationAgent],
     ["security-analyst", securityAnalystAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -21,6 +21,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  releaseEvidenceNormalizationSchema,
   releaseRequestSchema,
   securityArtifactSchema,
   securityEvidenceNormalizationSchema,
@@ -55,6 +56,7 @@ describe("schema fixtures", () => {
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
     expect(() => qaEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization)).not.toThrow();
     expect(() => securityEvidenceNormalizationSchema.parse(schemaFixtures.securityEvidenceNormalization)).not.toThrow();
+    expect(() => releaseEvidenceNormalizationSchema.parse(schemaFixtures.releaseEvidenceNormalization)).not.toThrow();
   });
 
   it("rejects invalid manifests", () => {
@@ -86,6 +88,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.implementationInventory).toBeDefined();
     expect(jsonSchemas.qaEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.securityEvidenceNormalization).toBeDefined();
+    expect(jsonSchemas.releaseEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
     expect(jsonSchemas.planningArtifact).toBeDefined();
     expect(jsonSchemas.designArtifact).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -681,6 +681,19 @@ export const releaseVersionTargetSchema = z.object({
   version: z.string().min(1)
 });
 
+export const releaseVersionResolutionSchema = z.object({
+  name: z.string().min(1),
+  targetVersion: z.string().min(1),
+  currentVersion: z.string().min(1).optional(),
+  status: z.enum(["matches-target", "pending-version-bump", "package-missing"])
+});
+
+export const releaseApprovalRecommendationSchema = z.object({
+  action: z.string().min(1),
+  classification: z.enum(["allow", "approval_required", "deny"]),
+  reason: z.string().min(1)
+});
+
 export const releaseRequestSchema = z.object({
   releaseScope: z.string().min(1),
   versionTargets: z.array(releaseVersionTargetSchema).min(1),
@@ -690,11 +703,25 @@ export const releaseRequestSchema = z.object({
   constraints: z.array(z.string().min(1)).default([])
 });
 
+export const releaseEvidenceNormalizationSchema = z.object({
+  qaReportRefs: z.array(z.string().min(1)).default([]),
+  securityReportRefs: z.array(z.string().min(1)).default([]),
+  normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
+  missingEvidenceSources: z.array(z.string().min(1)).default([]),
+  versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
+  localReadinessChecks: z.array(releaseVerificationCheckSchema).default([]),
+  readinessStatus: z.enum(["ready", "blocked", "partial"]),
+  approvalRecommendations: z.array(releaseApprovalRecommendationSchema).default([]),
+  provenanceRefs: z.array(z.string().min(1)).default([])
+});
+
 export const releaseArtifactPayloadSchema = z.object({
   releaseScope: z.string().min(1),
   versionTargets: z.array(releaseVersionTargetSchema).min(1),
   readinessStatus: z.enum(["ready", "blocked", "partial"]),
   verificationChecks: z.array(releaseVerificationCheckSchema).default([]),
+  versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
+  approvalRecommendations: z.array(releaseApprovalRecommendationSchema).default([]),
   publishingPlan: z.array(z.string().min(1)).default([]),
   trustStatus: z.string().min(1),
   publishedPackages: z.array(z.string().min(1)).default([]),
@@ -830,6 +857,9 @@ export const schemaRegistry = {
   reviewArtifactPayload: reviewArtifactPayloadSchema,
   releaseVerificationCheck: releaseVerificationCheckSchema,
   releaseVersionTarget: releaseVersionTargetSchema,
+  releaseVersionResolution: releaseVersionResolutionSchema,
+  releaseApprovalRecommendation: releaseApprovalRecommendationSchema,
+  releaseEvidenceNormalization: releaseEvidenceNormalizationSchema,
   releaseArtifactPayload: releaseArtifactPayloadSchema,
   maintenanceArtifactPayload: maintenanceArtifactPayloadSchema,
   planningArtifact: planningArtifactSchema,
@@ -1073,8 +1103,28 @@ const releaseArtifactFixture = {
     versionTargets: [{ name: "@h9-foundry/agentforge-schemas", version: "0.4.1" }],
     readinessStatus: "ready",
     verificationChecks: [{ name: "release-verify", status: "passed" }],
+    versionResolutions: [
+      {
+        name: "@h9-foundry/agentforge-schemas",
+        targetVersion: "0.4.1",
+        currentVersion: "0.4.0",
+        status: "pending-version-bump"
+      }
+    ],
+    approvalRecommendations: [
+      {
+        action: "publish-packages",
+        classification: "approval_required",
+        reason: "Package publication remains outside the default read-only workflow path."
+      }
+    ],
     publishingPlan: ["Merge version PR", "Let GitHub Actions publish"],
-    trustStatus: "trusted-publishing-configured"
+    trustStatus: "trusted-publishing-configured",
+    publishedPackages: [],
+    tagRefs: [],
+    provenanceRefs: [".agentops/runs/run-321/bundle.json"],
+    rollbackNotes: ["Pause the release if the verification set changes before publish."],
+    externalDependencies: ["Trusted publishing remains configured in GitHub Actions."]
   }
 } as const;
 
@@ -1301,6 +1351,49 @@ const securityEvidenceNormalizationFixture = {
   affectedPackages: ["packages/cli", "packages/runtime"]
 } as const;
 
+const releaseEvidenceNormalizationFixture = {
+  qaReportRefs: [".agentops/runs/run-789/bundle.json"],
+  securityReportRefs: [".agentops/runs/run-790/bundle.json"],
+  normalizedEvidenceSources: [
+    ".agentops/runs/run-789/bundle.json",
+    ".agentops/runs/run-790/bundle.json",
+    ".agentops/runs/run-790/summary.md"
+  ],
+  missingEvidenceSources: [],
+  versionResolutions: [
+    {
+      name: "@h9-foundry/agentforge-cli",
+      targetVersion: "0.7.0",
+      currentVersion: "0.6.0",
+      status: "pending-version-bump"
+    }
+  ],
+  localReadinessChecks: [
+    { name: "qa-report-refs", status: "passed", detail: "Using one validated QA report reference." },
+    { name: "security-report-refs", status: "passed", detail: "Using one validated security report reference." },
+    { name: "workspace-version-targets", status: "passed", detail: "Resolved one workspace version target." }
+  ],
+  readinessStatus: "ready",
+  approvalRecommendations: [
+    {
+      action: "publish-packages",
+      classification: "approval_required",
+      reason: "Package publication remains outside the default read-only workflow path."
+    },
+    {
+      action: "promote-release",
+      classification: "approval_required",
+      reason: "Promotion remains a release-significant side effect and requires explicit maintainer approval."
+    }
+  ],
+  provenanceRefs: [
+    ".agentops/runs/run-789/bundle.json",
+    ".agentops/runs/run-790/bundle.json",
+    ".agentops/runs/run-790/summary.md",
+    "packages/cli/package.json"
+  ]
+} as const;
+
 export const schemaFixtures = {
   finding: {
     id: "finding-1",
@@ -1417,6 +1510,7 @@ export const schemaFixtures = {
   implementationInventory: implementationInventoryFixture,
   qaEvidenceNormalization: qaEvidenceNormalizationFixture,
   securityEvidenceNormalization: securityEvidenceNormalizationFixture,
+  releaseEvidenceNormalization: releaseEvidenceNormalizationFixture,
   lifecycleArtifactEnvelope: planningArtifactFixture,
   planningArtifact: planningArtifactFixture,
   designArtifact: designArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -14,12 +14,15 @@ import type {
   QaArtifact,
   QaEvidenceNormalization,
   QaRequest,
+  ReleaseApprovalRecommendation,
   ReleaseRequest,
+  ReleaseEvidenceNormalization,
   SecurityArtifact,
   SecurityEvidenceNormalization,
   SecurityRequest,
   ReleaseArtifact,
   ReleaseVerificationCheck,
+  ReleaseVersionResolution,
   ReleaseVersionTarget,
   ReviewArtifact
 } from "./index.js";
@@ -48,6 +51,8 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<DesignArtifact["payload"]["optionsConsidered"]>().toEqualTypeOf<DesignArtifactOption[]>();
     expectTypeOf<ReleaseArtifact["payload"]["verificationChecks"]>().toEqualTypeOf<ReleaseVerificationCheck[]>();
     expectTypeOf<ReleaseArtifact["payload"]["versionTargets"]>().toEqualTypeOf<ReleaseVersionTarget[]>();
+    expectTypeOf<ReleaseArtifact["payload"]["versionResolutions"]>().toEqualTypeOf<ReleaseVersionResolution[]>();
+    expectTypeOf<ReleaseArtifact["payload"]["approvalRecommendations"]>().toEqualTypeOf<ReleaseApprovalRecommendation[]>();
   });
 
   it("exports workflow request helper types", () => {
@@ -59,6 +64,8 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<SecurityRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ReleaseRequest["releaseScope"]>().toEqualTypeOf<string>();
     expectTypeOf<ReleaseRequest["versionTargets"]>().toEqualTypeOf<ReleaseVersionTarget[]>();
+    expectTypeOf<ReleaseEvidenceNormalization["approvalRecommendations"]>().toEqualTypeOf<ReleaseApprovalRecommendation[]>();
+    expectTypeOf<ReleaseEvidenceNormalization["versionResolutions"]>().toEqualTypeOf<ReleaseVersionResolution[]>();
     expectTypeOf<QaEvidenceNormalization["targetType"]>().toEqualTypeOf<
       "artifact-bundle" | "validation-output" | "local-reference"
     >();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -45,6 +45,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  releaseApprovalRecommendationSchema,
   securityEvidenceNormalizationSchema,
   securityArtifactPayloadSchema,
   securityArtifactSchema,
@@ -55,8 +56,10 @@ import {
   proposedActionSchema,
   releaseArtifactPayloadSchema,
   releaseArtifactSchema,
+  releaseEvidenceNormalizationSchema,
   releaseRequestSchema,
   releaseVerificationCheckSchema,
+  releaseVersionResolutionSchema,
   releaseVersionTargetSchema,
   reviewArtifactPayloadSchema,
   reviewArtifactSchema,
@@ -117,7 +120,10 @@ export type ReviewArtifact = Infer<typeof reviewArtifactSchema>;
 export type NormalizedValidationCommand = Infer<typeof normalizedValidationCommandSchema>;
 export type ReleaseVerificationCheck = Infer<typeof releaseVerificationCheckSchema>;
 export type ReleaseVersionTarget = Infer<typeof releaseVersionTargetSchema>;
+export type ReleaseVersionResolution = Infer<typeof releaseVersionResolutionSchema>;
+export type ReleaseApprovalRecommendation = Infer<typeof releaseApprovalRecommendationSchema>;
 export type ReleaseRequest = Infer<typeof releaseRequestSchema>;
+export type ReleaseEvidenceNormalization = Infer<typeof releaseEvidenceNormalizationSchema>;
 export type ReleaseArtifactPayload = Infer<typeof releaseArtifactPayloadSchema>;
 export type ReleaseArtifact = Infer<typeof releaseArtifactSchema>;
 export type MaintenanceArtifactPayload = Infer<typeof maintenanceArtifactPayloadSchema>;


### PR DESCRIPTION
## Summary
- add deterministic release-state normalization for the local `release-readiness` workflow
- classify publish or promotion follow-on steps without widening the default read-only posture
- keep the tracked workflow asset, starter agent, and release workflow docs aligned with the new deterministic evidence step

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts agents/release-analyst/src/index.test.ts; echo EXIT:$?`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Residual Risk
- `#191` still reproduces: `explain last-run --json` can select an older run immediately after a fresh successful run. This PR does not promote the release family as official and keeps that evaluator-path bug explicitly out of scope.

Closes #157