### PR TITLE
feat: emit incident brief artifacts

### DIFF
--- a/.agentops/workflows/incident-handoff.yaml
+++ b/.agentops/workflows/incident-handoff.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: incident-intake
     outputs_to: agentResults.intake
+  - id: incident
+    kind: reasoning
+    agent: incident-analyst
+    outputs_to: agentResults.incident
   - id: report
     kind: report
     outputs_to: reports.final

--- a/.changeset/incident-brief-artifact.md
+++ b/.changeset/incident-brief-artifact.md
@@ -1,0 +1,8 @@
+---
+"@h9-foundry/agentforge-audit": patch
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add the bounded `incident-analyst` workflow stage and first `incident-brief` lifecycle artifact for `incident-handoff`.

--- a/agents/incident-analyst/CHANGELOG.md
+++ b/agents/incident-analyst/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @h9-foundry/agentforge-agent-incident-analyst
+
+## 0.1.0
+
+### Patch Changes
+
+- Add the bounded `incident-analyst` starter agent and emit `incident-brief` lifecycle artifacts for `incident-handoff`.

--- a/agents/incident-analyst/agent.manifest.json
+++ b/agents/incident-analyst/agent.manifest.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "name": "incident-analyst",
+  "displayName": "Incident Analyst",
+  "category": "operate",
+  "runtime": {
+    "minVersion": "0.1.0",
+    "kind": "reasoning"
+  },
+  "permissions": {
+    "model": true,
+    "network": false,
+    "tools": [],
+    "readPaths": ["**/*"],
+    "writePaths": []
+  },
+  "inputs": ["workflowInputs", "repo", "changes", "agentResults"],
+  "outputs": ["lifecycleArtifacts"],
+  "contextPolicy": {
+    "sections": ["workflowInputs", "repo", "changes", "agentResults"],
+    "minimalContext": true
+  },
+  "catalog": {
+    "domain": "operate",
+    "supportLevel": "internal",
+    "maturity": "mvp",
+    "trustScope": "official-core-only"
+  },
+  "trust": {
+    "tier": "core",
+    "source": "official",
+    "reviewed": true
+  }
+}

--- a/agents/incident-analyst/package.json
+++ b/agents/incident-analyst/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@h9-foundry/agentforge-agent-incident-analyst",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "agent.manifest.json"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@h9-foundry/agentforge-schemas": "workspace:*",
+    "@h9-foundry/agentforge-sdk": "workspace:*",
+    "@h9-foundry/agentforge-shared-types": "workspace:*"
+  }
+}

--- a/agents/incident-analyst/src/index.test.ts
+++ b/agents/incident-analyst/src/index.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { incidentAnalystAgent } from "./index.js";
+
+describe("incident analyst agent", () => {
+  it("emits an incident-brief artifact from validated inputs", async () => {
+    const output = await incidentAnalystAgent.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-incident",
+        workflow: "incident-handoff",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: ["packages"],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          incidentRequest: {
+            incidentSummary: "Customers saw elevated 500s after the latest release candidate.",
+            severityHint: "high",
+            evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+            releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+            issueRefs: ["#151"],
+            constraints: ["Keep staged incident evidence read-only"]
+          },
+          incidentIssueRefs: ["#151"],
+          incidentGithubRefs: [
+            {
+              platform: "github",
+              host: "github.com",
+              owner: "H9-Foundry",
+              repo: "AgentForge",
+              kind: "issue",
+              number: 151,
+              canonical: "H9-Foundry/AgentForge#151",
+              url: "https://github.com/H9-Foundry/AgentForge/issues/151",
+              source: "#151"
+            }
+          ],
+          requestFile: ".agentops/requests/incident.yaml"
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+              severityHint: "high",
+              constraints: ["Keep staged incident evidence read-only"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.lifecycleArtifacts).toHaveLength(1);
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("incident-brief");
+    if (!artifact || artifact.artifactKind !== "incident-brief") {
+      throw new Error("Expected incident-brief artifact.");
+    }
+
+    expect(artifact.payload.incidentSummary).toContain("elevated 500s");
+    expect(artifact.payload.followUpWorkflowRefs).toContain("security-review");
+    expect(artifact.payload.followUpWorkflowRefs).toContain("maintenance-triage");
+  });
+});

