### PR TITLE
Implement incident evidence normalization and routing

### DIFF
--- a/.agentops/workflows/incident-handoff.yaml
+++ b/.agentops/workflows/incident-handoff.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: incident-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: incident-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: incident
     kind: reasoning
     agent: incident-analyst

--- a/.changeset/incident-evidence-normalization.md
+++ b/.changeset/incident-evidence-normalization.md
@@ -1,0 +1,9 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+"@h9-foundry/agentforge-policy-engine": patch
+"@h9-foundry/incident-analyst-agent": patch
+---
+
+Add deterministic incident-evidence normalization, provenance capture, and redaction-aware routing for `incident-handoff`.

--- a/agents/incident-analyst/src/index.test.ts
+++ b/agents/incident-analyst/src/index.test.ts
@@ -77,6 +77,40 @@ describe("incident analyst agent", () => {
               severityHint: "high",
               constraints: ["Keep staged incident evidence read-only"]
             }
+          },
+          evidence: {
+            metadata: {
+              incidentSummary: "Customers saw elevated 500s after the latest release candidate.",
+              severityHint: "high",
+              normalizedEvidenceSources: [
+                ".agentops/evidence/incident-summary.md",
+                ".agentops/evidence/alerts.json",
+                ".agentops/runs/run-release/bundle.json"
+              ],
+              missingEvidenceSources: [],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+              timelineSummary: [
+                "Severity hint: high.",
+                "Normalized staged incident evidence and release-report references before reasoning."
+              ],
+              likelyImpactedAreas: ["release-readiness", "staged-operational-evidence", "security-follow-up"],
+              followUpWorkflowRefs: ["maintenance-triage", "release-readiness", "security-review"],
+              provenanceRefs: [
+                ".agentops/evidence/incident-summary.md",
+                ".agentops/evidence/alerts.json",
+                ".agentops/runs/run-release/bundle.json#release-report"
+              ],
+              redactionCategories: [
+                "github-token",
+                "api-key",
+                "aws-key",
+                "bearer-token",
+                "password",
+                "private-key",
+                "operational-sensitive"
+              ],
+              referencedArtifactKinds: ["release-report"]
+            }
           }
         }
       } as never,
@@ -94,5 +128,7 @@ describe("incident analyst agent", () => {
     expect(artifact.payload.incidentSummary).toContain("elevated 500s");
     expect(artifact.payload.followUpWorkflowRefs).toContain("security-review");
     expect(artifact.payload.followUpWorkflowRefs).toContain("maintenance-triage");
+    expect(artifact.payload.timelineSummary[1]).toContain("Normalized staged incident evidence");
+    expect(artifact.payload.likelyImpactedAreas).toContain("security-follow-up");
   });
 });

