### PR TITLE
Add maintenance triage intake workflow

### DIFF
--- a/.agentops/workflows/maintenance-triage.yaml
+++ b/.agentops/workflows/maintenance-triage.yaml
@@ -1,0 +1,17 @@
+version: 1
+name: maintenance-triage
+description: Validate a bounded maintenance request while keeping the default path local, read-only, and routing-oriented.
+trigger: manual
+catalog:
+  domain: maintain
+  supportLevel: partial
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: maintenance-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final

--- a/.changeset/maintenance-triage-intake.md
+++ b/.changeset/maintenance-triage-intake.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add the `maintenance-triage` intake workflow, request schema, and deterministic maintenance request validation.

--- a/docs/MAINTENANCE_WORKFLOWS.md
+++ b/docs/MAINTENANCE_WORKFLOWS.md
@@ -4,7 +4,7 @@ This document defines the design target for issue [#61](https://github.com/H9-Fo
 
 It describes how AgentForge should support routine maintenance work as a lifecycle domain separate from review and release.
 
-It does **not** claim that these workflows are implemented or officially shipped today.
+It does **not** claim that the broader maintenance workflow family is fully implemented or officially promoted today.
 
 ## Why This Exists
 
@@ -38,12 +38,14 @@ Available now:
 - GitHub issue planning and queue tracking
 - newcomer and contributor docs/process scaffolding
 - lifecycle artifact and audit infrastructure
+- official `maintenance-triage` workflow asset with bounded maintenance request intake
+- deterministic maintenance request validation and release-report reference checks
 
 Not yet available:
 
-- official maintenance workflow assets
-- dedicated maintenance artifacts in runtime use
-- explicit dependency/docs-hygiene workflow boundaries
+- `maintenance-analyst` and `maintenance-report` artifact emission
+- deterministic dependency/docs/release signal collection and routing classification
+- official promotion of `maintenance-triage` before the later maintenance slices land
 
 ## Recommended Initial Workflow Family
 
@@ -57,7 +59,7 @@ Later planned variants can include:
 - `docs-hygiene-review`
 - `maintenance-backlog-refresh`
 
-Only `maintenance-triage` should be targeted for first implementation planning.
+`maintenance-triage` is now implemented as an intake-only wedge. The later maintenance variants remain planned.
 
 ## User Jobs
 
@@ -97,7 +99,7 @@ Recommended input model:
 ### Workflow Stages
 
 1. intake normalization
-2. deterministic maintenance evidence collection
+2. deterministic maintenance reference validation
 3. maintenance analysis
 4. report and artifact emission
 
@@ -156,10 +158,13 @@ Adapter expectations:
 
 ## Follow-On Implementation Slices
 
-This epic should be decomposed into at least:
+Implemented on current `main`:
 
 1. maintenance request schema and official `maintenance-triage` workflow asset
-2. `maintenance-analyst` starter agent and `maintenance-report` artifact emission
-3. deterministic dependency/docs/release signal collection and routing classification
-4. GitHub and release/readiness handoff wiring for maintenance follow-up work
+2. deterministic validation of dependency alert refs, docs task refs, release-report refs, and backlog issue refs before reasoning
 
+Next maintenance family follow-ons:
+
+1. `maintenance-analyst` starter agent and `maintenance-report` artifact emission
+2. deterministic dependency/docs/release signal collection and routing classification
+3. GitHub and release/readiness handoff wiring for maintenance follow-up work

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1507,6 +1507,102 @@ describe("cli smoke flows", () => {
     expect(bundle.lifecycleArtifacts[0]?.redaction?.categories).toContain("operational-sensitive");
   });
 
+  it("fails maintenance-triage before reasoning when the request is missing", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+
+    await expect(runLocalWorkflow("maintenance-triage", root)).rejects.toThrow("Missing maintenance request");
+  });
+
+  it("rejects underspecified maintenance-triage requests before reasoning", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+    writeYamlFile(join(root, ".agentops", "requests", "maintenance.yaml"), {
+      maintenanceGoal: "Triage routine maintenance work."
+    });
+
+    await expect(runLocalWorkflow("maintenance-triage", root)).rejects.toThrow(/Maintenance request is underspecified/i);
+  });
+
+  it("runs maintenance-triage after valid maintenance request references", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+
+    const releaseBundleDir = join(root, ".agentops", "runs", "run-release");
+    mkdirSync(releaseBundleDir, { recursive: true });
+    writeFileSync(
+      join(releaseBundleDir, "bundle.json"),
+      JSON.stringify(
+        {
+          version: "1.0.0",
+          runId: "run-release",
+          workflow: "release-readiness",
+          startedAt: new Date().toISOString(),
+          finishedAt: new Date().toISOString(),
+          status: "success",
+          policy: {
+            version: 1,
+            environment: "local",
+            resolvedAt: new Date().toISOString(),
+            defaults: schemaFixtures.policyDocument.defaults,
+            paths: schemaFixtures.policyDocument.paths,
+            plugins: schemaFixtures.policyDocument.plugins,
+            tools: schemaFixtures.policyDocument.tools
+          },
+          entries: [],
+          findings: [],
+          proposedActions: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [schemaFixtures.releaseArtifact],
+          artifactPaths: {
+            json: ".agentops/runs/run-release/bundle.json",
+            markdown: ".agentops/runs/run-release/summary.md"
+          },
+          provenance: {
+            generatedBy: "agentforge-runtime",
+            schemaVersion: "1.0.0",
+            executionEnvironment: "local",
+            repoRoot: root
+          },
+          redaction: {
+            applied: true,
+            strategyVersion: "1.0.0",
+            categories: ["github-token"]
+          },
+          components: []
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(join(releaseBundleDir, "summary.md"), "# release summary\n");
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    writeFileSync(join(root, ".agentops", "evidence", "dependency-alerts.json"), JSON.stringify({ alerts: ["vitest upgrade"] }, null, 2));
+    writeFileSync(join(root, ".agentops", "evidence", "docs-task.md"), "# docs task\n");
+    writeYamlFile(join(root, ".agentops", "requests", "maintenance.yaml"), {
+      maintenanceGoal: "Triage dependency and docs hygiene follow-up after the latest release.",
+      dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+      docsTaskRefs: [".agentops/evidence/docs-task.md"],
+      releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+      issueRefs: ["#145"],
+      constraints: ["Keep maintenance triage read-only"]
+    });
+
+    const maintenanceRun = await runLocalWorkflow("maintenance-triage", root);
+
+    expect(maintenanceRun.status).toBe("success");
+    expect(maintenanceRun.artifactCount).toBe(0);
+
+    const bundle = readJson<{
+      workflow: string;
+      entries: Array<{ nodeId: string }>;
+    }>(maintenanceRun.jsonPath);
+    expect(bundle.workflow).toBe("maintenance-triage");
+    expect(bundle.entries.some((entry) => entry.nodeId === "intake")).toBe(true);
+  });
+
   it("propagates normalized GitHub references through downstream lifecycle artifacts", async () => {
     const root = createGitFixture("agentops-github-refs-");
     initProject(root);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,6 +15,7 @@ import {
   designRequestSchema,
   implementationRequestSchema,
   incidentRequestSchema,
+  maintenanceRequestSchema,
   planningArtifactSchema,
   planningRequestSchema,
   qaRequestSchema,
@@ -32,6 +33,7 @@ import type {
   GithubWorkflowStatusMapping,
   ImplementationRequest,
   IncidentRequest,
+  MaintenanceRequest,
   PlanningArtifact,
   PlanningRequest,
   QaRequest,
@@ -337,6 +339,25 @@ nodes:
     outputs_to: reports.final
 `;
 
+const maintenanceWorkflowTemplate = `version: 1
+name: maintenance-triage
+description: Validate a bounded maintenance request while keeping the default path local, read-only, and routing-oriented.
+trigger: manual
+catalog:
+  domain: maintain
+  supportLevel: partial
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: maintenance-intake
+    outputs_to: agentResults.intake
+  - id: report
+    kind: report
+    outputs_to: reports.final
+`;
+
 function loadYaml(filePath: string): unknown {
   return yaml.load(readFileSync(filePath, "utf8"));
 }
@@ -562,6 +583,21 @@ function validateIncidentRequestCompleteness(request: IncidentRequest): Incident
   if (evidenceSignalCount === 0) {
     throw new Error(
       "Incident request is underspecified. Add at least one of evidenceSources or releaseReportRefs."
+    );
+  }
+
+  return request;
+}
+
+function validateMaintenanceRequestCompleteness(request: MaintenanceRequest): MaintenanceRequest {
+  const supportingSignalCount =
+    request.dependencyAlertRefs.length +
+    request.docsTaskRefs.length +
+    request.releaseReportRefs.length +
+    request.issueRefs.length;
+  if (supportingSignalCount === 0) {
+    throw new Error(
+      "Maintenance request is underspecified. Add at least one of dependencyAlertRefs, docsTaskRefs, releaseReportRefs, or issueRefs."
     );
   }
 
@@ -890,6 +926,54 @@ function prepareWorkflowInputs(
     };
   }
 
+  if (workflow.name === "maintenance-triage") {
+    const requestPath = ".agentops/requests/maintenance.yaml";
+    ensureReadablePath(policyEngine, requestPath, "maintenance request");
+    const maintenanceRequest = validateMaintenanceRequestCompleteness(
+      readYamlFile(join(root, requestPath), maintenanceRequestSchema, "maintenance request")
+    );
+
+    const repoContext = inferGitHubRepoContext(root);
+    const maintenanceIssueRefs = new Set<string>(maintenanceRequest.issueRefs);
+    const maintenanceGithubRefMap = new Map<string, GithubReference>();
+    for (const githubRef of normalizeGitHubReferences(maintenanceRequest.issueRefs, repoContext)) {
+      maintenanceGithubRefMap.set(githubRef.canonical, githubRef);
+    }
+
+    for (const releaseReportRef of maintenanceRequest.releaseReportRefs) {
+      ensureReadablePath(policyEngine, releaseReportRef, "release report reference");
+      ensureBundleContainsArtifactKind(root, releaseReportRef, "release-report", "release report reference");
+      const refs = loadLifecycleArtifactSourceReferences(root, releaseReportRef);
+      for (const issueRef of refs.issueRefs) {
+        maintenanceIssueRefs.add(issueRef);
+      }
+      for (const githubRef of refs.githubRefs) {
+        maintenanceGithubRefMap.set(githubRef.canonical, githubRef);
+      }
+    }
+
+    for (const dependencyAlertRef of maintenanceRequest.dependencyAlertRefs) {
+      ensureReadablePath(policyEngine, dependencyAlertRef, "dependency alert reference");
+      if (!existsSync(join(root, dependencyAlertRef))) {
+        throw new Error(`Dependency alert reference not found: ${dependencyAlertRef}`);
+      }
+    }
+
+    for (const docsTaskRef of maintenanceRequest.docsTaskRefs) {
+      ensureReadablePath(policyEngine, docsTaskRef, "docs task reference");
+      if (!existsSync(join(root, docsTaskRef))) {
+        throw new Error(`Docs task reference not found: ${docsTaskRef}`);
+      }
+    }
+
+    return {
+      maintenanceRequest: maintenanceRequest satisfies MaintenanceRequest,
+      maintenanceIssueRefs: [...maintenanceIssueRefs],
+      maintenanceGithubRefs: [...maintenanceGithubRefMap.values()],
+      requestFile: requestPath
+    };
+  }
+
   return {};
 }
 
@@ -1106,6 +1190,10 @@ function ensureInitFiles(root: string): string[] {
     {
       path: join(workflowsDir, "incident-handoff.yaml"),
       contents: incidentWorkflowTemplate
+    },
+    {
+      path: join(workflowsDir, "maintenance-triage.yaml"),
+      contents: maintenanceWorkflowTemplate
     }
   ];
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -11,6 +11,7 @@ import {
   incidentArtifactSchema,
   incidentEvidenceNormalizationSchema,
   incidentRequestSchema,
+  maintenanceRequestSchema,
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
@@ -36,6 +37,7 @@ import type {
   IncidentArtifact,
   IncidentEvidenceNormalization,
   IncidentRequest,
+  MaintenanceRequest,
   NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
@@ -1208,6 +1210,77 @@ const incidentEvidenceNormalizationAgent: RuntimeAgent = {
       requestedTools: [],
       blockedActionFlags: [],
       metadata: normalization satisfies IncidentEvidenceNormalization
+    });
+  }
+};
+
+const maintenanceIntakeAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "maintenance-intake",
+    displayName: "Maintenance Intake",
+    category: "maintain",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**", "**/*.json", "**/*.md", "**/*.txt"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "context"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "maintain",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const maintenanceRequest = getWorkflowInput<MaintenanceRequest>(stateSlice, "maintenanceRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    const maintenanceIssueRefs = getWorkflowInput<string[]>(stateSlice, "maintenanceIssueRefs") ?? [];
+    const maintenanceGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "maintenanceGithubRefs") ?? [];
+    if (!maintenanceRequest) {
+      throw new Error("maintenance-triage requires a validated maintenance request before runtime execution.");
+    }
+
+    return agentOutputSchema.parse({
+      summary: `Loaded maintenance request from ${requestFile ?? ".agentops/requests/maintenance.yaml"} for ${maintenanceRequest.maintenanceGoal}.`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: {
+        ...maintenanceRequestSchema.parse({
+          ...maintenanceRequest,
+          dependencyAlertRefs: [...new Set(maintenanceRequest.dependencyAlertRefs)],
+          docsTaskRefs: [...new Set(maintenanceRequest.docsTaskRefs)],
+          releaseReportRefs: [...new Set(maintenanceRequest.releaseReportRefs)],
+          issueRefs: [...new Set(maintenanceRequest.issueRefs)]
+        }),
+        maintenanceIssueRefs,
+        maintenanceGithubRefs,
+        evidenceSourceCount:
+          maintenanceRequest.dependencyAlertRefs.length +
+          maintenanceRequest.docsTaskRefs.length +
+          maintenanceRequest.releaseReportRefs.length
+      }
     });
   }
 };
@@ -3001,6 +3074,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["security-intake", securityIntakeAgent],
     ["incident-intake", incidentIntakeAgent],
     ["incident-evidence-normalizer", incidentEvidenceNormalizationAgent],
+    ["maintenance-intake", maintenanceIntakeAgent],
     ["incident-analyst", incidentAnalystAgent],
     ["release-intake", releaseIntakeAgent],
     ["release-evidence-normalizer", releaseEvidenceNormalizationAgent],

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -736,6 +736,15 @@ export const incidentRequestSchema = z.object({
   constraints: z.array(z.string().min(1)).default([])
 });
 
+export const maintenanceRequestSchema = z.object({
+  maintenanceGoal: z.string().min(1),
+  dependencyAlertRefs: z.array(z.string().min(1)).default([]),
+  docsTaskRefs: z.array(z.string().min(1)).default([]),
+  releaseReportRefs: z.array(z.string().min(1)).default([]),
+  issueRefs: z.array(z.string().min(1)).default([]),
+  constraints: z.array(z.string().min(1)).default([])
+});
+
 export const releaseEvidenceNormalizationSchema = z.object({
   qaReportRefs: z.array(z.string().min(1)).default([]),
   securityReportRefs: z.array(z.string().min(1)).default([]),
@@ -924,6 +933,7 @@ export const schemaRegistry = {
   securityRequest: securityRequestSchema,
   releaseRequest: releaseRequestSchema,
   incidentRequest: incidentRequestSchema,
+  maintenanceRequest: maintenanceRequestSchema,
   normalizedValidationCommand: normalizedValidationCommandSchema,
   implementationInventory: implementationInventorySchema,
   qaEvidenceNormalization: qaEvidenceNormalizationSchema,
@@ -1273,6 +1283,15 @@ const incidentRequestFixture = {
   constraints: ["Keep staged incident evidence read-only"]
 } as const;
 
+const maintenanceRequestFixture = {
+  maintenanceGoal: "Triage dependency and docs hygiene follow-up after the latest release.",
+  dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+  docsTaskRefs: [".agentops/evidence/docs-task.md"],
+  releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+  issueRefs: ["#145"],
+  constraints: ["Keep maintenance triage read-only"]
+} as const;
+
 const normalizedValidationCommandFixture = {
   command: "pnpm test",
   source: "request",
@@ -1606,6 +1625,7 @@ export const schemaFixtures = {
   securityRequest: securityRequestFixture,
   releaseRequest: releaseRequestFixture,
   incidentRequest: incidentRequestFixture,
+  maintenanceRequest: maintenanceRequestFixture,
   githubReference: githubReferenceFixture,
   githubActionsEvidence: githubActionsEvidenceFixture,
   githubHandoffSummary: githubHandoffSummaryFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -11,6 +11,7 @@ import type {
   IncidentEvidenceNormalization,
   IncidentRequest,
   MaintenanceArtifact,
+  MaintenanceRequest,
   NormalizedValidationCommand,
   PlanningArtifact,
   PlanningRequest,
@@ -69,6 +70,7 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<IncidentEvidenceNormalization["severityHint"]>().toEqualTypeOf<
       "unknown" | "low" | "medium" | "high" | "critical"
     >();
+    expectTypeOf<MaintenanceRequest["maintenanceGoal"]>().toEqualTypeOf<string>();
     expectTypeOf<QaRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<SecurityRequest["targetRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ReleaseRequest["releaseScope"]>().toEqualTypeOf<string>();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -43,6 +43,7 @@ import {
   incidentRequestSchema,
   maintenanceArtifactPayloadSchema,
   maintenanceArtifactSchema,
+  maintenanceRequestSchema,
   normalizedValidationCommandSchema,
   policyDocumentSchema,
   qaArtifactPayloadSchema,
@@ -136,6 +137,7 @@ export type ReleaseArtifactPayload = Infer<typeof releaseArtifactPayloadSchema>;
 export type ReleaseArtifact = Infer<typeof releaseArtifactSchema>;
 export type MaintenanceArtifactPayload = Infer<typeof maintenanceArtifactPayloadSchema>;
 export type MaintenanceArtifact = Infer<typeof maintenanceArtifactSchema>;
+export type MaintenanceRequest = Infer<typeof maintenanceRequestSchema>;
 export type AgentOutput = Infer<typeof agentOutputSchema>;
 export type AgentManifest = Infer<typeof agentManifestSchema>;
 export type AgentPluginRegistration = Infer<typeof agentPluginRegistrationSchema>;


### PR DESCRIPTION
## Summary
- add the maintenance request schema and shared type export
- add the bounded `maintenance-triage` workflow asset and deterministic intake agent
- keep the maintenance family honest in docs while leaving analyst and routing work to later slices

## Changes
- add `maintenanceRequest` to shared schema/type contracts
- add deterministic `maintenance-intake` support for validated request loading and normalized refs
- add `maintenance-triage` workflow asset and CLI/init wiring
- add request validation for dependency alert refs, docs task refs, release-report refs, and issue refs
- update maintenance workflow docs and add a changeset

## Validation
- `pnpm exec vitest run packages/cli/src/index.test.ts packages/shared-types/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- disposable repo smoke run for `node packages/cli/dist/bin.js run maintenance-triage --json`

## Notes
- this PR intentionally stops at deterministic intake and request validation; `maintenance-analyst` and maintenance routing remain in `#152` and `#158`
- `#191` remains a separate evaluator-path bug and is not part of this slice

Closes #145