--- a/agents/incident-analyst/src/index.ts
+++ b/agents/incident-analyst/src/index.ts
@@ -1,0 +1,200 @@
+import { agentManifestSchema, agentOutputSchema, incidentArtifactSchema } from "@h9-foundry/agentforge-schemas";
+import type { GithubReference, IncidentArtifact, IncidentRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function asGithubRefs(value: unknown): GithubReference[] {
+  return Array.isArray(value)
+    ? value.filter(
+        (entry): entry is GithubReference =>
+          Boolean(entry) && typeof entry === "object" && "canonical" in entry && typeof (entry as { canonical?: unknown }).canonical === "string"
+      )
+    : [];
+}
+
+function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: string): T | undefined {
+  if (!isRecord(stateSlice.workflowInputs)) {
+    return undefined;
+  }
+
+  return stateSlice.workflowInputs[key] as T | undefined;
+}
+
+function buildArtifactEnvelopeBase(
+  state: WorkflowStateEnvelope,
+  summary: string,
+  inputRefs: readonly string[],
+  issueRefs: readonly string[],
+  githubRefs: readonly GithubReference[]
+) {
+  return {
+    schemaVersion: state.version,
+    workflow: {
+      name: state.workflow,
+      displayName: "Incident Handoff"
+    },
+    source: {
+      sourceType: "workflow-run" as const,
+      runId: state.runId,
+      inputRefs: [...inputRefs],
+      issueRefs: [...issueRefs],
+      githubRefs: [...githubRefs]
+    },
+    status: "complete" as const,
+    generatedAt: new Date().toISOString(),
+    repo: {
+      root: state.repo.root,
+      name: state.repo.name,
+      branch: state.repo.branch
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" as const : "local" as const,
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key", "operational-sensitive"]
+    },
+    auditLink: {
+      entryIds: [],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary
+  };
+}
+
+export const manifest = agentManifestSchema.parse({
+  version: 1,
+  name: "incident-analyst",
+  displayName: "Incident Analyst",
+  category: "operate",
+  runtime: {
+    minVersion: "0.1.0",
+    kind: "reasoning"
+  },
+  permissions: {
+    model: true,
+    network: false,
+    tools: [],
+    readPaths: ["**/*"],
+    writePaths: []
+  },
+  inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+  outputs: ["lifecycleArtifacts"],
+  contextPolicy: {
+    sections: ["workflowInputs", "repo", "changes", "agentResults"],
+    minimalContext: true
+  },
+  catalog: {
+    domain: "operate",
+    supportLevel: "internal",
+    maturity: "mvp",
+    trustScope: "official-core-only"
+  },
+  trust: {
+    tier: "core",
+    source: "official",
+    reviewed: true
+  }
+});
+
+export const incidentAnalystAgent: RuntimeAgent = {
+  manifest,
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const incidentRequest = getWorkflowInput<IncidentRequest>(stateSlice, "incidentRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    const incidentIssueRefs = getWorkflowInput<string[]>(stateSlice, "incidentIssueRefs") ?? [];
+    const incidentGithubRefs = asGithubRefs(getWorkflowInput<unknown>(stateSlice, "incidentGithubRefs"));
+    if (!incidentRequest) {
+      throw new Error("incident-handoff requires validated incident inputs before incident analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const severityHint =
+      typeof intakeMetadata.severityHint === "string" ? intakeMetadata.severityHint : incidentRequest.severityHint;
+    const evidenceSources = [
+      ...new Set([
+        ...asStringArray(intakeMetadata.evidenceSources),
+        ...asStringArray(intakeMetadata.releaseReportRefs),
+        ...incidentRequest.evidenceSources,
+        ...incidentRequest.releaseReportRefs
+      ])
+    ];
+    const constraints = asStringArray(intakeMetadata.constraints);
+    const followUpWorkflowRefs = [
+      "maintenance-triage",
+      ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+      ...(severityHint === "high" || severityHint === "critical" ? ["security-review"] : [])
+    ];
+    const likelyImpactedAreas = [
+      ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+      ...(incidentRequest.evidenceSources.length > 0 ? ["staged-operational-evidence"] : []),
+      ...(severityHint === "high" || severityHint === "critical" ? ["security-follow-up"] : [])
+    ];
+    const openQuestions = [
+      ...(incidentRequest.issueRefs.length === 0 ? ["Should this incident be linked to a tracked issue before escalation?"] : []),
+      ...(incidentRequest.releaseReportRefs.length === 0 ? ["Is there a release-report bundle that should be attached for additional provenance?"] : [])
+    ];
+    const summary = `Incident brief prepared for ${incidentRequest.incidentSummary}.`;
+    const incidentBrief = incidentArtifactSchema.parse({
+      ...buildArtifactEnvelopeBase(
+        state,
+        summary,
+        [requestFile ?? ".agentops/requests/incident.yaml", ...incidentRequest.evidenceSources, ...incidentRequest.releaseReportRefs],
+        incidentIssueRefs,
+        incidentGithubRefs
+      ),
+      artifactKind: "incident-brief",
+      lifecycleDomain: "operate",
+      payload: {
+        incidentSummary: incidentRequest.incidentSummary,
+        evidenceSources,
+        timelineSummary: [
+          `Severity hint: ${severityHint}.`,
+          `Validated ${incidentRequest.evidenceSources.length} staged evidence source(s) and ${incidentRequest.releaseReportRefs.length} release-report reference(s) before reasoning.`
+        ],
+        likelyImpactedAreas:
+          likelyImpactedAreas.length > 0
+            ? likelyImpactedAreas
+            : ["manual incident triage is still required to identify impacted repository areas."],
+        followUpWorkflowRefs: [...new Set(followUpWorkflowRefs)],
+        openQuestions
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [incidentBrief satisfies IncidentArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: severityHint === "critical" ? 0.7 : 0.74,
+      metadata: {
+        deterministicInputs: {
+          severityHint,
+          evidenceSources,
+          issueRefs: incidentIssueRefs,
+          constraints
+        },
+        synthesizedAssessment: {
+          likelyImpactedAreas: incidentBrief.payload.likelyImpactedAreas,
+          followUpWorkflowRefs: incidentBrief.payload.followUpWorkflowRefs,
+          openQuestions: incidentBrief.payload.openQuestions
+        }
+      }
+    });
+  }
+};

--- a/agents/incident-analyst/tsconfig.json
+++ b/agents/incident-analyst/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
+++ b/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
@@ -32,12 +32,12 @@ Available now:
 - context, policy, artifact, and audit infrastructure
 - official `incident-handoff` workflow asset with bounded staged-evidence intake
 - deterministic incident request validation and release-report reference checks
+- bounded `incident-analyst`
+- `incident-brief` lifecycle artifact emission
 - explicit local staged-evidence posture with read-only default behavior
 
 Not yet available:
 
-- `incident-analyst`
-- `incident-brief` lifecycle artifact emission
 - deterministic staged incident-evidence normalization and routing
 - broader operations or observability adapter support
 
@@ -161,9 +161,9 @@ Implemented on current `main`:
 
 1. incident request schema and official `incident-handoff` workflow asset
 2. deterministic validation of staged incident evidence and referenced `release-report` artifacts before reasoning
+3. `incident-analyst` starter agent and `incident-brief` artifact emission
 
 Next incident family follow-ons:
 
-1. `incident-analyst` starter agent and `incident-brief` artifact emission
-2. deterministic staged incident-evidence normalization and source provenance capture
-3. redaction/policy wiring for sensitive operational evidence and follow-up routing
+1. deterministic staged incident-evidence normalization and source provenance capture
+2. redaction/policy wiring for sensitive operational evidence and follow-up routing

--- a/packages/audit/src/index.test.ts
+++ b/packages/audit/src/index.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { schemaFixtures } from "@h9-foundry/agentforge-schemas";
 import type {
   DesignArtifact,
+  IncidentArtifact,
   PlanningArtifact,
   QaArtifact,
   ReleaseArtifact
@@ -38,6 +39,14 @@ describe("renderGitHubHandoffSummary", () => {
     expect(summary.artifactKind).toBe("qa-report");
     expect(summary.sections.some((section) => section.heading === "Findings")).toBe(true);
     expect(summary.sections.some((section) => section.heading === "Coverage Gaps")).toBe(true);
+  });
+
+  it("renders a bounded incident handoff summary", () => {
+    const summary = renderGitHubHandoffSummary(cloneFixture(schemaFixtures.incidentArtifact) as unknown as IncidentArtifact);
+
+    expect(summary.artifactKind).toBe("incident-brief");
+    expect(summary.sections.some((section) => section.heading === "Timeline Summary")).toBe(true);
+    expect(summary.sections.some((section) => section.heading === "Follow-Up Workflows")).toBe(true);
   });
 
   it("renders a bounded release handoff summary with overrideable status mapping", () => {

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -6,13 +6,14 @@ import type {
   GithubHandoffSummary,
   GithubReference,
   GithubWorkflowStatusMapping,
+  IncidentArtifact,
   PlanningArtifact,
   QaArtifact,
   ReleaseArtifact,
   WorkflowStateEnvelope
 } from "@h9-foundry/agentforge-shared-types";
 
-type GitHubRenderableArtifact = PlanningArtifact | DesignArtifact | QaArtifact | ReleaseArtifact;
+type GitHubRenderableArtifact = PlanningArtifact | DesignArtifact | IncidentArtifact | QaArtifact | ReleaseArtifact;
 
 export function createAuditEntry(entry: AuditEntry): AuditEntry {
   return entry;
@@ -89,6 +90,16 @@ function renderQaSections(artifact: QaArtifact): GithubHandoffSection[] {
   ].filter((section) => section.lines.length > 0);
 }
 
+function renderIncidentSections(artifact: IncidentArtifact): GithubHandoffSection[] {
+  return [
+    { heading: "Summary", lines: [artifact.summary] },
+    { heading: "Timeline Summary", lines: artifact.payload.timelineSummary ?? [] },
+    { heading: "Likely Impacted Areas", lines: artifact.payload.likelyImpactedAreas ?? [] },
+    { heading: "Follow-Up Workflows", lines: artifact.payload.followUpWorkflowRefs ?? [] },
+    { heading: "Open Questions", lines: artifact.payload.openQuestions ?? [] }
+  ].filter((section) => section.lines.length > 0);
+}
+
 function renderReleaseSections(artifact: ReleaseArtifact): GithubHandoffSection[] {
   return [
     { heading: "Summary", lines: [artifact.summary] },
@@ -108,6 +119,8 @@ function buildGitHubHandoffSections(artifact: GitHubRenderableArtifact): GithubH
       return renderPlanningSections(artifact);
     case "design-record":
       return renderDesignSections(artifact);
+    case "incident-brief":
+      return renderIncidentSections(artifact);
     case "qa-report":
       return renderQaSections(artifact);
     case "release-report":

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1478,11 +1478,27 @@ describe("cli smoke flows", () => {
 
     expect(incidentRun.status).toBe("success");
     expect(incidentRun.findings).toBe(0);
-    expect(incidentRun.artifactCount).toBe(0);
+    expect(incidentRun.artifactKinds).toContain("incident-brief");
 
-    const bundle = readJson<{ workflow: string; lifecycleArtifacts: Array<{ artifactKind: string }> }>(incidentRun.jsonPath);
+    const bundle = readJson<{
+      workflow: string;
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: {
+          incidentSummary?: string;
+          followUpWorkflowRefs?: string[];
+          likelyImpactedAreas?: string[];
+        };
+      }>;
+    }>(incidentRun.jsonPath);
     expect(bundle.workflow).toBe("incident-handoff");
-    expect(bundle.lifecycleArtifacts).toHaveLength(0);
+    expect(bundle.lifecycleArtifacts).toHaveLength(1);
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("incident-brief");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.incidentSummary).toContain("elevated 500s");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.followUpWorkflowRefs).toEqual(
+      expect.arrayContaining(["maintenance-triage", "security-review", "release-readiness"])
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.likelyImpactedAreas).toContain("release-readiness");
   });
 
   it("propagates normalized GitHub references through downstream lifecycle artifacts", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -324,6 +324,10 @@ nodes:
     kind: deterministic
     agent: incident-intake
     outputs_to: agentResults.intake
+  - id: incident
+    kind: reasoning
+    agent: incident-analyst
+    outputs_to: agentResults.incident
   - id: report
     kind: report
     outputs_to: reports.final

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { describe, expect, it } from "vitest";
+import { schemaFixtures } from "@h9-foundry/agentforge-schemas";
 
 import { createBuiltinAgentRegistry } from "./builtin-agents.js";
 
@@ -376,6 +377,92 @@ describe("builtin incident intake agent", () => {
     expect(output.metadata?.incidentSummary).toContain("elevated 500s");
     expect(output.metadata?.releaseReportRefs).toEqual([".agentops/runs/run-release/bundle.json"]);
     expect(output.metadata?.evidenceSourceCount).toBe(3);
+  });
+});
+
+describe("builtin incident analyst agent", () => {
+  it("emits an incident-brief artifact from bounded incident inputs", async () => {
+    const agent = createBuiltinAgentRegistry().get("incident-analyst");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-incident",
+        workflow: "incident-handoff",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: ["packages"],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          incidentRequest: {
+            incidentSummary: "Customers saw elevated 500s after the latest release candidate.",
+            severityHint: "high",
+            evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+            releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+            issueRefs: ["#151"],
+            constraints: ["Keep staged incident evidence read-only"]
+          },
+          incidentIssueRefs: ["#151"],
+          incidentGithubRefs: [schemaFixtures.githubReference],
+          requestFile: ".agentops/requests/incident.yaml"
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+              severityHint: "high",
+              constraints: ["Keep staged incident evidence read-only"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("incident-brief");
+    if (!artifact || artifact.artifactKind !== "incident-brief") {
+      throw new Error("Expected incident-brief artifact.");
+    }
+
+    expect(artifact.payload.incidentSummary).toContain("elevated 500s");
+    expect(artifact.payload.followUpWorkflowRefs).toContain("security-review");
+    expect((output.metadata as { synthesizedAssessment?: { likelyImpactedAreas?: string[] } } | undefined)?.synthesizedAssessment?.likelyImpactedAreas)
+      .toContain("release-readiness");
   });
 });
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -8,6 +8,7 @@ import {
   githubActionsEvidenceSchema,
   implementationArtifactSchema,
   implementationInventorySchema,
+  incidentArtifactSchema,
   incidentRequestSchema,
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
@@ -31,6 +32,7 @@ import type {
   ImplementationArtifact,
   ImplementationInventory,
   ImplementationRequest,
+  IncidentArtifact,
   IncidentRequest,
   NormalizedValidationCommand,
   PlanningArtifact,
@@ -1067,6 +1069,138 @@ const incidentIntakeAgent: RuntimeAgent = {
           evidenceSources: [...new Set(incidentRequest.evidenceSources)]
         }),
         evidenceSourceCount: incidentRequest.evidenceSources.length + incidentRequest.releaseReportRefs.length
+      }
+    });
+  }
+};
+
+const incidentAnalystAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "incident-analyst",
+    displayName: "Incident Analyst",
+    category: "operate",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "reasoning"
+    },
+    permissions: {
+      model: true,
+      network: false,
+      tools: [],
+      readPaths: ["**/*"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+    outputs: ["lifecycleArtifacts"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "changes", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "operate",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const incidentRequest = getWorkflowInput<IncidentRequest>(stateSlice, "incidentRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    const incidentIssueRefs = getWorkflowInput<string[]>(stateSlice, "incidentIssueRefs") ?? [];
+    const incidentGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "incidentGithubRefs") ?? [];
+    if (!incidentRequest) {
+      throw new Error("incident-handoff requires validated incident inputs before incident analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const evidenceSources =
+      asStringArray(intakeMetadata.evidenceSources).length > 0
+        ? [
+            ...new Set([
+              ...asStringArray(intakeMetadata.evidenceSources),
+              ...asStringArray(intakeMetadata.releaseReportRefs)
+            ])
+          ]
+        : [...new Set([...incidentRequest.evidenceSources, ...incidentRequest.releaseReportRefs])];
+    const severityHint =
+      typeof intakeMetadata.severityHint === "string" ? intakeMetadata.severityHint : incidentRequest.severityHint;
+    const constraints = asStringArray(intakeMetadata.constraints);
+    const followUpWorkflowRefs = [
+      "maintenance-triage",
+      ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+      ...(severityHint === "high" || severityHint === "critical" ? ["security-review"] : [])
+    ];
+    const likelyImpactedAreas = [
+      ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+      ...(incidentRequest.evidenceSources.length > 0 ? ["staged-operational-evidence"] : []),
+      ...(severityHint === "high" || severityHint === "critical" ? ["security-follow-up"] : [])
+    ];
+    const openQuestions = [
+      ...(incidentRequest.issueRefs.length === 0 ? ["Should this incident be linked to a tracked issue before escalation?"] : []),
+      ...(incidentRequest.releaseReportRefs.length === 0
+        ? ["Is there a release-report bundle that should be attached for additional provenance?"]
+        : [])
+    ];
+    const summary = `Incident brief prepared for ${incidentRequest.incidentSummary}.`;
+    const incidentBrief = incidentArtifactSchema.parse({
+      ...buildLifecycleArtifactEnvelopeBase(
+        state,
+        "Incident Handoff",
+        summary,
+        [requestFile ?? ".agentops/requests/incident.yaml", ...incidentRequest.evidenceSources, ...incidentRequest.releaseReportRefs],
+        incidentIssueRefs,
+        incidentGithubRefs
+      ),
+      artifactKind: "incident-brief",
+      lifecycleDomain: "operate",
+      redaction: {
+        applied: true,
+        strategyVersion: "1.0.0",
+        categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key", "operational-sensitive"]
+      },
+      payload: {
+        incidentSummary: incidentRequest.incidentSummary,
+        evidenceSources,
+        timelineSummary: [
+          `Severity hint: ${severityHint}.`,
+          `Validated ${incidentRequest.evidenceSources.length} staged evidence source(s) and ${incidentRequest.releaseReportRefs.length} release-report reference(s) before reasoning.`
+        ],
+        likelyImpactedAreas:
+          likelyImpactedAreas.length > 0
+            ? likelyImpactedAreas
+            : ["manual incident triage is still required to identify impacted repository areas."],
+        followUpWorkflowRefs: [...new Set(followUpWorkflowRefs)],
+        openQuestions
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [incidentBrief satisfies IncidentArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: severityHint === "critical" ? 0.7 : 0.74,
+      metadata: {
+        deterministicInputs: {
+          severityHint,
+          evidenceSources,
+          issueRefs: incidentIssueRefs,
+          constraints
+        },
+        synthesizedAssessment: {
+          likelyImpactedAreas: incidentBrief.payload.likelyImpactedAreas,
+          followUpWorkflowRefs: incidentBrief.payload.followUpWorkflowRefs,
+          openQuestions: incidentBrief.payload.openQuestions
+        }
       }
     });
   }
@@ -2712,6 +2846,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["qa-intake", qaIntakeAgent],
     ["security-intake", securityIntakeAgent],
     ["incident-intake", incidentIntakeAgent],
+    ["incident-analyst", incidentAnalystAgent],
     ["release-intake", releaseIntakeAgent],
     ["release-evidence-normalizer", releaseEvidenceNormalizationAgent],
     ["release-analyst", releaseAnalystAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   implementationArtifactSchema,
   implementationInventorySchema,
   implementationRequestSchema,
+  incidentArtifactSchema,
   incidentRequestSchema,
   lifecycleArtifactEnvelopeSchema,
   maintenanceArtifactSchema,
@@ -56,6 +57,7 @@ describe("schema fixtures", () => {
     expect(() => githubWorkflowStatusMappingSchema.parse(schemaFixtures.githubWorkflowStatusMapping)).not.toThrow();
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
+    expect(() => incidentArtifactSchema.parse(schemaFixtures.incidentArtifact)).not.toThrow();
     expect(() => qaEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization)).not.toThrow();
     expect(() => securityEvidenceNormalizationSchema.parse(schemaFixtures.securityEvidenceNormalization)).not.toThrow();
     expect(() => releaseEvidenceNormalizationSchema.parse(schemaFixtures.releaseEvidenceNormalization)).not.toThrow();
@@ -96,6 +98,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.planningArtifact).toBeDefined();
     expect(jsonSchemas.designArtifact).toBeDefined();
     expect(jsonSchemas.implementationArtifact).toBeDefined();
+    expect(jsonSchemas.incidentArtifact).toBeDefined();
     expect(jsonSchemas.qaArtifact).toBeDefined();
     expect(jsonSchemas.securityArtifact).toBeDefined();
     expect(jsonSchemas.reviewArtifact).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -17,13 +17,14 @@ export const lifecycleArtifactKindSchema = z.enum([
   "planning-brief",
   "design-record",
   "implementation-proposal",
+  "incident-brief",
   "qa-report",
   "security-report",
   "review-report",
   "release-report",
   "maintenance-report"
 ]);
-export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "test", "security", "review", "release", "maintain"]);
+export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "test", "security", "review", "release", "operate", "maintain"]);
 export const lifecycleArtifactSourceTypeSchema = z.enum(["workflow-run", "manual-input", "imported"]);
 export const lifecycleArtifactStatusSchema = z.enum(["draft", "complete", "superseded", "cancelled"]);
 export const githubReferenceKindSchema = z.enum(["issue", "pull_request"]);
@@ -534,7 +535,7 @@ export const githubWorkflowStatusMappingSchema = z.object({
   reason: z.string().min(1)
 });
 
-export const githubHandoffArtifactKindSchema = z.enum(["planning-brief", "design-record", "qa-report", "release-report"]);
+export const githubHandoffArtifactKindSchema = z.enum(["planning-brief", "design-record", "incident-brief", "qa-report", "release-report"]);
 
 export const githubHandoffSectionSchema = z.object({
   heading: z.string().min(1),
@@ -670,6 +671,15 @@ export const implementationArtifactPayloadSchema = z.object({
   openQuestions: z.array(z.string().min(1)).default([])
 });
 
+export const incidentArtifactPayloadSchema = z.object({
+  incidentSummary: z.string().min(1),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  timelineSummary: z.array(z.string().min(1)).default([]),
+  likelyImpactedAreas: z.array(z.string().min(1)).default([]),
+  followUpWorkflowRefs: z.array(z.string().min(1)).default([]),
+  openQuestions: z.array(z.string().min(1)).default([])
+});
+
 export const releaseVerificationCheckSchema = z.object({
   name: z.string().min(1),
   status: z.enum(["passed", "failed", "skipped"]),
@@ -769,6 +779,12 @@ export const implementationArtifactSchema = lifecycleArtifactEnvelopeSchema.exte
   payload: implementationArtifactPayloadSchema
 });
 
+export const incidentArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("incident-brief"),
+  lifecycleDomain: z.literal("operate"),
+  payload: incidentArtifactPayloadSchema
+});
+
 export const qaArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   artifactKind: z.literal("qa-report"),
   lifecycleDomain: z.literal("test"),
@@ -803,6 +819,7 @@ export const lifecycleArtifactSchema = z.discriminatedUnion("artifactKind", [
   planningArtifactSchema,
   designArtifactSchema,
   implementationArtifactSchema,
+  incidentArtifactSchema,
   qaArtifactSchema,
   securityArtifactSchema,
   reviewArtifactSchema,
@@ -861,6 +878,7 @@ export const schemaRegistry = {
   designArtifactOption: designArtifactOptionSchema,
   designArtifactPayload: designArtifactPayloadSchema,
   implementationArtifactPayload: implementationArtifactPayloadSchema,
+  incidentArtifactPayload: incidentArtifactPayloadSchema,
   qaArtifactPayload: qaArtifactPayloadSchema,
   securityArtifactPayload: securityArtifactPayloadSchema,
   reviewArtifactPayload: reviewArtifactPayloadSchema,
@@ -874,6 +892,7 @@ export const schemaRegistry = {
   planningArtifact: planningArtifactSchema,
   designArtifact: designArtifactSchema,
   implementationArtifact: implementationArtifactSchema,
+  incidentArtifact: incidentArtifactSchema,
   qaArtifact: qaArtifactSchema,
   securityArtifact: securityArtifactSchema,
   reviewArtifact: reviewArtifactSchema,
@@ -1021,6 +1040,28 @@ const implementationArtifactFixture = {
     ],
     risks: ["Affected repository surfaces may widen once deterministic inventory lands."],
     openQuestions: ["Which validation commands should become allowlisted in the next slice?"]
+  }
+} as const;
+
+const incidentArtifactFixture = {
+  ...lifecycleArtifactFixtureBase,
+  artifactKind: "incident-brief",
+  lifecycleDomain: "operate",
+  summary: "Incident brief prepared for elevated 500s after the latest release candidate.",
+  payload: {
+    incidentSummary: "Customers saw elevated 500s after the latest release candidate.",
+    evidenceSources: [
+      ".agentops/evidence/incident-summary.md",
+      ".agentops/evidence/alerts.json",
+      ".agentops/runs/run-release/bundle.json"
+    ],
+    timelineSummary: [
+      "Severity hint: high.",
+      "Two staged evidence sources and one release-report reference were validated before reasoning."
+    ],
+    likelyImpactedAreas: ["release-readiness", "maintenance-triage", "packages/cli"],
+    followUpWorkflowRefs: ["maintenance-triage", "security-review"],
+    openQuestions: ["Which release candidate introduced the first reproducible 500 response?"]
   }
 } as const;
 
@@ -1535,6 +1576,7 @@ export const schemaFixtures = {
   planningArtifact: planningArtifactFixture,
   designArtifact: designArtifactFixture,
   implementationArtifact: implementationArtifactFixture,
+  incidentArtifact: incidentArtifactFixture,
   qaArtifact: qaArtifactFixture,
   securityArtifact: securityArtifactFixture,
   reviewArtifact: reviewArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -7,6 +7,7 @@ import type {
   ImplementationArtifact,
   ImplementationInventory,
   ImplementationRequest,
+  IncidentArtifact,
   IncidentRequest,
   MaintenanceArtifact,
   NormalizedValidationCommand,
@@ -36,6 +37,8 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<DesignArtifact["lifecycleDomain"]>().toEqualTypeOf<"design">();
     expectTypeOf<ImplementationArtifact["artifactKind"]>().toEqualTypeOf<"implementation-proposal">();
     expectTypeOf<ImplementationArtifact["lifecycleDomain"]>().toEqualTypeOf<"build">();
+    expectTypeOf<IncidentArtifact["artifactKind"]>().toEqualTypeOf<"incident-brief">();
+    expectTypeOf<IncidentArtifact["lifecycleDomain"]>().toEqualTypeOf<"operate">();
     expectTypeOf<QaArtifact["artifactKind"]>().toEqualTypeOf<"qa-report">();
     expectTypeOf<QaArtifact["lifecycleDomain"]>().toEqualTypeOf<"test">();
     expectTypeOf<SecurityArtifact["artifactKind"]>().toEqualTypeOf<"security-report">();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -37,6 +37,8 @@ import {
   implementationArtifactSchema,
   implementationInventorySchema,
   implementationRequestSchema,
+  incidentArtifactPayloadSchema,
+  incidentArtifactSchema,
   incidentRequestSchema,
   maintenanceArtifactPayloadSchema,
   maintenanceArtifactSchema,
@@ -108,6 +110,8 @@ export type ImplementationArtifactPayload = Infer<typeof implementationArtifactP
 export type ImplementationArtifact = Infer<typeof implementationArtifactSchema>;
 export type ImplementationInventory = Infer<typeof implementationInventorySchema>;
 export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
+export type IncidentArtifactPayload = Infer<typeof incidentArtifactPayloadSchema>;
+export type IncidentArtifact = Infer<typeof incidentArtifactSchema>;
 export type IncidentRequest = Infer<typeof incidentRequestSchema>;
 export type QaArtifactPayload = Infer<typeof qaArtifactPayloadSchema>;
 export type QaArtifact = Infer<typeof qaArtifactSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-types
 
+  agents/incident-analyst:
+    dependencies:
+      '@h9-foundry/agentforge-schemas':
+        specifier: workspace:*
+        version: link:../../packages/schemas
+      '@h9-foundry/agentforge-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@h9-foundry/agentforge-shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
+
   agents/planning-analyst:
     dependencies:
       '@h9-foundry/agentforge-schemas':


### PR DESCRIPTION
## Summary
- add the bounded `incident-analyst` starter agent and first `incident-brief` lifecycle artifact
- wire the incident reasoning step into `incident-handoff` and render incident handoff summaries through audit output
- update the incident workflow doc and changesets for the new artifact-emission slice

Closes #151

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/audit/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts agents/incident-analyst/src/index.test.ts`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- `#191` still reproduces and remains the separate `explain last-run` bug; this slice keeps incident analysis bounded to staged evidence and artifact emission.
- `pnpm test; echo EXIT:$?` remains tool-wrapper-ambiguous in this environment, so the slice relies on focused passing suites plus the standard build and smoke gates.