--- a/agents/incident-analyst/src/index.ts
+++ b/agents/incident-analyst/src/index.ts
@@ -1,5 +1,5 @@
-import { agentManifestSchema, agentOutputSchema, incidentArtifactSchema } from "@h9-foundry/agentforge-schemas";
-import type { GithubReference, IncidentArtifact, IncidentRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import { agentManifestSchema, agentOutputSchema, incidentArtifactSchema, incidentEvidenceNormalizationSchema } from "@h9-foundry/agentforge-schemas";
+import type { GithubReference, IncidentArtifact, IncidentEvidenceNormalization, IncidentRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -122,27 +122,39 @@ export const incidentAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const evidenceMetadata = incidentEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence = evidenceMetadata.success ? evidenceMetadata.data : undefined;
     const severityHint =
-      typeof intakeMetadata.severityHint === "string" ? intakeMetadata.severityHint : incidentRequest.severityHint;
-    const evidenceSources = [
-      ...new Set([
-        ...asStringArray(intakeMetadata.evidenceSources),
-        ...asStringArray(intakeMetadata.releaseReportRefs),
-        ...incidentRequest.evidenceSources,
-        ...incidentRequest.releaseReportRefs
-      ])
-    ];
+      normalizedEvidence?.severityHint ??
+      (typeof intakeMetadata.severityHint === "string" ? intakeMetadata.severityHint : incidentRequest.severityHint);
+    const evidenceSources =
+      normalizedEvidence?.normalizedEvidenceSources && normalizedEvidence.normalizedEvidenceSources.length > 0
+        ? normalizedEvidence.normalizedEvidenceSources
+        : [
+            ...new Set([
+              ...asStringArray(intakeMetadata.evidenceSources),
+              ...asStringArray(intakeMetadata.releaseReportRefs),
+              ...incidentRequest.evidenceSources,
+              ...incidentRequest.releaseReportRefs
+            ])
+          ];
     const constraints = asStringArray(intakeMetadata.constraints);
-    const followUpWorkflowRefs = [
-      "maintenance-triage",
-      ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
-      ...(severityHint === "high" || severityHint === "critical" ? ["security-review"] : [])
-    ];
-    const likelyImpactedAreas = [
-      ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
-      ...(incidentRequest.evidenceSources.length > 0 ? ["staged-operational-evidence"] : []),
-      ...(severityHint === "high" || severityHint === "critical" ? ["security-follow-up"] : [])
-    ];
+    const followUpWorkflowRefs =
+      normalizedEvidence?.followUpWorkflowRefs && normalizedEvidence.followUpWorkflowRefs.length > 0
+        ? normalizedEvidence.followUpWorkflowRefs
+        : [
+            "maintenance-triage",
+            ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+            ...(severityHint === "high" || severityHint === "critical" ? ["security-review"] : [])
+          ];
+    const likelyImpactedAreas =
+      normalizedEvidence?.likelyImpactedAreas && normalizedEvidence.likelyImpactedAreas.length > 0
+        ? normalizedEvidence.likelyImpactedAreas
+        : [
+            ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+            ...(incidentRequest.evidenceSources.length > 0 ? ["staged-operational-evidence"] : []),
+            ...(severityHint === "high" || severityHint === "critical" ? ["security-follow-up"] : [])
+          ];
     const openQuestions = [
       ...(incidentRequest.issueRefs.length === 0 ? ["Should this incident be linked to a tracked issue before escalation?"] : []),
       ...(incidentRequest.releaseReportRefs.length === 0 ? ["Is there a release-report bundle that should be attached for additional provenance?"] : [])
@@ -152,7 +164,7 @@ export const incidentAnalystAgent: RuntimeAgent = {
       ...buildArtifactEnvelopeBase(
         state,
         summary,
-        [requestFile ?? ".agentops/requests/incident.yaml", ...incidentRequest.evidenceSources, ...incidentRequest.releaseReportRefs],
+        [requestFile ?? ".agentops/requests/incident.yaml", ...evidenceSources],
         incidentIssueRefs,
         incidentGithubRefs
       ),
@@ -161,10 +173,12 @@ export const incidentAnalystAgent: RuntimeAgent = {
       payload: {
         incidentSummary: incidentRequest.incidentSummary,
         evidenceSources,
-        timelineSummary: [
-          `Severity hint: ${severityHint}.`,
-          `Validated ${incidentRequest.evidenceSources.length} staged evidence source(s) and ${incidentRequest.releaseReportRefs.length} release-report reference(s) before reasoning.`
-        ],
+        timelineSummary:
+          normalizedEvidence?.timelineSummary ??
+          [
+            `Severity hint: ${severityHint}.`,
+            `Validated ${incidentRequest.evidenceSources.length} staged evidence source(s) and ${incidentRequest.releaseReportRefs.length} release-report reference(s) before reasoning.`
+          ],
         likelyImpactedAreas:
           likelyImpactedAreas.length > 0
             ? likelyImpactedAreas
@@ -187,7 +201,8 @@ export const incidentAnalystAgent: RuntimeAgent = {
           severityHint,
           evidenceSources,
           issueRefs: incidentIssueRefs,
-          constraints
+          constraints,
+          normalizedEvidence: (normalizedEvidence ?? null) satisfies IncidentEvidenceNormalization | null
         },
         synthesizedAssessment: {
           likelyImpactedAreas: incidentBrief.payload.likelyImpactedAreas,

--- a/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
+++ b/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
@@ -32,14 +32,16 @@ Available now:
 - context, policy, artifact, and audit infrastructure
 - official `incident-handoff` workflow asset with bounded staged-evidence intake
 - deterministic incident request validation and release-report reference checks
+- deterministic staged incident-evidence normalization, provenance capture, and follow-up routing
 - bounded `incident-analyst`
 - `incident-brief` lifecycle artifact emission
 - explicit local staged-evidence posture with read-only default behavior
+- redaction-aware handling for sensitive operational evidence in routing and artifact output
 
 Not yet available:
 
-- deterministic staged incident-evidence normalization and routing
 - broader operations or observability adapter support
+- official promotion of `incident-handoff` while the evaluator-path bug remains open
 
 ## Recommended Initial Workflow Family
 
@@ -53,7 +55,7 @@ Later planned variants can include:
 - `alert-triage`
 - `operational-readiness-review`
 
-`incident-handoff` is now implemented as an intake-only wedge. The later incident and operations variants remain planned.
+`incident-handoff` is now implemented as a bounded staged-evidence handoff wedge. The later incident and operations variants remain planned.
 
 ## User Jobs
 
@@ -94,7 +96,7 @@ Recommended input model:
 ### Workflow Stages
 
 1. intake normalization
-2. deterministic evidence staging and release-report reference validation
+2. deterministic staged evidence normalization, provenance capture, and release-report reference validation
 3. incident analysis
 4. report and artifact emission
 
@@ -162,8 +164,9 @@ Implemented on current `main`:
 1. incident request schema and official `incident-handoff` workflow asset
 2. deterministic validation of staged incident evidence and referenced `release-report` artifacts before reasoning
 3. `incident-analyst` starter agent and `incident-brief` artifact emission
+4. deterministic staged incident-evidence normalization, provenance capture, and follow-up routing
 
 Next incident family follow-ons:
 
-1. deterministic staged incident-evidence normalization and source provenance capture
-2. redaction/policy wiring for sensitive operational evidence and follow-up routing
+1. resolve the evaluator-path bug before official promotion of `incident-handoff`
+2. add broader operations and observability integrations only through explicit, approval-aware adapters

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1484,8 +1484,12 @@ describe("cli smoke flows", () => {
       workflow: string;
       lifecycleArtifacts: Array<{
         artifactKind: string;
+        redaction?: {
+          categories?: string[];
+        };
         payload?: {
           incidentSummary?: string;
+          timelineSummary?: string[];
           followUpWorkflowRefs?: string[];
           likelyImpactedAreas?: string[];
         };
@@ -1495,10 +1499,12 @@ describe("cli smoke flows", () => {
     expect(bundle.lifecycleArtifacts).toHaveLength(1);
     expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("incident-brief");
     expect(bundle.lifecycleArtifacts[0]?.payload?.incidentSummary).toContain("elevated 500s");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.timelineSummary?.[1]).toContain("Normalized staged incident evidence");
     expect(bundle.lifecycleArtifacts[0]?.payload?.followUpWorkflowRefs).toEqual(
       expect.arrayContaining(["maintenance-triage", "security-review", "release-readiness"])
     );
     expect(bundle.lifecycleArtifacts[0]?.payload?.likelyImpactedAreas).toContain("release-readiness");
+    expect(bundle.lifecycleArtifacts[0]?.redaction?.categories).toContain("operational-sensitive");
   });
 
   it("propagates normalized GitHub references through downstream lifecycle artifacts", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -324,6 +324,10 @@ nodes:
     kind: deterministic
     agent: incident-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: incident-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: incident
     kind: reasoning
     agent: incident-analyst

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -288,6 +288,84 @@ describe("builtin qa evidence normalizer", () => {
   });
 });
 
+describe("builtin incident evidence normalizer", () => {
+  it("normalizes staged incident evidence, provenance, and follow-up routing", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentforge-incident-evidence-"));
+    mkdirSync(join(root, ".agentops", "runs", "run-release"), { recursive: true });
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    writeFileSync(join(root, ".agentops", "evidence", "incident-summary.md"), "# incident summary\n");
+    writeFileSync(join(root, ".agentops", "evidence", "alerts.json"), JSON.stringify({ alert: "elevated-500s" }, null, 2));
+    writeFileSync(
+      join(root, ".agentops", "runs", "run-release", "bundle.json"),
+      JSON.stringify(
+        {
+          finishedAt: new Date().toISOString(),
+          lifecycleArtifacts: [schemaFixtures.releaseArtifact]
+        },
+        null,
+        2
+      )
+    );
+
+    const agent = createBuiltinAgentRegistry().get("incident-evidence-normalizer");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        repo: {
+          root,
+          name: "fixture-root",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        workflowInputs: {
+          incidentRequest: {
+            incidentSummary: "Customers saw elevated 500s after the last release candidate.",
+            severityHint: "high",
+            evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+            releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+            issueRefs: ["#159"],
+            constraints: ["Keep staged incident evidence read-only"]
+          }
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              evidenceSources: [".agentops/evidence/incident-summary.md", ".agentops/evidence/alerts.json"],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+              severityHint: "high"
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.metadata).toMatchObject({
+      incidentSummary: "Customers saw elevated 500s after the last release candidate.",
+      severityHint: "high"
+    });
+    expect(output.metadata?.normalizedEvidenceSources).toEqual(
+      expect.arrayContaining([
+        ".agentops/evidence/incident-summary.md",
+        ".agentops/evidence/alerts.json",
+        ".agentops/runs/run-release/bundle.json"
+      ])
+    );
+    expect(output.metadata?.referencedArtifactKinds).toContain("release-report");
+    expect(output.metadata?.followUpWorkflowRefs).toEqual(
+      expect.arrayContaining(["maintenance-triage", "release-readiness", "security-review"])
+    );
+    expect(output.metadata?.redactionCategories).toContain("operational-sensitive");
+    expect(output.metadata?.provenanceRefs).toContain(".agentops/runs/run-release/bundle.json#release-report");
+  });
+});
+
 describe("builtin security intake agent", () => {
   it("records bounded security request metadata and referenced artifact kinds", async () => {
     const root = mkdtempSync(join(tmpdir(), "agentforge-security-intake-"));

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import {
@@ -9,6 +9,7 @@ import {
   implementationArtifactSchema,
   implementationInventorySchema,
   incidentArtifactSchema,
+  incidentEvidenceNormalizationSchema,
   incidentRequestSchema,
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
@@ -33,6 +34,7 @@ import type {
   ImplementationInventory,
   ImplementationRequest,
   IncidentArtifact,
+  IncidentEvidenceNormalization,
   IncidentRequest,
   NormalizedValidationCommand,
   PlanningArtifact,
@@ -266,6 +268,33 @@ function loadBundleArtifactPayloadPaths(bundlePath: string): string[] {
 
     return [];
   });
+}
+
+function loadBundleFinishedAt(bundlePath: string): string | undefined {
+  if (!existsSync(bundlePath)) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(readFileSync(bundlePath, "utf8")) as unknown;
+  return isRecord(parsed) && typeof parsed.finishedAt === "string" ? parsed.finishedAt : undefined;
+}
+
+function describeEvidenceObservation(repoRoot: string | undefined, pathValue: string): string {
+  if (!repoRoot) {
+    return `Observed source ${pathValue} during deterministic intake.`;
+  }
+
+  const absolutePath = join(repoRoot, pathValue);
+  if (!existsSync(absolutePath)) {
+    return `Observed source ${pathValue} during deterministic intake.`;
+  }
+
+  const observedAt =
+    pathValue.endsWith(".json") && pathValue.includes(".agentops/runs/")
+      ? loadBundleFinishedAt(absolutePath)
+      : undefined;
+  const fallbackObservedAt = observedAt ?? statSync(absolutePath).mtime.toISOString();
+  return `Observed source ${pathValue} at ${fallbackObservedAt}.`;
 }
 
 function loadGitHubActionsEvidence(bundlePath: string): GithubActionsEvidence | undefined {
@@ -1074,6 +1103,115 @@ const incidentIntakeAgent: RuntimeAgent = {
   }
 };
 
+const incidentEvidenceNormalizationAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "incident-evidence-normalizer",
+    displayName: "Incident Evidence Normalizer",
+    category: "operate",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**", "**/*.json", "**/*.log", "**/*.md", "**/*.txt"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "agentResults"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "operate",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const incidentRequest = getWorkflowInput<IncidentRequest>(stateSlice, "incidentRequest");
+    if (!incidentRequest) {
+      throw new Error("incident-handoff requires validated incident request inputs before evidence normalization.");
+    }
+
+    const repoRoot = stateSlice.repo?.root;
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const releaseReportRefs =
+      asStringArray(intakeMetadata.releaseReportRefs).length > 0
+        ? asStringArray(intakeMetadata.releaseReportRefs)
+        : incidentRequest.releaseReportRefs;
+    const evidenceSources =
+      asStringArray(intakeMetadata.evidenceSources).length > 0
+        ? asStringArray(intakeMetadata.evidenceSources)
+        : incidentRequest.evidenceSources;
+    const severityHint =
+      typeof intakeMetadata.severityHint === "string" ? intakeMetadata.severityHint : incidentRequest.severityHint;
+    const normalizedEvidenceSources = [...new Set([...evidenceSources, ...releaseReportRefs])];
+    const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
+    if (missingEvidenceSources.length > 0) {
+      throw new Error(`Incident evidence source not found: ${missingEvidenceSources[0]}`);
+    }
+
+    const referencedArtifactKinds = [...new Set(
+      releaseReportRefs.flatMap((pathValue) => (repoRoot ? loadBundleArtifactKinds(join(repoRoot, pathValue)) : []))
+    )];
+    const timelineSummary = [
+      `Severity hint: ${severityHint}.`,
+      "Normalized staged incident evidence and release-report references before reasoning.",
+      ...normalizedEvidenceSources.map((pathValue) => describeEvidenceObservation(repoRoot, pathValue))
+    ];
+    const likelyImpactedAreas = [
+      ...(releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+      ...(evidenceSources.length > 0 ? ["staged-operational-evidence"] : []),
+      ...(severityHint === "high" || severityHint === "critical" ? ["security-follow-up"] : [])
+    ];
+    const followUpWorkflowRefs = [
+      "maintenance-triage",
+      ...(releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+      ...(severityHint === "high" || severityHint === "critical" ? ["security-review"] : [])
+    ];
+    const normalization = incidentEvidenceNormalizationSchema.parse({
+      incidentSummary: incidentRequest.incidentSummary,
+      severityHint,
+      normalizedEvidenceSources,
+      missingEvidenceSources: [],
+      releaseReportRefs,
+      timelineSummary,
+      likelyImpactedAreas: [...new Set(likelyImpactedAreas)],
+      followUpWorkflowRefs: [...new Set(followUpWorkflowRefs)],
+      provenanceRefs: [
+        ...new Set([
+          ...evidenceSources,
+          ...releaseReportRefs.map((pathValue) => `${pathValue}#release-report`)
+        ])
+      ],
+      redactionCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key", "operational-sensitive"],
+      referencedArtifactKinds
+    });
+
+    return agentOutputSchema.parse({
+      summary: `Normalized incident evidence across ${normalization.normalizedEvidenceSources.length} staged source(s).`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: normalization satisfies IncidentEvidenceNormalization
+    });
+  }
+};
+
 const incidentAnalystAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -1120,8 +1258,11 @@ const incidentAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const evidenceSources =
-      asStringArray(intakeMetadata.evidenceSources).length > 0
+    const evidenceMetadata = incidentEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence = evidenceMetadata.success ? evidenceMetadata.data : undefined;
+    const evidenceSources = normalizedEvidence?.normalizedEvidenceSources && normalizedEvidence.normalizedEvidenceSources.length > 0
+      ? normalizedEvidence.normalizedEvidenceSources
+      : asStringArray(intakeMetadata.evidenceSources).length > 0
         ? [
             ...new Set([
               ...asStringArray(intakeMetadata.evidenceSources),
@@ -1129,19 +1270,23 @@ const incidentAnalystAgent: RuntimeAgent = {
             ])
           ]
         : [...new Set([...incidentRequest.evidenceSources, ...incidentRequest.releaseReportRefs])];
-    const severityHint =
-      typeof intakeMetadata.severityHint === "string" ? intakeMetadata.severityHint : incidentRequest.severityHint;
+    const severityHint = normalizedEvidence?.severityHint ??
+      (typeof intakeMetadata.severityHint === "string" ? intakeMetadata.severityHint : incidentRequest.severityHint);
     const constraints = asStringArray(intakeMetadata.constraints);
-    const followUpWorkflowRefs = [
-      "maintenance-triage",
-      ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
-      ...(severityHint === "high" || severityHint === "critical" ? ["security-review"] : [])
-    ];
-    const likelyImpactedAreas = [
-      ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
-      ...(incidentRequest.evidenceSources.length > 0 ? ["staged-operational-evidence"] : []),
-      ...(severityHint === "high" || severityHint === "critical" ? ["security-follow-up"] : [])
-    ];
+    const followUpWorkflowRefs = normalizedEvidence?.followUpWorkflowRefs && normalizedEvidence.followUpWorkflowRefs.length > 0
+      ? normalizedEvidence.followUpWorkflowRefs
+      : [
+          "maintenance-triage",
+          ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+          ...(severityHint === "high" || severityHint === "critical" ? ["security-review"] : [])
+        ];
+    const likelyImpactedAreas = normalizedEvidence?.likelyImpactedAreas && normalizedEvidence.likelyImpactedAreas.length > 0
+      ? normalizedEvidence.likelyImpactedAreas
+      : [
+          ...(incidentRequest.releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+          ...(incidentRequest.evidenceSources.length > 0 ? ["staged-operational-evidence"] : []),
+          ...(severityHint === "high" || severityHint === "critical" ? ["security-follow-up"] : [])
+        ];
     const openQuestions = [
       ...(incidentRequest.issueRefs.length === 0 ? ["Should this incident be linked to a tracked issue before escalation?"] : []),
       ...(incidentRequest.releaseReportRefs.length === 0
@@ -1154,7 +1299,7 @@ const incidentAnalystAgent: RuntimeAgent = {
         state,
         "Incident Handoff",
         summary,
-        [requestFile ?? ".agentops/requests/incident.yaml", ...incidentRequest.evidenceSources, ...incidentRequest.releaseReportRefs],
+        [requestFile ?? ".agentops/requests/incident.yaml", ...evidenceSources],
         incidentIssueRefs,
         incidentGithubRefs
       ),
@@ -1163,12 +1308,20 @@ const incidentAnalystAgent: RuntimeAgent = {
       redaction: {
         applied: true,
         strategyVersion: "1.0.0",
-        categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key", "operational-sensitive"]
+        categories: normalizedEvidence?.redactionCategories ?? [
+          "github-token",
+          "api-key",
+          "aws-key",
+          "bearer-token",
+          "password",
+          "private-key",
+          "operational-sensitive"
+        ]
       },
       payload: {
         incidentSummary: incidentRequest.incidentSummary,
         evidenceSources,
-        timelineSummary: [
+        timelineSummary: normalizedEvidence?.timelineSummary ?? [
           `Severity hint: ${severityHint}.`,
           `Validated ${incidentRequest.evidenceSources.length} staged evidence source(s) and ${incidentRequest.releaseReportRefs.length} release-report reference(s) before reasoning.`
         ],
@@ -1194,7 +1347,8 @@ const incidentAnalystAgent: RuntimeAgent = {
           severityHint,
           evidenceSources,
           issueRefs: incidentIssueRefs,
-          constraints
+          constraints,
+          normalizedEvidence: normalizedEvidence ?? null
         },
         synthesizedAssessment: {
           likelyImpactedAreas: incidentBrief.payload.likelyImpactedAreas,
@@ -2846,6 +3000,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["qa-intake", qaIntakeAgent],
     ["security-intake", securityIntakeAgent],
     ["incident-intake", incidentIntakeAgent],
+    ["incident-evidence-normalizer", incidentEvidenceNormalizationAgent],
     ["incident-analyst", incidentAnalystAgent],
     ["release-intake", releaseIntakeAgent],
     ["release-evidence-normalizer", releaseEvidenceNormalizationAgent],

--- a/packages/policy-engine/src/index.test.ts
+++ b/packages/policy-engine/src/index.test.ts
@@ -256,4 +256,56 @@ describe("policy engine", () => {
     }
     expect(sanitized.redaction.categories).toContain("security-sensitive");
   });
+
+  it("marks incident-brief artifacts as operational-sensitive during sanitization", () => {
+    const engine = createPolicyEngine(
+      {
+        version: 1,
+        environment: "local",
+        resolvedAt: new Date().toISOString(),
+        defaults: {
+          executionMode: "inspect",
+          modelAccess: false,
+          network: "deny",
+          writes: "approval_required"
+        },
+        paths: {
+          allowedRead: ["**/*"],
+          allowedWrite: [".agentops/runs/**", "tests/**"],
+          blocked: [".env*", "secrets/**"]
+        },
+        plugins: {
+          allowedTiers: ["core", "verified"],
+          allowedSources: ["official", "local"],
+          requireReviewed: true
+        },
+        tools: {
+          "filesystem.read-file": { effect: "allow" }
+        }
+      },
+      "/repo"
+    );
+
+    const incidentArtifact = lifecycleArtifactSchema.parse(JSON.parse(JSON.stringify(schemaFixtures.incidentArtifact)));
+    expect(incidentArtifact.artifactKind).toBe("incident-brief");
+    if (incidentArtifact.artifactKind !== "incident-brief") {
+      throw new Error("Expected incident artifact fixture");
+    }
+
+    const sanitized = engine.sanitizeLifecycleArtifact({
+      ...incidentArtifact,
+      redaction: {
+        ...incidentArtifact.redaction,
+        categories: ["github-token"]
+      },
+      summary: "summary token=ghp_1234567890ABCDE"
+    });
+
+    expect(sanitized.summary).toContain("[REDACTED_TOKEN]");
+    expect(sanitized.artifactKind).toBe("incident-brief");
+    if (sanitized.artifactKind !== "incident-brief") {
+      throw new Error("Expected sanitized incident artifact");
+    }
+    expect(sanitized.redaction.categories).toContain("operational-sensitive");
+  });
 });

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -285,7 +285,14 @@ export function createPolicyEngine(policy: EffectivePolicySnapshot, repoRoot: st
 
   function sanitizeLifecycleArtifact(artifact: LifecycleArtifact): LifecycleArtifact {
     const sanitized = lifecycleArtifactSchema.parse(sanitizeUnknown(artifact, redactSecrets));
-    if (sanitized.artifactKind !== "security-report") {
+    const additionalCategories =
+      sanitized.artifactKind === "security-report"
+        ? ["security-sensitive"]
+        : sanitized.artifactKind === "incident-brief"
+          ? ["operational-sensitive"]
+          : [];
+
+    if (additionalCategories.length === 0) {
       return sanitized;
     }
 
@@ -293,7 +300,7 @@ export function createPolicyEngine(policy: EffectivePolicySnapshot, repoRoot: st
       ...sanitized,
       redaction: {
         ...sanitized.redaction,
-        categories: Array.from(new Set([...sanitized.redaction.categories, "security-sensitive"]))
+        categories: Array.from(new Set([...sanitized.redaction.categories, ...additionalCategories]))
       }
     });
   }

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -433,6 +433,20 @@ export const securityEvidenceNormalizationSchema = z.object({
   affectedPackages: z.array(z.string().min(1)).default([])
 });
 
+export const incidentEvidenceNormalizationSchema = z.object({
+  incidentSummary: z.string().min(1),
+  severityHint: z.enum(["unknown", "low", "medium", "high", "critical"]),
+  normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
+  missingEvidenceSources: z.array(z.string().min(1)).default([]),
+  releaseReportRefs: z.array(z.string().min(1)).default([]),
+  timelineSummary: z.array(z.string().min(1)).default([]),
+  likelyImpactedAreas: z.array(z.string().min(1)).default([]),
+  followUpWorkflowRefs: z.array(z.string().min(1)).default([]),
+  provenanceRefs: z.array(z.string().min(1)).default([]),
+  redactionCategories: z.array(z.string().min(1)).default([]),
+  referencedArtifactKinds: z.array(z.string().min(1)).default([])
+});
+
 export const repoMetadataSchema = z.object({
   root: z.string().min(1),
   name: z.string().min(1),
@@ -914,6 +928,7 @@ export const schemaRegistry = {
   implementationInventory: implementationInventorySchema,
   qaEvidenceNormalization: qaEvidenceNormalizationSchema,
   securityEvidenceNormalization: securityEvidenceNormalizationSchema,
+  incidentEvidenceNormalization: incidentEvidenceNormalizationSchema,
   policyDocument: policyDocumentSchema,
   effectivePolicySnapshot: effectivePolicySnapshotSchema,
   workflowDefinition: workflowDefinitionSchema,
@@ -1411,6 +1426,34 @@ const securityEvidenceNormalizationFixture = {
   affectedPackages: ["packages/cli", "packages/runtime"]
 } as const;
 
+const incidentEvidenceNormalizationFixture = {
+  incidentSummary: "Customers saw elevated 500s after the last release candidate.",
+  severityHint: "high",
+  normalizedEvidenceSources: [
+    ".agentops/evidence/incident-summary.md",
+    ".agentops/evidence/alerts.json",
+    ".agentops/runs/run-release/bundle.json"
+  ],
+  missingEvidenceSources: [],
+  releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+  timelineSummary: [
+    "Severity hint: high.",
+    "Normalized staged incident evidence and release-report references before reasoning.",
+    "Observed source .agentops/evidence/incident-summary.md during deterministic intake.",
+    "Observed source .agentops/evidence/alerts.json during deterministic intake.",
+    "Observed source .agentops/runs/run-release/bundle.json during deterministic intake."
+  ],
+  likelyImpactedAreas: ["release-readiness", "staged-operational-evidence", "security-follow-up"],
+  followUpWorkflowRefs: ["maintenance-triage", "release-readiness", "security-review"],
+  provenanceRefs: [
+    ".agentops/evidence/incident-summary.md",
+    ".agentops/evidence/alerts.json",
+    ".agentops/runs/run-release/bundle.json#release-report"
+  ],
+  redactionCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key", "operational-sensitive"],
+  referencedArtifactKinds: ["release-report"]
+} as const;
+
 const releaseEvidenceNormalizationFixture = {
   qaReportRefs: [".agentops/runs/run-789/bundle.json"],
   securityReportRefs: [".agentops/runs/run-790/bundle.json"],
@@ -1571,6 +1614,7 @@ export const schemaFixtures = {
   implementationInventory: implementationInventoryFixture,
   qaEvidenceNormalization: qaEvidenceNormalizationFixture,
   securityEvidenceNormalization: securityEvidenceNormalizationFixture,
+  incidentEvidenceNormalization: incidentEvidenceNormalizationFixture,
   releaseEvidenceNormalization: releaseEvidenceNormalizationFixture,
   lifecycleArtifactEnvelope: planningArtifactFixture,
   planningArtifact: planningArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -8,6 +8,7 @@ import type {
   ImplementationInventory,
   ImplementationRequest,
   IncidentArtifact,
+  IncidentEvidenceNormalization,
   IncidentRequest,
   MaintenanceArtifact,
   NormalizedValidationCommand,
@@ -65,6 +66,9 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
     expectTypeOf<IncidentRequest["incidentSummary"]>().toEqualTypeOf<string>();
+    expectTypeOf<IncidentEvidenceNormalization["severityHint"]>().toEqualTypeOf<
+      "unknown" | "low" | "medium" | "high" | "critical"
+    >();
     expectTypeOf<QaRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<SecurityRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ReleaseRequest["releaseScope"]>().toEqualTypeOf<string>();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -36,6 +36,7 @@ import {
   implementationArtifactPayloadSchema,
   implementationArtifactSchema,
   implementationInventorySchema,
+  incidentEvidenceNormalizationSchema,
   implementationRequestSchema,
   incidentArtifactPayloadSchema,
   incidentArtifactSchema,
@@ -110,6 +111,7 @@ export type ImplementationArtifactPayload = Infer<typeof implementationArtifactP
 export type ImplementationArtifact = Infer<typeof implementationArtifactSchema>;
 export type ImplementationInventory = Infer<typeof implementationInventorySchema>;
 export type ImplementationRequest = Infer<typeof implementationRequestSchema>;
+export type IncidentEvidenceNormalization = Infer<typeof incidentEvidenceNormalizationSchema>;
 export type IncidentArtifactPayload = Infer<typeof incidentArtifactPayloadSchema>;
 export type IncidentArtifact = Infer<typeof incidentArtifactSchema>;
 export type IncidentRequest = Infer<typeof incidentRequestSchema>;


### PR DESCRIPTION
## Summary
- implement deterministic staged incident-evidence normalization for `incident-handoff`
- preserve provenance, derived follow-up routing, and redaction-aware incident metadata
- wire the new deterministic evidence node into the incident workflow and keep docs honest about current support

## Changes
- add `incidentEvidenceNormalization` schema and shared type export
- add builtin `incident-evidence-normalizer` and consume normalized metadata in `incident-analyst`
- wire `incident-handoff` to run intake -> evidence normalization -> incident analysis
- mark sanitized `incident-brief` artifacts as `operational-sensitive`
- update incident workflow docs and add a changeset

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/policy-engine/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts agents/incident-analyst/src/index.test.ts`
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts agents/incident-analyst/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo smoke run for `node packages/cli/dist/bin.js run incident-handoff --json`

## Notes
- `#191` still reproduces and remains out of scope for this PR; it continues to block official promotion of `incident-handoff`
- `pnpm test; echo EXIT:$?` remains wrapper-ambiguous in this environment, so this PR relies on the focused passing suites plus the standard build and smoke gates

Closes #159