### PR TITLE
Add maintenance analyst artifact emission

### DIFF
--- a/.agentops/workflows/maintenance-triage.yaml
+++ b/.agentops/workflows/maintenance-triage.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: maintenance-intake
     outputs_to: agentResults.intake
+  - id: maintenance
+    kind: reasoning
+    agent: maintenance-analyst
+    outputs_to: agentResults.maintenance
   - id: report
     kind: report
     outputs_to: reports.final

--- a/.changeset/maintenance-analyst-report.md
+++ b/.changeset/maintenance-analyst-report.md
@@ -1,0 +1,8 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+"@h9-foundry/agentforge-agent-maintenance-analyst": patch
+---
+
+Add the bounded `maintenance-analyst` starter agent and emit `maintenance-report` lifecycle artifacts for `maintenance-triage`.

--- a/agents/maintenance-analyst/CHANGELOG.md
+++ b/agents/maintenance-analyst/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @h9-foundry/agentforge-agent-maintenance-analyst
+
+## 0.1.0
+
+- Add the bounded `maintenance-analyst` starter agent and emit `maintenance-report` lifecycle artifacts for `maintenance-triage`.

--- a/agents/maintenance-analyst/agent.manifest.json
+++ b/agents/maintenance-analyst/agent.manifest.json
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "name": "maintenance-analyst",
+  "displayName": "Maintenance Analyst",
+  "category": "maintain",
+  "runtime": {
+    "minVersion": "0.1.0",
+    "kind": "reasoning"
+  },
+  "permissions": {
+    "model": true,
+    "network": false,
+    "tools": [],
+    "readPaths": ["**/*"],
+    "writePaths": []
+  },
+  "inputs": ["workflowInputs", "repo", "changes", "agentResults"],
+  "outputs": ["lifecycleArtifacts"],
+  "contextPolicy": {
+    "sections": ["workflowInputs", "repo", "changes", "agentResults"],
+    "minimalContext": true
+  },
+  "catalog": {
+    "domain": "maintain",
+    "supportLevel": "internal",
+    "maturity": "mvp",
+    "trustScope": "official-core-only"
+  },
+  "trust": {
+    "tier": "core",
+    "source": "official",
+    "reviewed": true
+  }
+}

--- a/agents/maintenance-analyst/package.json
+++ b/agents/maintenance-analyst/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@h9-foundry/agentforge-agent-maintenance-analyst",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "agent.manifest.json"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@h9-foundry/agentforge-schemas": "workspace:*",
+    "@h9-foundry/agentforge-sdk": "workspace:*",
+    "@h9-foundry/agentforge-shared-types": "workspace:*"
+  }
+}

--- a/agents/maintenance-analyst/src/index.test.ts
+++ b/agents/maintenance-analyst/src/index.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import { maintenanceAnalystAgent } from "./index.js";
+
+describe("maintenance analyst agent", () => {
+  it("emits a maintenance-report artifact from validated inputs", async () => {
+    const output = await maintenanceAnalystAgent.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-maintenance",
+        workflow: "maintenance-triage",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: ["docs"],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          maintenanceRequest: {
+            maintenanceGoal: "Triage dependency and docs hygiene follow-up after the latest release.",
+            dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+            docsTaskRefs: [".agentops/evidence/docs-task.md"],
+            releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+            issueRefs: ["#152"],
+            constraints: ["Keep maintenance triage read-only"]
+          },
+          maintenanceIssueRefs: ["#152"],
+          maintenanceGithubRefs: [
+            {
+              platform: "github",
+              host: "github.com",
+              owner: "H9-Foundry",
+              repo: "AgentForge",
+              kind: "issue",
+              number: 152,
+              canonical: "H9-Foundry/AgentForge#152",
+              url: "https://github.com/H9-Foundry/AgentForge/issues/152",
+              source: "#152"
+            }
+          ],
+          requestFile: ".agentops/requests/maintenance.yaml"
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+              docsTaskRefs: [".agentops/evidence/docs-task.md"],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+              constraints: ["Keep maintenance triage read-only"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.lifecycleArtifacts).toHaveLength(1);
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("maintenance-report");
+    if (!artifact || artifact.artifactKind !== "maintenance-report") {
+      throw new Error("Expected maintenance-report artifact.");
+    }
+
+    expect(artifact.payload.maintenanceScope).toContain("dependency and docs hygiene");
+    expect(artifact.payload.dependencyUpdates).toContain(".agentops/evidence/dependency-alerts.json");
+    expect(artifact.payload.docsUpdates).toContain(".agentops/evidence/docs-task.md");
+    expect(artifact.payload.followUpIssues).toContain("#152");
+  });
+});

