### PR TITLE
feat: add incident-handoff intake workflow

### DIFF
--- a/.agentops/workflows/incident-handoff.yaml
+++ b/.agentops/workflows/incident-handoff.yaml
@@ -1,0 +1,17 @@
+version: 1
+name: incident-handoff
+description: Validate staged incident evidence while keeping the default path local, read-only, and explicit.
+trigger: manual
+catalog:
+  domain: operate
+  supportLevel: partial
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: incident-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final

--- a/.changeset/incident-handoff-intake.md
+++ b/.changeset/incident-handoff-intake.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add the bounded `incident-handoff` intake workflow, incident request schema, and deterministic staged-evidence validation.

--- a/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
+++ b/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
@@ -2,9 +2,9 @@
 
 This document defines the design target for issue [#60](https://github.com/H9-Foundry/AgentForge/issues/60).
 
-It describes how AgentForge should support operational handoff and incident response workflows without pretending to be a hosted observability platform.
+It now records the implemented `incident-handoff` intake wedge and the remaining planned expansion beyond that first operations entry point.
 
-It does **not** claim that these workflows are implemented or officially shipped today.
+It does **not** claim that the broader operations or incident workflow family is fully implemented or officially promoted today.
 
 ## Why This Exists
 
@@ -30,14 +30,16 @@ The first operations expansion should define one bounded incident-handoff wedge 
 Available now:
 
 - context, policy, artifact, and audit infrastructure
-- planning and design workflow design targets
-- release/readiness tooling
+- official `incident-handoff` workflow asset with bounded staged-evidence intake
+- deterministic incident request validation and release-report reference checks
+- explicit local staged-evidence posture with read-only default behavior
 
 Not yet available:
 
-- official operations or incident workflow assets
-- explicit observability evidence adapters
-- incident-oriented lifecycle artifacts in runtime use
+- `incident-analyst`
+- `incident-brief` lifecycle artifact emission
+- deterministic staged incident-evidence normalization and routing
+- broader operations or observability adapter support
 
 ## Recommended Initial Workflow Family
 
@@ -51,15 +53,15 @@ Later planned variants can include:
 - `alert-triage`
 - `operational-readiness-review`
 
-Only `incident-handoff` should be targeted for first implementation planning.
+`incident-handoff` is now implemented as an intake-only wedge. The later incident and operations variants remain planned.
 
 ## User Jobs
 
-The first incident wedge should solve these jobs:
+The current incident intake wedge solves these jobs:
 
 1. capture bounded operational evidence for an incident or production issue
-2. summarize likely impacted repository areas and follow-up work
-3. hand off incident findings into planning, maintenance, or security workflows
+2. validate release-report handoff inputs and staged local evidence before reasoning
+3. preserve a clean handoff into the later incident analysis slice
 4. keep sensitive operational data policy-aware and auditable
 
 ## Non-Goals
@@ -77,7 +79,8 @@ This expansion should not:
 - workflow name: `incident-handoff`
 - trigger: `manual`
 - primary lifecycle domain: `operate`
-- support level at first implementation: `official`
+- support level at the intake-only implementation slice: `partial`
+- official promotion only after `incident-analyst`, `incident-brief`, deterministic evidence normalization, and the evaluator path are all implemented and validated
 - maturity at first implementation: `mvp`
 
 ### Entry Model
@@ -91,7 +94,7 @@ Recommended input model:
 ### Workflow Stages
 
 1. intake normalization
-2. deterministic evidence staging and normalization
+2. deterministic evidence staging and release-report reference validation
 3. incident analysis
 4. report and artifact emission
 
@@ -154,10 +157,13 @@ Adapter expectations:
 
 ## Follow-On Implementation Slices
 
-This epic should be decomposed into at least:
+Implemented on current `main`:
 
 1. incident request schema and official `incident-handoff` workflow asset
-2. `incident-analyst` starter agent and `incident-brief` artifact emission
-3. deterministic staged incident-evidence normalization and source provenance capture
-4. redaction/policy wiring for sensitive operational evidence and follow-up routing
+2. deterministic validation of staged incident evidence and referenced `release-report` artifacts before reasoning
 
+Next incident family follow-ons:
+
+1. `incident-analyst` starter agent and `incident-brief` artifact emission
+2. deterministic staged incident-evidence normalization and source provenance capture
+3. redaction/policy wiring for sensitive operational evidence and follow-up routing

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1327,6 +1327,164 @@ describe("cli smoke flows", () => {
     );
   });
 