--- a/agents/maintenance-analyst/src/index.ts
+++ b/agents/maintenance-analyst/src/index.ts
@@ -1,0 +1,210 @@
+import { agentManifestSchema, agentOutputSchema, maintenanceArtifactSchema } from "@h9-foundry/agentforge-schemas";
+import type { GithubReference, MaintenanceArtifact, MaintenanceRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : [];
+}
+
+function asGithubRefs(value: unknown): GithubReference[] {
+  return Array.isArray(value)
+    ? value.filter(
+        (entry): entry is GithubReference =>
+          Boolean(entry) && typeof entry === "object" && "canonical" in entry && typeof (entry as { canonical?: unknown }).canonical === "string"
+      )
+    : [];
+}
+
+function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: string): T | undefined {
+  if (!isRecord(stateSlice.workflowInputs)) {
+    return undefined;
+  }
+
+  return stateSlice.workflowInputs[key] as T | undefined;
+}
+
+function buildArtifactEnvelopeBase(
+  state: WorkflowStateEnvelope,
+  summary: string,
+  inputRefs: readonly string[],
+  issueRefs: readonly string[],
+  githubRefs: readonly GithubReference[]
+) {
+  return {
+    schemaVersion: state.version,
+    workflow: {
+      name: state.workflow,
+      displayName: "Maintenance Triage"
+    },
+    source: {
+      sourceType: "workflow-run" as const,
+      runId: state.runId,
+      inputRefs: [...inputRefs],
+      issueRefs: [...issueRefs],
+      githubRefs: [...githubRefs]
+    },
+    status: "complete" as const,
+    generatedAt: new Date().toISOString(),
+    repo: {
+      root: state.repo.root,
+      name: state.repo.name,
+      branch: state.repo.branch
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" as const : "local" as const,
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
+    },
+    auditLink: {
+      entryIds: [],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary
+  };
+}
+
+export const manifest = agentManifestSchema.parse({
+  version: 1,
+  name: "maintenance-analyst",
+  displayName: "Maintenance Analyst",
+  category: "maintain",
+  runtime: {
+    minVersion: "0.1.0",
+    kind: "reasoning"
+  },
+  permissions: {
+    model: true,
+    network: false,
+    tools: [],
+    readPaths: ["**/*"],
+    writePaths: []
+  },
+  inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+  outputs: ["lifecycleArtifacts"],
+  contextPolicy: {
+    sections: ["workflowInputs", "repo", "changes", "agentResults"],
+    minimalContext: true
+  },
+  catalog: {
+    domain: "maintain",
+    supportLevel: "internal",
+    maturity: "mvp",
+    trustScope: "official-core-only"
+  },
+  trust: {
+    tier: "core",
+    source: "official",
+    reviewed: true
+  }
+});
+
+export const maintenanceAnalystAgent: RuntimeAgent = {
+  manifest,
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const maintenanceRequest = getWorkflowInput<MaintenanceRequest>(stateSlice, "maintenanceRequest");
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    const maintenanceIssueRefs = getWorkflowInput<string[]>(stateSlice, "maintenanceIssueRefs") ?? [];
+    const maintenanceGithubRefs = asGithubRefs(getWorkflowInput<unknown>(stateSlice, "maintenanceGithubRefs"));
+    if (!maintenanceRequest) {
+      throw new Error("maintenance-triage requires validated maintenance inputs before maintenance analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const dependencyAlertRefs = asStringArray(intakeMetadata.dependencyAlertRefs).length > 0
+      ? asStringArray(intakeMetadata.dependencyAlertRefs)
+      : maintenanceRequest.dependencyAlertRefs;
+    const docsTaskRefs = asStringArray(intakeMetadata.docsTaskRefs).length > 0
+      ? asStringArray(intakeMetadata.docsTaskRefs)
+      : maintenanceRequest.docsTaskRefs;
+    const releaseReportRefs = asStringArray(intakeMetadata.releaseReportRefs).length > 0
+      ? asStringArray(intakeMetadata.releaseReportRefs)
+      : maintenanceRequest.releaseReportRefs;
+    const constraints = asStringArray(intakeMetadata.constraints);
+    const evidenceSources = [...new Set([...dependencyAlertRefs, ...docsTaskRefs, ...releaseReportRefs])];
+    const currentFindings = [
+      ...(dependencyAlertRefs.length > 0 ? [`${dependencyAlertRefs.length} dependency alert reference(s) require maintenance triage.`] : []),
+      ...(docsTaskRefs.length > 0 ? [`${docsTaskRefs.length} docs task reference(s) require maintenance triage.`] : []),
+      ...(releaseReportRefs.length > 0 ? [`${releaseReportRefs.length} release-report reference(s) contribute maintenance follow-up context.`] : [])
+    ];
+    const recommendedActions = [
+      ...dependencyAlertRefs.map((pathValue) => `Review dependency alert reference \`${pathValue}\` before choosing a follow-up workflow.`),
+      ...docsTaskRefs.map((pathValue) => `Review docs task reference \`${pathValue}\` before choosing a follow-up workflow.`),
+      ...releaseReportRefs.map((pathValue) => `Review release report reference \`${pathValue}\` for maintenance-linked follow-up work.`),
+      ...(constraints.length > 0 ? [`Keep maintenance follow-up bounded by: ${constraints.join("; ")}.`] : [])
+    ];
+    const priorityAssessment =
+      dependencyAlertRefs.length > 1 || releaseReportRefs.length > 0
+        ? "Elevated maintenance triage: release-linked or multi-alert follow-up should be prioritized before broader maintenance work."
+        : "Routine maintenance triage: review bounded references and route follow-up deliberately.";
+    const stalenessSignals = [
+      ...(dependencyAlertRefs.length > 0 ? ["Dependency alert follow-up remains pending review."] : []),
+      ...(docsTaskRefs.length > 0 ? ["Documentation maintenance follow-up remains pending review."] : []),
+      ...(releaseReportRefs.length > 0 ? ["Release-linked maintenance follow-up remains pending review."] : [])
+    ];
+    const summary = `Maintenance report prepared for ${maintenanceRequest.maintenanceGoal}.`;
+    const maintenanceReport = maintenanceArtifactSchema.parse({
+      ...buildArtifactEnvelopeBase(
+        state,
+        summary,
+        [requestFile ?? ".agentops/requests/maintenance.yaml", ...evidenceSources],
+        maintenanceIssueRefs,
+        maintenanceGithubRefs
+      ),
+      artifactKind: "maintenance-report",
+      lifecycleDomain: "maintain",
+      payload: {
+        maintenanceScope: maintenanceRequest.maintenanceGoal,
+        currentFindings:
+          currentFindings.length > 0
+            ? currentFindings
+            : ["Maintenance triage remained bounded to validated references; no additional findings were synthesized."],
+        recommendedActions:
+          recommendedActions.length > 0
+            ? recommendedActions
+            : ["Add at least one bounded maintenance reference before broadening the workflow surface."],
+        priorityAssessment,
+        dependencyUpdates: dependencyAlertRefs,
+        docsUpdates: docsTaskRefs,
+        stalenessSignals,
+        followUpIssues: maintenanceIssueRefs
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [maintenanceReport satisfies MaintenanceArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.73,
+      metadata: {
+        deterministicInputs: {
+          evidenceSources,
+          dependencyAlertRefs,
+          docsTaskRefs,
+          releaseReportRefs,
+          issueRefs: maintenanceIssueRefs,
+          constraints
+        },
+        synthesizedAssessment: {
+          priorityAssessment: maintenanceReport.payload.priorityAssessment,
+          recommendedActions: maintenanceReport.payload.recommendedActions,
+          followUpIssues: maintenanceReport.payload.followUpIssues
+        }
+      }
+    });
+  }
+};

--- a/agents/maintenance-analyst/tsconfig.json
+++ b/agents/maintenance-analyst/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "tsBuildInfoFile": "./dist/.tsbuildinfo"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/docs/MAINTENANCE_WORKFLOWS.md
+++ b/docs/MAINTENANCE_WORKFLOWS.md
@@ -40,10 +40,10 @@ Available now:
 - lifecycle artifact and audit infrastructure
 - official `maintenance-triage` workflow asset with bounded maintenance request intake
 - deterministic maintenance request validation and release-report reference checks
+- bounded `maintenance-analyst` starter agent and `maintenance-report` lifecycle artifact emission
 
 Not yet available:
 
-- `maintenance-analyst` and `maintenance-report` artifact emission
 - deterministic dependency/docs/release signal collection and routing classification
 - official promotion of `maintenance-triage` before the later maintenance slices land
 
@@ -59,7 +59,7 @@ Later planned variants can include:
 - `docs-hygiene-review`
 - `maintenance-backlog-refresh`
 
-`maintenance-triage` is now implemented as an intake-only wedge. The later maintenance variants remain planned.
+`maintenance-triage` is now implemented as an intake-plus-analysis wedge. The later maintenance variants remain planned.
 
 ## User Jobs
 
@@ -162,9 +162,9 @@ Implemented on current `main`:
 
 1. maintenance request schema and official `maintenance-triage` workflow asset
 2. deterministic validation of dependency alert refs, docs task refs, release-report refs, and backlog issue refs before reasoning
+3. `maintenance-analyst` starter agent and `maintenance-report` lifecycle artifact emission
 
 Next maintenance family follow-ons:
 
-1. `maintenance-analyst` starter agent and `maintenance-report` artifact emission
-2. deterministic dependency/docs/release signal collection and routing classification
-3. GitHub and release/readiness handoff wiring for maintenance follow-up work
+1. deterministic dependency/docs/release signal collection and routing classification
+2. GitHub and release/readiness handoff wiring for maintenance follow-up work

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1593,14 +1593,29 @@ describe("cli smoke flows", () => {
     const maintenanceRun = await runLocalWorkflow("maintenance-triage", root);
 
     expect(maintenanceRun.status).toBe("success");
-    expect(maintenanceRun.artifactCount).toBe(0);
+    expect(maintenanceRun.artifactCount).toBe(1);
 
     const bundle = readJson<{
       workflow: string;
       entries: Array<{ nodeId: string }>;
+      lifecycleArtifacts: Array<{
+        artifactKind?: string;
+        payload?: {
+          maintenanceScope?: string;
+          followUpIssues?: string[];
+          dependencyUpdates?: string[];
+          docsUpdates?: string[];
+        };
+      }>;
     }>(maintenanceRun.jsonPath);
     expect(bundle.workflow).toBe("maintenance-triage");
     expect(bundle.entries.some((entry) => entry.nodeId === "intake")).toBe(true);
+    expect(bundle.entries.some((entry) => entry.nodeId === "maintenance")).toBe(true);
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("maintenance-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.maintenanceScope).toContain("dependency and docs hygiene");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.followUpIssues).toContain("#145");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.dependencyUpdates).toContain(".agentops/evidence/dependency-alerts.json");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.docsUpdates).toContain(".agentops/evidence/docs-task.md");
   });
 
   it("propagates normalized GitHub references through downstream lifecycle artifacts", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -353,6 +353,10 @@ nodes:
     kind: deterministic
     agent: maintenance-intake
     outputs_to: agentResults.intake
+  - id: maintenance
+    kind: reasoning
+    agent: maintenance-analyst
+    outputs_to: agentResults.maintenance
   - id: report
     kind: report
     outputs_to: reports.final

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -544,6 +544,93 @@ describe("builtin incident analyst agent", () => {
   });
 });
 
+describe("builtin maintenance analyst agent", () => {
+  it("emits a maintenance-report artifact from bounded maintenance inputs", async () => {
+    const agent = createBuiltinAgentRegistry().get("maintenance-analyst");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {
+        version: "1.0.0",
+        runId: "run-maintenance",
+        workflow: "maintenance-triage",
+        mode: "inspect",
+        repo: {
+          root: "/repo",
+          name: "repo",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        changes: {
+          changedFiles: [],
+          stagedFiles: [],
+          untrackedFiles: [],
+          impactedPaths: [],
+          diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+          fileDetails: []
+        },
+        context: {
+          localExecution: true,
+          ciExecution: false,
+          trigger: "manual",
+          timestamp: new Date().toISOString()
+        },
+        policy: {} as never,
+        approvals: [],
+        findings: [],
+        proposedActions: [],
+        lifecycleArtifacts: [],
+        blockedPlugins: [],
+        workflowInputs: {},
+        agentResults: {},
+        auditTrail: []
+      },
+      stateSlice: {
+        workflowInputs: {
+          maintenanceRequest: {
+            maintenanceGoal: "Triage dependency and docs hygiene follow-up.",
+            dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+            docsTaskRefs: [".agentops/evidence/docs-task.md"],
+            releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+            issueRefs: ["#152"],
+            constraints: ["Keep maintenance triage read-only"]
+          },
+          maintenanceIssueRefs: ["#152"],
+          maintenanceGithubRefs: [schemaFixtures.githubReference],
+          requestFile: ".agentops/requests/maintenance.yaml"
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+              docsTaskRefs: [".agentops/evidence/docs-task.md"],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+              constraints: ["Keep maintenance triage read-only"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.lifecycleArtifacts).toHaveLength(1);
+    const artifact = output.lifecycleArtifacts[0];
+    expect(artifact?.artifactKind).toBe("maintenance-report");
+    if (!artifact || artifact.artifactKind !== "maintenance-report") {
+      throw new Error("Expected maintenance-report artifact.");
+    }
+
+    expect(artifact.payload.maintenanceScope).toContain("dependency and docs hygiene");
+    expect(artifact.payload.dependencyUpdates).toContain(".agentops/evidence/dependency-alerts.json");
+    expect(artifact.payload.docsUpdates).toContain(".agentops/evidence/docs-task.md");
+    expect(artifact.payload.followUpIssues).toContain("#152");
+  });
+});
+
 describe("builtin security analyst agent", () => {
   it("emits a security-report artifact from bounded security inputs", async () => {
     const agent = createBuiltinAgentRegistry().get("security-analyst");

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -11,6 +11,7 @@ import {
   incidentArtifactSchema,
   incidentEvidenceNormalizationSchema,
   incidentRequestSchema,
+  maintenanceArtifactSchema,
   maintenanceRequestSchema,
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
@@ -37,6 +38,7 @@ import type {
   IncidentArtifact,
   IncidentEvidenceNormalization,
   IncidentRequest,
+  MaintenanceArtifact,
   MaintenanceRequest,
   NormalizedValidationCommand,
   PlanningArtifact,
@@ -1280,6 +1282,140 @@ const maintenanceIntakeAgent: RuntimeAgent = {
           maintenanceRequest.dependencyAlertRefs.length +
           maintenanceRequest.docsTaskRefs.length +
           maintenanceRequest.releaseReportRefs.length
+      }
+    });
+  }
+};
+
+const maintenanceAnalystAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "maintenance-analyst",
+    displayName: "Maintenance Analyst",
+    category: "maintain",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "reasoning"
+    },
+    permissions: {
+      model: true,
+      network: false,
+      tools: [],
+      readPaths: ["**/*"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "changes", "agentResults"],
+    outputs: ["lifecycleArtifacts"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "changes", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "maintain",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const maintenanceRequest = getWorkflowInput<MaintenanceRequest>(stateSlice, "maintenanceRequest");
+    const maintenanceIssueRefs = getWorkflowInput<string[]>(stateSlice, "maintenanceIssueRefs") ?? [];
+    const maintenanceGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "maintenanceGithubRefs") ?? [];
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!maintenanceRequest) {
+      throw new Error("maintenance-triage requires validated maintenance inputs before maintenance analysis.");
+    }
+
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const dependencyAlertRefs = asStringArray(intakeMetadata.dependencyAlertRefs).length > 0
+      ? asStringArray(intakeMetadata.dependencyAlertRefs)
+      : maintenanceRequest.dependencyAlertRefs;
+    const docsTaskRefs = asStringArray(intakeMetadata.docsTaskRefs).length > 0
+      ? asStringArray(intakeMetadata.docsTaskRefs)
+      : maintenanceRequest.docsTaskRefs;
+    const releaseReportRefs = asStringArray(intakeMetadata.releaseReportRefs).length > 0
+      ? asStringArray(intakeMetadata.releaseReportRefs)
+      : maintenanceRequest.releaseReportRefs;
+    const normalizedConstraints = asStringArray(intakeMetadata.constraints);
+    const evidenceSources = [...new Set([...dependencyAlertRefs, ...docsTaskRefs, ...releaseReportRefs])];
+    const currentFindings = [
+      ...(dependencyAlertRefs.length > 0 ? [`${dependencyAlertRefs.length} dependency alert reference(s) require maintenance triage.`] : []),
+      ...(docsTaskRefs.length > 0 ? [`${docsTaskRefs.length} docs task reference(s) require maintenance triage.`] : []),
+      ...(releaseReportRefs.length > 0 ? [`${releaseReportRefs.length} release-report reference(s) contribute maintenance follow-up context.`] : [])
+    ];
+    const recommendedActions = [
+      ...dependencyAlertRefs.map((pathValue) => `Review dependency alert reference \`${pathValue}\` before choosing a follow-up workflow.`),
+      ...docsTaskRefs.map((pathValue) => `Review docs task reference \`${pathValue}\` before choosing a follow-up workflow.`),
+      ...releaseReportRefs.map((pathValue) => `Review release report reference \`${pathValue}\` for maintenance-linked follow-up work.`),
+      ...(normalizedConstraints.length > 0 ? [`Keep maintenance follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
+    ];
+    const priorityAssessment =
+      releaseReportRefs.length > 0 || dependencyAlertRefs.length > 1
+        ? "Elevated maintenance triage: release-linked or multi-alert follow-up should be prioritized before broader maintenance work."
+        : "Routine maintenance triage: review bounded references and route follow-up deliberately.";
+    const stalenessSignals = [
+      ...(dependencyAlertRefs.length > 0 ? ["Dependency alert follow-up remains pending review."] : []),
+      ...(docsTaskRefs.length > 0 ? ["Documentation maintenance follow-up remains pending review."] : []),
+      ...(releaseReportRefs.length > 0 ? ["Release-linked maintenance follow-up remains pending review."] : [])
+    ];
+    const summary = `Maintenance report prepared for ${maintenanceRequest.maintenanceGoal}.`;
+    const maintenanceReport = maintenanceArtifactSchema.parse({
+      ...buildLifecycleArtifactEnvelopeBase(
+        state,
+        "Maintenance Triage",
+        summary,
+        [requestFile ?? ".agentops/requests/maintenance.yaml", ...evidenceSources],
+        maintenanceIssueRefs,
+        maintenanceGithubRefs
+      ),
+      artifactKind: "maintenance-report",
+      lifecycleDomain: "maintain",
+      payload: {
+        maintenanceScope: maintenanceRequest.maintenanceGoal,
+        currentFindings:
+          currentFindings.length > 0
+            ? currentFindings
+            : ["Maintenance triage remained bounded to validated references; no additional findings were synthesized."],
+        recommendedActions:
+          recommendedActions.length > 0
+            ? recommendedActions
+            : ["Add at least one bounded maintenance reference before broadening the workflow surface."],
+        priorityAssessment,
+        dependencyUpdates: dependencyAlertRefs,
+        docsUpdates: docsTaskRefs,
+        stalenessSignals,
+        followUpIssues: maintenanceIssueRefs
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [maintenanceReport satisfies MaintenanceArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.73,
+      metadata: {
+        deterministicInputs: {
+          evidenceSources,
+          dependencyAlertRefs,
+          docsTaskRefs,
+          releaseReportRefs,
+          issueRefs: maintenanceIssueRefs,
+          constraints: normalizedConstraints
+        },
+        synthesizedAssessment: {
+          priorityAssessment: maintenanceReport.payload.priorityAssessment,
+          recommendedActions: maintenanceReport.payload.recommendedActions,
+          followUpIssues: maintenanceReport.payload.followUpIssues
+        }
       }
     });
   }
@@ -3075,6 +3211,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["incident-intake", incidentIntakeAgent],
     ["incident-evidence-normalizer", incidentEvidenceNormalizationAgent],
     ["maintenance-intake", maintenanceIntakeAgent],
+    ["maintenance-analyst", maintenanceAnalystAgent],
     ["incident-analyst", incidentAnalystAgent],
     ["release-intake", releaseIntakeAgent],
     ["release-evidence-normalizer", releaseEvidenceNormalizationAgent],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,18 @@ importers:
         specifier: workspace:*
         version: link:../../packages/shared-types
 
+  agents/maintenance-analyst:
+    dependencies:
+      '@h9-foundry/agentforge-schemas':
+        specifier: workspace:*
+        version: link:../../packages/schemas
+      '@h9-foundry/agentforge-sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      '@h9-foundry/agentforge-shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
+
   agents/planning-analyst:
     dependencies:
       '@h9-foundry/agentforge-schemas':


### PR DESCRIPTION
## Summary
- add the bounded `maintenance-analyst` starter agent and `maintenance-report` lifecycle artifact
- wire `maintenance-triage` through an intake -> maintenance -> report workflow shape
- keep the maintenance family honest in docs while leaving deterministic signal collection and routing to `#158`

## Changes
- add the `maintenance-analyst` starter agent package and manifest
- add builtin maintenance analyst support and emit `maintenance-report` artifacts
- update the maintenance workflow asset/template to include the reasoning step
- update maintenance tests and docs for the new bounded artifact-emission slice
- add a changeset and workspace lockfile entry for the new agent package

## Validation
- `pnpm exec vitest run agents/maintenance-analyst/src/index.test.ts; echo EXIT:$?`
- `pnpm exec vitest run packages/cli/src/internal/builtin-agents.test.ts; echo EXIT:$?`
- `pnpm exec vitest run packages/cli/src/index.test.ts -t "maintenance-triage"; echo EXIT:$?`
- `pnpm typecheck; echo EXIT:$?`
- `pnpm lint; echo EXIT:$?`
- `pnpm build; echo EXIT:$?`
- `pnpm build:packages; echo EXIT:$?`
- `pnpm test; echo EXIT:$?`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo smoke run for `node packages/cli/dist/bin.js run maintenance-triage --json`

## Notes
- this PR intentionally stops at bounded maintenance analysis and artifact emission; deterministic signal collection/routing stays in `#158`
- `#191` remains a separate evaluator-path bug and still reproduces when `explain last-run --json` selects an older run after a fresh workflow execution
- local commit creation required the established unsigned-local-commit path because signing approval was unavailable; no branch protection or repo policy was changed

Closes #152