+  it("fails incident-handoff before reasoning when the request is missing", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+
+    await expect(runLocalWorkflow("incident-handoff", root)).rejects.toThrow("Missing incident request");
+  });
+
+  it("rejects underspecified incident-handoff requests before reasoning", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+    writeYamlFile(join(root, ".agentops", "requests", "incident.yaml"), {
+      incidentSummary: "Customers saw elevated 500s after the latest release candidate."
+    });
+
+    await expect(runLocalWorkflow("incident-handoff", root)).rejects.toThrow(
+      /Incident request is underspecified/i
+    );
+  });
+
+  it("rejects incident-handoff when the referenced release bundle lacks a release-report artifact", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+    const bundleDir = join(root, ".agentops", "runs", "run-review");
+    mkdirSync(bundleDir, { recursive: true });
+    writeFileSync(
+      join(bundleDir, "bundle.json"),
+      JSON.stringify(
+        {
+          version: "1.0.0",
+          runId: "run-review",
+          workflow: "pr-review",
+          startedAt: new Date().toISOString(),
+          finishedAt: new Date().toISOString(),
+          status: "success",
+          policy: {
+            version: 1,
+            environment: "local",
+            resolvedAt: new Date().toISOString(),
+            defaults: schemaFixtures.policyDocument.defaults,
+            paths: schemaFixtures.policyDocument.paths,
+            plugins: schemaFixtures.policyDocument.plugins,
+            tools: schemaFixtures.policyDocument.tools
+          },
+          entries: [],
+          findings: [],
+          proposedActions: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [schemaFixtures.reviewArtifact],
+          artifactPaths: {
+            json: ".agentops/runs/run-review/bundle.json",
+            markdown: ".agentops/runs/run-review/summary.md"
+          },
+          provenance: {
+            generatedBy: "agentforge-runtime",
+            schemaVersion: "1.0.0",
+            executionEnvironment: "local",
+            repoRoot: root
+          },
+          redaction: {
+            applied: true,
+            strategyVersion: "1.0.0",
+            categories: ["github-token"]
+          },
+          components: []
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(bundleDir, "summary.md"), "# review summary\n");
+    writeYamlFile(join(root, ".agentops", "requests", "incident.yaml"), {
+      incidentSummary: "Customers saw elevated 500s after the latest release candidate.",
+      releaseReportRefs: [".agentops/runs/run-review/bundle.json"]
+    });
+
+    await expect(runLocalWorkflow("incident-handoff", root)).rejects.toThrow(
+      /does not contain a release-report artifact/i
+    );
+  });
+
+  it("runs incident-handoff after valid staged incident evidence and release-report references", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+
+    const releaseBundleDir = join(root, ".agentops", "runs", "run-release");
+    mkdirSync(releaseBundleDir, { recursive: true });
+    writeFileSync(
+      join(releaseBundleDir, "bundle.json"),
+      JSON.stringify(
+        {
+          version: "1.0.0",
+          runId: "run-release",
+          workflow: "release-readiness",
+          startedAt: new Date().toISOString(),
+          finishedAt: new Date().toISOString(),
+          status: "success",
+          policy: {
+            version: 1,
+            environment: "local",
+            resolvedAt: new Date().toISOString(),
+            defaults: schemaFixtures.policyDocument.defaults,
+            paths: schemaFixtures.policyDocument.paths,
+            plugins: schemaFixtures.policyDocument.plugins,
+            tools: schemaFixtures.policyDocument.tools
+          },
+          entries: [],
+          findings: [],
+          proposedActions: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [schemaFixtures.releaseArtifact],
+          artifactPaths: {
+            json: ".agentops/runs/run-release/bundle.json",
+            markdown: ".agentops/runs/run-release/summary.md"
+          },
+          provenance: {
+            generatedBy: "agentforge-runtime",
+            schemaVersion: "1.0.0",
+            executionEnvironment: "local",
+            repoRoot: root
+          },
+          redaction: {
+            applied: true,
+            strategyVersion: "1.0.0",
+            categories: ["github-token"]
+          },
+          components: []
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(releaseBundleDir, "summary.md"), "# release summary\n");
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    writeFileSync(join(root, ".agentops", "evidence", "incident-summary.md"), "# incident summary\n");
+    writeFileSync(join(root, ".agentops", "evidence", "alerts.json"), JSON.stringify({ alert: "elevated-500s" }, null, 2));
+    writeYamlFile(join(root, ".agentops", "requests", "incident.yaml"), {
+      incidentSummary: "Customers saw elevated 500s after the latest release candidate.",
+      severityHint: "high",
+      evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+      releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+      issueRefs: ["#144"],
+      constraints: ["Keep staged incident evidence read-only"]
+    });
+
+    const incidentRun = await runLocalWorkflow("incident-handoff", root);
+
+    expect(incidentRun.status).toBe("success");
+    expect(incidentRun.findings).toBe(0);
+    expect(incidentRun.artifactCount).toBe(0);
+
+    const bundle = readJson<{ workflow: string; lifecycleArtifacts: Array<{ artifactKind: string }> }>(incidentRun.jsonPath);
+    expect(bundle.workflow).toBe("incident-handoff");
+    expect(bundle.lifecycleArtifacts).toHaveLength(0);
+  });
+
   it("propagates normalized GitHub references through downstream lifecycle artifacts", async () => {
     const root = createGitFixture("agentops-github-refs-");
     initProject(root);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,6 +14,7 @@ import {
   designArtifactSchema,
   designRequestSchema,
   implementationRequestSchema,
+  incidentRequestSchema,
   planningArtifactSchema,
   planningRequestSchema,
   qaRequestSchema,
@@ -30,6 +31,7 @@ import type {
   GithubReference,
   GithubWorkflowStatusMapping,
   ImplementationRequest,
+  IncidentRequest,
   PlanningArtifact,
   PlanningRequest,
   QaRequest,
@@ -308,6 +310,25 @@ nodes:
     outputs_to: reports.final
 `;
 
+const incidentWorkflowTemplate = `version: 1
+name: incident-handoff
+description: Validate staged incident evidence while keeping the default path local, read-only, and explicit.
+trigger: manual
+catalog:
+  domain: operate
+  supportLevel: partial
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: incident-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final
+`;
+
 function loadYaml(filePath: string): unknown {
   return yaml.load(readFileSync(filePath, "utf8"));
 }
@@ -528,12 +549,30 @@ function validatePlanningRequestCompleteness(request: PlanningRequest): Planning
   return request;
 }
 
+function validateIncidentRequestCompleteness(request: IncidentRequest): IncidentRequest {
+  const evidenceSignalCount = request.evidenceSources.length + request.releaseReportRefs.length;
+  if (evidenceSignalCount === 0) {
+    throw new Error(
+      "Incident request is underspecified. Add at least one of evidenceSources or releaseReportRefs."
+    );
+  }
+
+  return request;
+}
+
 function validateWorkflowLifecyclePosture(
   workflow: WorkflowDefinition,
   policyEngine: ReturnType<typeof createPolicyEngine>
 ): void {
   const domain = workflow.catalog?.domain;
-  if (domain !== "plan" && domain !== "design" && domain !== "build" && domain !== "security" && domain !== "release") {
+  if (
+    domain !== "plan" &&
+    domain !== "design" &&
+    domain !== "build" &&
+    domain !== "security" &&
+    domain !== "release" &&
+    domain !== "operate"
+  ) {
     return;
   }
 
@@ -802,6 +841,47 @@ function prepareWorkflowInputs(
     };
   }
 
+  if (workflow.name === "incident-handoff") {
+    const requestPath = ".agentops/requests/incident.yaml";
+    ensureReadablePath(policyEngine, requestPath, "incident request");
+    const incidentRequest = validateIncidentRequestCompleteness(
+      readYamlFile(join(root, requestPath), incidentRequestSchema, "incident request")
+    );
+
+    const repoContext = inferGitHubRepoContext(root);
+    const incidentIssueRefs = new Set<string>(incidentRequest.issueRefs);
+    const incidentGithubRefMap = new Map<string, GithubReference>();
+    for (const githubRef of normalizeGitHubReferences(incidentRequest.issueRefs, repoContext)) {
+      incidentGithubRefMap.set(githubRef.canonical, githubRef);
+    }
+
+    for (const releaseReportRef of incidentRequest.releaseReportRefs) {
+      ensureReadablePath(policyEngine, releaseReportRef, "release report reference");
+      ensureBundleContainsArtifactKind(root, releaseReportRef, "release-report", "release report reference");
+      const refs = loadLifecycleArtifactSourceReferences(root, releaseReportRef);
+      for (const issueRef of refs.issueRefs) {
+        incidentIssueRefs.add(issueRef);
+      }
+      for (const githubRef of refs.githubRefs) {
+        incidentGithubRefMap.set(githubRef.canonical, githubRef);
+      }
+    }
+
+    for (const evidenceSource of incidentRequest.evidenceSources) {
+      ensureReadablePath(policyEngine, evidenceSource, "incident evidence source");
+      if (!existsSync(join(root, evidenceSource))) {
+        throw new Error(`Incident evidence source not found: ${evidenceSource}`);
+      }
+    }
+
+    return {
+      incidentRequest: incidentRequest satisfies IncidentRequest,
+      incidentIssueRefs: [...incidentIssueRefs],
+      incidentGithubRefs: [...incidentGithubRefMap.values()],
+      requestFile: requestPath
+    };
+  }
+
   return {};
 }
 
@@ -1014,6 +1094,10 @@ function ensureInitFiles(root: string): string[] {
     {
       path: join(workflowsDir, "release-readiness.yaml"),
       contents: releaseWorkflowTemplate
+    },
+    {
+      path: join(workflowsDir, "incident-handoff.yaml"),
+      contents: incidentWorkflowTemplate
     }
   ];
 

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -348,6 +348,37 @@ describe("builtin security intake agent", () => {
   });
 });
 
+describe("builtin incident intake agent", () => {
+  it("records bounded incident request metadata and staged evidence references", async () => {
+    const agent = createBuiltinAgentRegistry().get("incident-intake");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        workflowInputs: {
+          incidentRequest: {
+            incidentSummary: "Customers saw elevated 500s after the latest release candidate.",
+            severityHint: "high",
+            evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+            releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+            issueRefs: ["#144"],
+            constraints: ["Keep staged incident evidence read-only"]
+          },
+          requestFile: ".agentops/requests/incident.yaml"
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.summary).toContain(".agentops/requests/incident.yaml");
+    expect(output.metadata?.incidentSummary).toContain("elevated 500s");
+    expect(output.metadata?.releaseReportRefs).toEqual([".agentops/runs/run-release/bundle.json"]);
+    expect(output.metadata?.evidenceSourceCount).toBe(3);
+  });
+});
+
 describe("builtin security analyst agent", () => {
   it("emits a security-report artifact from bounded security inputs", async () => {
     const agent = createBuiltinAgentRegistry().get("security-analyst");

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -8,6 +8,7 @@ import {
   githubActionsEvidenceSchema,
   implementationArtifactSchema,
   implementationInventorySchema,
+  incidentRequestSchema,
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
@@ -30,6 +31,7 @@ import type {
   ImplementationArtifact,
   ImplementationInventory,
   ImplementationRequest,
+  IncidentRequest,
   NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
@@ -1004,6 +1006,67 @@ const securityIntakeAgent: RuntimeAgent = {
         }),
         targetType,
         referencedArtifactKinds
+      }
+    });
+  }
+};
+
+const incidentIntakeAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "incident-intake",
+    displayName: "Incident Intake",
+    category: "operate",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**", "**/*.json", "**/*.log", "**/*.md"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "context"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "operate",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const incidentRequest = getWorkflowInput<IncidentRequest>(stateSlice, "incidentRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!incidentRequest) {
+      throw new Error("incident-handoff requires a validated incident request before runtime execution.");
+    }
+
+    return agentOutputSchema.parse({
+      summary: `Loaded incident request from ${requestFile ?? ".agentops/requests/incident.yaml"} for ${incidentRequest.incidentSummary}.`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: {
+        ...incidentRequestSchema.parse({
+          ...incidentRequest,
+          evidenceSources: [...new Set(incidentRequest.evidenceSources)]
+        }),
+        evidenceSourceCount: incidentRequest.evidenceSources.length + incidentRequest.releaseReportRefs.length
       }
     });
   }
@@ -2648,6 +2711,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["implementation-intake", implementationIntakeAgent],
     ["qa-intake", qaIntakeAgent],
     ["security-intake", securityIntakeAgent],
+    ["incident-intake", incidentIntakeAgent],
     ["release-intake", releaseIntakeAgent],
     ["release-evidence-normalizer", releaseEvidenceNormalizationAgent],
     ["release-analyst", releaseAnalystAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   implementationArtifactSchema,
   implementationInventorySchema,
   implementationRequestSchema,
+  incidentRequestSchema,
   lifecycleArtifactEnvelopeSchema,
   maintenanceArtifactSchema,
   normalizedValidationCommandSchema,
@@ -42,6 +43,7 @@ describe("schema fixtures", () => {
     expect(() => planningRequestSchema.parse(schemaFixtures.planningRequest)).not.toThrow();
     expect(() => designRequestSchema.parse(schemaFixtures.designRequest)).not.toThrow();
     expect(() => implementationRequestSchema.parse(schemaFixtures.implementationRequest)).not.toThrow();
+    expect(() => incidentRequestSchema.parse(schemaFixtures.incidentRequest)).not.toThrow();
     expect(() => qaRequestSchema.parse(schemaFixtures.qaRequest)).not.toThrow();
     expect(() => securityRequestSchema.parse(schemaFixtures.securityRequest)).not.toThrow();
     expect(() => releaseRequestSchema.parse(schemaFixtures.releaseRequest)).not.toThrow();
@@ -76,6 +78,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.planningRequest).toBeDefined();
     expect(jsonSchemas.designRequest).toBeDefined();
     expect(jsonSchemas.implementationRequest).toBeDefined();
+    expect(jsonSchemas.incidentRequest).toBeDefined();
     expect(jsonSchemas.qaRequest).toBeDefined();
     expect(jsonSchemas.securityRequest).toBeDefined();
     expect(jsonSchemas.releaseRequest).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -703,6 +703,15 @@ export const releaseRequestSchema = z.object({
   constraints: z.array(z.string().min(1)).default([])
 });
 
+export const incidentRequestSchema = z.object({
+  incidentSummary: z.string().min(1),
+  severityHint: z.enum(["unknown", "low", "medium", "high", "critical"]).default("unknown"),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  releaseReportRefs: z.array(z.string().min(1)).default([]),
+  issueRefs: z.array(z.string().min(1)).default([]),
+  constraints: z.array(z.string().min(1)).default([])
+});
+
 export const releaseEvidenceNormalizationSchema = z.object({
   qaReportRefs: z.array(z.string().min(1)).default([]),
   securityReportRefs: z.array(z.string().min(1)).default([]),
@@ -881,6 +890,7 @@ export const schemaRegistry = {
   qaRequest: qaRequestSchema,
   securityRequest: securityRequestSchema,
   releaseRequest: releaseRequestSchema,
+  incidentRequest: incidentRequestSchema,
   normalizedValidationCommand: normalizedValidationCommandSchema,
   implementationInventory: implementationInventorySchema,
   qaEvidenceNormalization: qaEvidenceNormalizationSchema,
@@ -1198,6 +1208,15 @@ const releaseRequestFixture = {
   constraints: ["Keep release readiness read-only by default"]
 } as const;
 
+const incidentRequestFixture = {
+  incidentSummary: "Customers saw elevated 500s after the last release candidate.",
+  severityHint: "high",
+  evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+  releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+  issueRefs: ["#144"],
+  constraints: ["Keep staged incident evidence read-only"]
+} as const;
+
 const normalizedValidationCommandFixture = {
   command: "pnpm test",
   source: "request",
@@ -1502,6 +1521,7 @@ export const schemaFixtures = {
   qaRequest: qaRequestFixture,
   securityRequest: securityRequestFixture,
   releaseRequest: releaseRequestFixture,
+  incidentRequest: incidentRequestFixture,
   githubReference: githubReferenceFixture,
   githubActionsEvidence: githubActionsEvidenceFixture,
   githubHandoffSummary: githubHandoffSummaryFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -7,6 +7,7 @@ import type {
   ImplementationArtifact,
   ImplementationInventory,
   ImplementationRequest,
+  IncidentRequest,
   MaintenanceArtifact,
   NormalizedValidationCommand,
   PlanningArtifact,
@@ -60,6 +61,7 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<DesignRequest["planningBriefRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
+    expectTypeOf<IncidentRequest["incidentSummary"]>().toEqualTypeOf<string>();
     expectTypeOf<QaRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<SecurityRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ReleaseRequest["releaseScope"]>().toEqualTypeOf<string>();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -37,6 +37,7 @@ import {
   implementationArtifactSchema,
   implementationInventorySchema,
   implementationRequestSchema,
+  incidentRequestSchema,
   maintenanceArtifactPayloadSchema,
   maintenanceArtifactSchema,
   normalizedValidationCommandSchema,
@@ -107,6 +108,7 @@ export type ImplementationArtifactPayload = Infer<typeof implementationArtifactP
 export type ImplementationArtifact = Infer<typeof implementationArtifactSchema>;
 export type ImplementationInventory = Infer<typeof implementationInventorySchema>;
 export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
+export type IncidentRequest = Infer<typeof incidentRequestSchema>;
 export type QaArtifactPayload = Infer<typeof qaArtifactPayloadSchema>;
 export type QaArtifact = Infer<typeof qaArtifactSchema>;
 export type QaEvidenceNormalization = Infer<typeof qaEvidenceNormalizationSchema>;


### PR DESCRIPTION
## Summary
- add the bounded `incident-handoff` request schema and official workflow asset
- validate staged local incident evidence and referenced `release-report` bundles before reasoning
- document the intake-only incident slice honestly and add the public package changeset

Closes #144

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- `pnpm test; echo EXIT:$?` still remains wrapper-ambiguous in this environment, so this slice relies on the focused passing suite plus the standard build and smoke gates.
- `#191` still reproduces and remains the known blocker before any later public promotion of the incident family.