### PR TITLE
Implement maintenance evidence normalization

### DIFF
--- a/.agentops/workflows/maintenance-triage.yaml
+++ b/.agentops/workflows/maintenance-triage.yaml
@@ -12,6 +12,10 @@ nodes:
     kind: deterministic
     agent: maintenance-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: maintenance-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: maintenance
     kind: reasoning
     agent: maintenance-analyst

--- a/.changeset/maintenance-signal-normalization.md
+++ b/.changeset/maintenance-signal-normalization.md
@@ -1,0 +1,8 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+"@h9-foundry/agentforge-agent-maintenance-analyst": patch
+---
+
+Add deterministic maintenance evidence normalization and bounded routing classification for `maintenance-triage`.

--- a/agents/maintenance-analyst/src/index.test.ts
+++ b/agents/maintenance-analyst/src/index.test.ts
@@ -77,6 +77,30 @@ describe("maintenance analyst agent", () => {
               releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
               constraints: ["Keep maintenance triage read-only"]
             }
+          },
+          evidence: {
+            metadata: {
+              maintenanceGoal: "Triage dependency and docs hygiene follow-up after the latest release.",
+              dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+              docsTaskRefs: [".agentops/evidence/docs-task.md"],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+              normalizedEvidenceSources: [
+                ".agentops/evidence/dependency-alerts.json",
+                ".agentops/evidence/docs-task.md",
+                ".agentops/runs/run-release/bundle.json"
+              ],
+              missingEvidenceSources: [],
+              referencedArtifactKinds: ["release-report"],
+              affectedPackagesOrDocs: ["docs/quickstart.md", "packages/cli"],
+              maintenanceSignals: ["Release report references contribute bounded maintenance follow-up context."],
+              followUpWorkflowRefs: ["implementation-proposal", "release-readiness"],
+              routingRecommendation: "implementation-proposal",
+              provenanceRefs: [
+                ".agentops/evidence/dependency-alerts.json",
+                ".agentops/evidence/docs-task.md",
+                ".agentops/runs/run-release/bundle.json#release-report"
+              ]
+            }
           }
         }
       } as never,
@@ -92,6 +116,11 @@ describe("maintenance analyst agent", () => {
     }
 
     expect(artifact.payload.maintenanceScope).toContain("dependency and docs hygiene");
+    expect(artifact.payload.evidenceSources).toContain(".agentops/runs/run-release/bundle.json");
+    expect(artifact.payload.affectedPackagesOrDocs).toContain("packages/cli");
+    expect(artifact.payload.routingRecommendation).toBe("implementation-proposal");
+    expect(artifact.payload.followUpWorkflowRefs).toContain("release-readiness");
+    expect(artifact.payload.risks.length).toBeGreaterThan(0);
     expect(artifact.payload.dependencyUpdates).toContain(".agentops/evidence/dependency-alerts.json");
     expect(artifact.payload.docsUpdates).toContain(".agentops/evidence/docs-task.md");
     expect(artifact.payload.followUpIssues).toContain("#152");

--- a/agents/maintenance-analyst/src/index.ts
+++ b/agents/maintenance-analyst/src/index.ts
@@ -1,5 +1,11 @@
-import { agentManifestSchema, agentOutputSchema, maintenanceArtifactSchema } from "@h9-foundry/agentforge-schemas";
-import type { GithubReference, MaintenanceArtifact, MaintenanceRequest, WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+import { agentManifestSchema, agentOutputSchema, maintenanceArtifactSchema, maintenanceEvidenceNormalizationSchema } from "@h9-foundry/agentforge-schemas";
+import type {
+  GithubReference,
+  MaintenanceArtifact,
+  MaintenanceEvidenceNormalization,
+  MaintenanceRequest,
+  WorkflowStateEnvelope
+} from "@h9-foundry/agentforge-shared-types";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -122,32 +128,62 @@ export const maintenanceAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const dependencyAlertRefs = asStringArray(intakeMetadata.dependencyAlertRefs).length > 0
-      ? asStringArray(intakeMetadata.dependencyAlertRefs)
-      : maintenanceRequest.dependencyAlertRefs;
-    const docsTaskRefs = asStringArray(intakeMetadata.docsTaskRefs).length > 0
-      ? asStringArray(intakeMetadata.docsTaskRefs)
-      : maintenanceRequest.docsTaskRefs;
-    const releaseReportRefs = asStringArray(intakeMetadata.releaseReportRefs).length > 0
-      ? asStringArray(intakeMetadata.releaseReportRefs)
-      : maintenanceRequest.releaseReportRefs;
+    const evidenceMetadata = maintenanceEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence: MaintenanceEvidenceNormalization | undefined = evidenceMetadata.success ? evidenceMetadata.data : undefined;
+    const dependencyAlertRefs =
+      normalizedEvidence?.dependencyAlertRefs ??
+      (asStringArray(intakeMetadata.dependencyAlertRefs).length > 0
+        ? asStringArray(intakeMetadata.dependencyAlertRefs)
+        : maintenanceRequest.dependencyAlertRefs);
+    const docsTaskRefs =
+      normalizedEvidence?.docsTaskRefs ??
+      (asStringArray(intakeMetadata.docsTaskRefs).length > 0
+        ? asStringArray(intakeMetadata.docsTaskRefs)
+        : maintenanceRequest.docsTaskRefs);
+    const releaseReportRefs =
+      normalizedEvidence?.releaseReportRefs ??
+      (asStringArray(intakeMetadata.releaseReportRefs).length > 0
+        ? asStringArray(intakeMetadata.releaseReportRefs)
+        : maintenanceRequest.releaseReportRefs);
     const constraints = asStringArray(intakeMetadata.constraints);
-    const evidenceSources = [...new Set([...dependencyAlertRefs, ...docsTaskRefs, ...releaseReportRefs])];
+    const evidenceSources =
+      normalizedEvidence?.normalizedEvidenceSources ?? [...new Set([...dependencyAlertRefs, ...docsTaskRefs, ...releaseReportRefs])];
+    const affectedPackagesOrDocs = normalizedEvidence?.affectedPackagesOrDocs ?? [];
+    const followUpWorkflowRefs = normalizedEvidence?.followUpWorkflowRefs ?? [];
+    const routingRecommendation = normalizedEvidence?.routingRecommendation ?? "implementation-proposal";
+    const maintenanceSignals = normalizedEvidence?.maintenanceSignals ?? [];
+    const referencedArtifactKinds = normalizedEvidence?.referencedArtifactKinds ?? [];
     const currentFindings = [
-      ...(dependencyAlertRefs.length > 0 ? [`${dependencyAlertRefs.length} dependency alert reference(s) require maintenance triage.`] : []),
-      ...(docsTaskRefs.length > 0 ? [`${docsTaskRefs.length} docs task reference(s) require maintenance triage.`] : []),
-      ...(releaseReportRefs.length > 0 ? [`${releaseReportRefs.length} release-report reference(s) contribute maintenance follow-up context.`] : [])
+      ...(maintenanceSignals.length > 0
+        ? maintenanceSignals
+        : [
+            ...(dependencyAlertRefs.length > 0 ? [`${dependencyAlertRefs.length} dependency alert reference(s) require maintenance triage.`] : []),
+            ...(docsTaskRefs.length > 0 ? [`${docsTaskRefs.length} docs task reference(s) require maintenance triage.`] : []),
+            ...(releaseReportRefs.length > 0 ? [`${releaseReportRefs.length} release-report reference(s) contribute maintenance follow-up context.`] : [])
+          ])
     ];
     const recommendedActions = [
       ...dependencyAlertRefs.map((pathValue) => `Review dependency alert reference \`${pathValue}\` before choosing a follow-up workflow.`),
       ...docsTaskRefs.map((pathValue) => `Review docs task reference \`${pathValue}\` before choosing a follow-up workflow.`),
       ...releaseReportRefs.map((pathValue) => `Review release report reference \`${pathValue}\` for maintenance-linked follow-up work.`),
+      ...(affectedPackagesOrDocs.length > 0 ? [`Review the affected maintenance surfaces: ${affectedPackagesOrDocs.join(", ")}.`] : []),
+      ...(followUpWorkflowRefs.length > 0
+        ? [`Route the next bounded follow-up through ${routingRecommendation} (${followUpWorkflowRefs.join(", ")} considered).`]
+        : []),
       ...(constraints.length > 0 ? [`Keep maintenance follow-up bounded by: ${constraints.join("; ")}.`] : [])
     ];
     const priorityAssessment =
       dependencyAlertRefs.length > 1 || releaseReportRefs.length > 0
         ? "Elevated maintenance triage: release-linked or multi-alert follow-up should be prioritized before broader maintenance work."
         : "Routine maintenance triage: review bounded references and route follow-up deliberately.";
+    const risks = [
+      ...(releaseReportRefs.length > 0 ? ["Release-linked maintenance follow-up can drift if release-readiness is deferred."] : []),
+      ...(dependencyAlertRefs.length > 0 ? ["Dependency alert follow-up can widen change scope once implementation work begins."] : []),
+      ...(docsTaskRefs.length > 0 ? ["Documentation debt can diverge from implemented behavior if maintenance triage is deferred."] : []),
+      ...(referencedArtifactKinds.includes("security-report")
+        ? ["Security-linked maintenance follow-up should remain prioritized until the linked evidence is resolved."]
+        : [])
+    ];
     const stalenessSignals = [
       ...(dependencyAlertRefs.length > 0 ? ["Dependency alert follow-up remains pending review."] : []),
       ...(docsTaskRefs.length > 0 ? ["Documentation maintenance follow-up remains pending review."] : []),
@@ -166,6 +202,8 @@ export const maintenanceAnalystAgent: RuntimeAgent = {
       lifecycleDomain: "maintain",
       payload: {
         maintenanceScope: maintenanceRequest.maintenanceGoal,
+        evidenceSources,
+        affectedPackagesOrDocs,
         currentFindings:
           currentFindings.length > 0
             ? currentFindings
@@ -174,6 +212,9 @@ export const maintenanceAnalystAgent: RuntimeAgent = {
           recommendedActions.length > 0
             ? recommendedActions
             : ["Add at least one bounded maintenance reference before broadening the workflow surface."],
+        routingRecommendation,
+        followUpWorkflowRefs,
+        risks,
         priorityAssessment,
         dependencyUpdates: dependencyAlertRefs,
         docsUpdates: docsTaskRefs,
@@ -196,12 +237,18 @@ export const maintenanceAnalystAgent: RuntimeAgent = {
           dependencyAlertRefs,
           docsTaskRefs,
           releaseReportRefs,
+          affectedPackagesOrDocs,
+          maintenanceSignals,
+          referencedArtifactKinds,
           issueRefs: maintenanceIssueRefs,
           constraints
         },
         synthesizedAssessment: {
           priorityAssessment: maintenanceReport.payload.priorityAssessment,
           recommendedActions: maintenanceReport.payload.recommendedActions,
+          routingRecommendation: maintenanceReport.payload.routingRecommendation,
+          followUpWorkflowRefs: maintenanceReport.payload.followUpWorkflowRefs,
+          risks: maintenanceReport.payload.risks,
           followUpIssues: maintenanceReport.payload.followUpIssues
         }
       }

--- a/docs/MAINTENANCE_WORKFLOWS.md
+++ b/docs/MAINTENANCE_WORKFLOWS.md
@@ -59,7 +59,7 @@ Later planned variants can include:
 - `docs-hygiene-review`
 - `maintenance-backlog-refresh`
 
-`maintenance-triage` is now implemented as an intake-plus-analysis wedge. The later maintenance variants remain planned.
+`maintenance-triage` is now implemented as an intake-plus-evidence-plus-analysis wedge. The later maintenance variants remain planned, and public promotion remains blocked on `explain last-run` reliability.
 
 ## User Jobs
 
@@ -163,8 +163,8 @@ Implemented on current `main`:
 1. maintenance request schema and official `maintenance-triage` workflow asset
 2. deterministic validation of dependency alert refs, docs task refs, release-report refs, and backlog issue refs before reasoning
 3. `maintenance-analyst` starter agent and `maintenance-report` lifecycle artifact emission
+4. deterministic dependency/docs/release signal collection and routing classification before reasoning
 
 Next maintenance family follow-ons:
 
-1. deterministic dependency/docs/release signal collection and routing classification
-2. GitHub and release/readiness handoff wiring for maintenance follow-up work
+1. GitHub and release/readiness handoff wiring for maintenance follow-up work

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1602,6 +1602,9 @@ describe("cli smoke flows", () => {
         artifactKind?: string;
         payload?: {
           maintenanceScope?: string;
+          evidenceSources?: string[];
+          routingRecommendation?: string;
+          followUpWorkflowRefs?: string[];
           followUpIssues?: string[];
           dependencyUpdates?: string[];
           docsUpdates?: string[];
@@ -1610,9 +1613,13 @@ describe("cli smoke flows", () => {
     }>(maintenanceRun.jsonPath);
     expect(bundle.workflow).toBe("maintenance-triage");
     expect(bundle.entries.some((entry) => entry.nodeId === "intake")).toBe(true);
+    expect(bundle.entries.some((entry) => entry.nodeId === "evidence")).toBe(true);
     expect(bundle.entries.some((entry) => entry.nodeId === "maintenance")).toBe(true);
     expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("maintenance-report");
     expect(bundle.lifecycleArtifacts[0]?.payload?.maintenanceScope).toContain("dependency and docs hygiene");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.evidenceSources).toContain(".agentops/runs/run-release/bundle.json");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.routingRecommendation).toBe("implementation-proposal");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.followUpWorkflowRefs).toContain("release-readiness");
     expect(bundle.lifecycleArtifacts[0]?.payload?.followUpIssues).toContain("#145");
     expect(bundle.lifecycleArtifacts[0]?.payload?.dependencyUpdates).toContain(".agentops/evidence/dependency-alerts.json");
     expect(bundle.lifecycleArtifacts[0]?.payload?.docsUpdates).toContain(".agentops/evidence/docs-task.md");

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -353,6 +353,10 @@ nodes:
     kind: deterministic
     agent: maintenance-intake
     outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: maintenance-evidence-normalizer
+    outputs_to: agentResults.evidence
   - id: maintenance
     kind: reasoning
     agent: maintenance-analyst

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -545,6 +545,43 @@ describe("builtin incident analyst agent", () => {
 });
 
 describe("builtin maintenance analyst agent", () => {
+  it("normalizes maintenance evidence and routing before reasoning", async () => {
+    const agent = createBuiltinAgentRegistry().get("maintenance-evidence-normalizer");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        workflowInputs: {
+          maintenanceRequest: {
+            maintenanceGoal: "Triage dependency and docs hygiene follow-up.",
+            dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+            docsTaskRefs: ["docs/quickstart.md"],
+            releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+            issueRefs: ["#152"],
+            constraints: ["Keep maintenance triage read-only"]
+          }
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+              docsTaskRefs: ["docs/quickstart.md"],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect((output.metadata as { routingRecommendation?: string } | undefined)?.routingRecommendation).toBe("implementation-proposal");
+    expect((output.metadata as { followUpWorkflowRefs?: string[] } | undefined)?.followUpWorkflowRefs).toEqual(
+      expect.arrayContaining(["implementation-proposal", "release-readiness"])
+    );
+  });
+
   it("emits a maintenance-report artifact from bounded maintenance inputs", async () => {
     const agent = createBuiltinAgentRegistry().get("maintenance-analyst");
     expect(agent).toBeDefined();
@@ -610,6 +647,31 @@ describe("builtin maintenance analyst agent", () => {
               releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
               constraints: ["Keep maintenance triage read-only"]
             }
+          },
+          evidence: {
+            metadata: {
+              maintenanceGoal: "Triage dependency and docs hygiene follow-up.",
+              dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+              docsTaskRefs: [".agentops/evidence/docs-task.md"],
+              releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+              normalizedEvidenceSources: [
+                ".agentops/evidence/dependency-alerts.json",
+                ".agentops/evidence/docs-task.md",
+                ".agentops/runs/run-release/bundle.json"
+              ],
+              missingEvidenceSources: [],
+              referencedArtifactKinds: ["release-report"],
+              affectedPackagesOrDocs: ["packages/cli", ".agentops/evidence/docs-task.md"],
+              maintenanceSignals: [
+                "Observed source .agentops/evidence/dependency-alerts.json during deterministic intake."
+              ],
+              followUpWorkflowRefs: ["implementation-proposal", "release-readiness"],
+              routingRecommendation: "implementation-proposal",
+              provenanceRefs: [
+                ".agentops/evidence/dependency-alerts.json",
+                ".agentops/runs/run-release/bundle.json#release-report"
+              ]
+            }
           }
         }
       } as never,
@@ -625,6 +687,11 @@ describe("builtin maintenance analyst agent", () => {
     }
 
     expect(artifact.payload.maintenanceScope).toContain("dependency and docs hygiene");
+    expect(artifact.payload.evidenceSources).toContain(".agentops/runs/run-release/bundle.json");
+    expect(artifact.payload.affectedPackagesOrDocs).toContain("packages/cli");
+    expect(artifact.payload.routingRecommendation).toBe("implementation-proposal");
+    expect(artifact.payload.followUpWorkflowRefs).toContain("release-readiness");
+    expect(artifact.payload.risks.length).toBeGreaterThan(0);
     expect(artifact.payload.dependencyUpdates).toContain(".agentops/evidence/dependency-alerts.json");
     expect(artifact.payload.docsUpdates).toContain(".agentops/evidence/docs-task.md");
     expect(artifact.payload.followUpIssues).toContain("#152");

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -12,6 +12,7 @@ import {
   incidentEvidenceNormalizationSchema,
   incidentRequestSchema,
   maintenanceArtifactSchema,
+  maintenanceEvidenceNormalizationSchema,
   maintenanceRequestSchema,
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
@@ -39,6 +40,7 @@ import type {
   IncidentEvidenceNormalization,
   IncidentRequest,
   MaintenanceArtifact,
+  MaintenanceEvidenceNormalization,
   MaintenanceRequest,
   NormalizedValidationCommand,
   PlanningArtifact,
@@ -379,6 +381,11 @@ function derivePackageScope(pathValue: string): string | undefined {
   }
 
   return undefined;
+}
+
+function includesAnyKeyword(values: readonly string[], keywords: readonly string[]): boolean {
+  const haystack = values.join(" ").toLowerCase();
+  return keywords.some((keyword) => haystack.includes(keyword));
 }
 
 function getWorkflowInput<T>(stateSlice: Partial<WorkflowStateEnvelope>, key: string): T | undefined {
@@ -1287,6 +1294,142 @@ const maintenanceIntakeAgent: RuntimeAgent = {
   }
 };
 
+const maintenanceEvidenceNormalizerAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "maintenance-evidence-normalizer",
+    displayName: "Maintenance Evidence Normalizer",
+    category: "maintain",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**", "**/*.json", "**/*.md", "**/*.txt", "**/package.json"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "agentResults"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "maintain",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const maintenanceRequest = getWorkflowInput<MaintenanceRequest>(stateSlice, "maintenanceRequest");
+    if (!maintenanceRequest) {
+      throw new Error("maintenance-triage requires validated maintenance inputs before evidence normalization.");
+    }
+
+    const repoRoot = stateSlice.repo?.root;
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const dependencyAlertRefs =
+      asStringArray(intakeMetadata.dependencyAlertRefs).length > 0
+        ? asStringArray(intakeMetadata.dependencyAlertRefs)
+        : maintenanceRequest.dependencyAlertRefs;
+    const docsTaskRefs =
+      asStringArray(intakeMetadata.docsTaskRefs).length > 0
+        ? asStringArray(intakeMetadata.docsTaskRefs)
+        : maintenanceRequest.docsTaskRefs;
+    const releaseReportRefs =
+      asStringArray(intakeMetadata.releaseReportRefs).length > 0
+        ? asStringArray(intakeMetadata.releaseReportRefs)
+        : maintenanceRequest.releaseReportRefs;
+    const normalizedEvidenceSources = [...new Set([...dependencyAlertRefs, ...docsTaskRefs, ...releaseReportRefs])];
+    const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
+    if (missingEvidenceSources.length > 0) {
+      throw new Error(`Maintenance evidence source not found: ${missingEvidenceSources[0]}`);
+    }
+
+    const referencedArtifactKinds = [
+      ...new Set(releaseReportRefs.flatMap((pathValue) => (repoRoot ? loadBundleArtifactKinds(join(repoRoot, pathValue)) : [])))
+    ];
+    const releasePayloadPaths = releaseReportRefs.flatMap((pathValue) => (repoRoot ? loadBundleArtifactPayloadPaths(join(repoRoot, pathValue)) : []));
+    const affectedPackagesOrDocs = [
+      ...new Set(
+        [...docsTaskRefs, ...releasePayloadPaths]
+          .map((pathValue) => derivePackageScope(pathValue) ?? pathValue)
+          .filter((value): value is string => Boolean(value))
+      )
+    ];
+    const maintenanceSignals = [
+      ...normalizedEvidenceSources.map((pathValue) => describeEvidenceObservation(repoRoot, pathValue)),
+      ...(dependencyAlertRefs.length > 0 ? ["Dependency alert references contribute bounded maintenance follow-up context."] : []),
+      ...(docsTaskRefs.length > 0 ? ["Documentation task references contribute bounded maintenance follow-up context."] : []),
+      ...(releaseReportRefs.length > 0 ? ["Release report references contribute bounded maintenance follow-up context."] : []),
+      ...(referencedArtifactKinds.length > 0 ? [`Referenced artifact kinds: ${referencedArtifactKinds.join(", ")}`] : [])
+    ];
+    const routingInputs = [
+      maintenanceRequest.maintenanceGoal,
+      ...dependencyAlertRefs,
+      ...docsTaskRefs,
+      ...releaseReportRefs,
+      ...maintenanceSignals
+    ];
+    const securitySignal =
+      referencedArtifactKinds.includes("security-report") ||
+      includesAnyKeyword(routingInputs, ["security", "vulnerability", "vuln", "cve", "advisory"]);
+    const qaSignal =
+      referencedArtifactKinds.includes("qa-report") ||
+      includesAnyKeyword(routingInputs, ["qa", "test", "coverage", "flaky"]);
+    const followUpWorkflowRefs = [
+      ...new Set([
+        ...(securitySignal ? ["security-review"] : []),
+        ...(dependencyAlertRefs.length > 0 || docsTaskRefs.length > 0 ? ["implementation-proposal"] : []),
+        ...(releaseReportRefs.length > 0 ? ["release-readiness"] : []),
+        ...(qaSignal ? ["qa-review"] : [])
+      ])
+    ];
+    const routingRecommendation = followUpWorkflowRefs[0] ?? "implementation-proposal";
+    const provenanceRefs = [
+      ...new Set([
+        ...dependencyAlertRefs,
+        ...docsTaskRefs,
+        ...releaseReportRefs.map((pathValue) => `${pathValue}#release-report`)
+      ])
+    ];
+    const normalization = maintenanceEvidenceNormalizationSchema.parse({
+      maintenanceGoal: maintenanceRequest.maintenanceGoal,
+      dependencyAlertRefs,
+      docsTaskRefs,
+      releaseReportRefs,
+      normalizedEvidenceSources,
+      missingEvidenceSources: [],
+      referencedArtifactKinds,
+      affectedPackagesOrDocs,
+      maintenanceSignals,
+      followUpWorkflowRefs,
+      routingRecommendation,
+      provenanceRefs
+    });
+
+    return agentOutputSchema.parse({
+      summary: `Normalized maintenance evidence across ${normalization.normalizedEvidenceSources.length} source(s) for ${maintenanceRequest.maintenanceGoal}.`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: normalization satisfies MaintenanceEvidenceNormalization
+    });
+  }
+};
+
 const maintenanceAnalystAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -1333,32 +1476,62 @@ const maintenanceAnalystAgent: RuntimeAgent = {
     }
 
     const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
-    const dependencyAlertRefs = asStringArray(intakeMetadata.dependencyAlertRefs).length > 0
-      ? asStringArray(intakeMetadata.dependencyAlertRefs)
-      : maintenanceRequest.dependencyAlertRefs;
-    const docsTaskRefs = asStringArray(intakeMetadata.docsTaskRefs).length > 0
-      ? asStringArray(intakeMetadata.docsTaskRefs)
-      : maintenanceRequest.docsTaskRefs;
-    const releaseReportRefs = asStringArray(intakeMetadata.releaseReportRefs).length > 0
-      ? asStringArray(intakeMetadata.releaseReportRefs)
-      : maintenanceRequest.releaseReportRefs;
+    const evidenceMetadata = maintenanceEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence = evidenceMetadata.success ? evidenceMetadata.data : undefined;
+    const dependencyAlertRefs =
+      normalizedEvidence?.dependencyAlertRefs ??
+      (asStringArray(intakeMetadata.dependencyAlertRefs).length > 0
+        ? asStringArray(intakeMetadata.dependencyAlertRefs)
+        : maintenanceRequest.dependencyAlertRefs);
+    const docsTaskRefs =
+      normalizedEvidence?.docsTaskRefs ??
+      (asStringArray(intakeMetadata.docsTaskRefs).length > 0
+        ? asStringArray(intakeMetadata.docsTaskRefs)
+        : maintenanceRequest.docsTaskRefs);
+    const releaseReportRefs =
+      normalizedEvidence?.releaseReportRefs ??
+      (asStringArray(intakeMetadata.releaseReportRefs).length > 0
+        ? asStringArray(intakeMetadata.releaseReportRefs)
+        : maintenanceRequest.releaseReportRefs);
     const normalizedConstraints = asStringArray(intakeMetadata.constraints);
-    const evidenceSources = [...new Set([...dependencyAlertRefs, ...docsTaskRefs, ...releaseReportRefs])];
+    const evidenceSources =
+      normalizedEvidence?.normalizedEvidenceSources ?? [...new Set([...dependencyAlertRefs, ...docsTaskRefs, ...releaseReportRefs])];
+    const affectedPackagesOrDocs = normalizedEvidence?.affectedPackagesOrDocs ?? [];
+    const followUpWorkflowRefs = normalizedEvidence?.followUpWorkflowRefs ?? [];
+    const routingRecommendation = normalizedEvidence?.routingRecommendation ?? "implementation-proposal";
+    const maintenanceSignals = normalizedEvidence?.maintenanceSignals ?? [];
+    const referencedArtifactKinds = normalizedEvidence?.referencedArtifactKinds ?? [];
     const currentFindings = [
-      ...(dependencyAlertRefs.length > 0 ? [`${dependencyAlertRefs.length} dependency alert reference(s) require maintenance triage.`] : []),
-      ...(docsTaskRefs.length > 0 ? [`${docsTaskRefs.length} docs task reference(s) require maintenance triage.`] : []),
-      ...(releaseReportRefs.length > 0 ? [`${releaseReportRefs.length} release-report reference(s) contribute maintenance follow-up context.`] : [])
+      ...(maintenanceSignals.length > 0
+        ? maintenanceSignals
+        : [
+            ...(dependencyAlertRefs.length > 0 ? [`${dependencyAlertRefs.length} dependency alert reference(s) require maintenance triage.`] : []),
+            ...(docsTaskRefs.length > 0 ? [`${docsTaskRefs.length} docs task reference(s) require maintenance triage.`] : []),
+            ...(releaseReportRefs.length > 0 ? [`${releaseReportRefs.length} release-report reference(s) contribute maintenance follow-up context.`] : [])
+          ])
     ];
     const recommendedActions = [
       ...dependencyAlertRefs.map((pathValue) => `Review dependency alert reference \`${pathValue}\` before choosing a follow-up workflow.`),
       ...docsTaskRefs.map((pathValue) => `Review docs task reference \`${pathValue}\` before choosing a follow-up workflow.`),
       ...releaseReportRefs.map((pathValue) => `Review release report reference \`${pathValue}\` for maintenance-linked follow-up work.`),
+      ...(affectedPackagesOrDocs.length > 0 ? [`Review the affected maintenance surfaces: ${affectedPackagesOrDocs.join(", ")}.`] : []),
+      ...(followUpWorkflowRefs.length > 0
+        ? [`Route the next bounded follow-up through ${routingRecommendation} (${followUpWorkflowRefs.join(", ")} considered).`]
+        : []),
       ...(normalizedConstraints.length > 0 ? [`Keep maintenance follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
     ];
     const priorityAssessment =
       releaseReportRefs.length > 0 || dependencyAlertRefs.length > 1
         ? "Elevated maintenance triage: release-linked or multi-alert follow-up should be prioritized before broader maintenance work."
         : "Routine maintenance triage: review bounded references and route follow-up deliberately.";
+    const risks = [
+      ...(releaseReportRefs.length > 0 ? ["Release-linked maintenance follow-up can drift if release-readiness is deferred."] : []),
+      ...(dependencyAlertRefs.length > 0 ? ["Dependency alert follow-up can widen change scope once implementation work begins."] : []),
+      ...(docsTaskRefs.length > 0 ? ["Documentation debt can diverge from implemented behavior if maintenance triage is deferred."] : []),
+      ...(referencedArtifactKinds.includes("security-report")
+        ? ["Security-linked maintenance follow-up should remain prioritized until the linked evidence is resolved."]
+        : [])
+    ];
     const stalenessSignals = [
       ...(dependencyAlertRefs.length > 0 ? ["Dependency alert follow-up remains pending review."] : []),
       ...(docsTaskRefs.length > 0 ? ["Documentation maintenance follow-up remains pending review."] : []),
@@ -1378,6 +1551,8 @@ const maintenanceAnalystAgent: RuntimeAgent = {
       lifecycleDomain: "maintain",
       payload: {
         maintenanceScope: maintenanceRequest.maintenanceGoal,
+        evidenceSources,
+        affectedPackagesOrDocs,
         currentFindings:
           currentFindings.length > 0
             ? currentFindings
@@ -1386,6 +1561,9 @@ const maintenanceAnalystAgent: RuntimeAgent = {
           recommendedActions.length > 0
             ? recommendedActions
             : ["Add at least one bounded maintenance reference before broadening the workflow surface."],
+        routingRecommendation,
+        followUpWorkflowRefs,
+        risks,
         priorityAssessment,
         dependencyUpdates: dependencyAlertRefs,
         docsUpdates: docsTaskRefs,
@@ -1408,12 +1586,18 @@ const maintenanceAnalystAgent: RuntimeAgent = {
           dependencyAlertRefs,
           docsTaskRefs,
           releaseReportRefs,
+          affectedPackagesOrDocs,
+          maintenanceSignals,
+          referencedArtifactKinds,
           issueRefs: maintenanceIssueRefs,
           constraints: normalizedConstraints
         },
         synthesizedAssessment: {
           priorityAssessment: maintenanceReport.payload.priorityAssessment,
           recommendedActions: maintenanceReport.payload.recommendedActions,
+          routingRecommendation: maintenanceReport.payload.routingRecommendation,
+          followUpWorkflowRefs: maintenanceReport.payload.followUpWorkflowRefs,
+          risks: maintenanceReport.payload.risks,
           followUpIssues: maintenanceReport.payload.followUpIssues
         }
       }
@@ -3211,6 +3395,7 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["incident-intake", incidentIntakeAgent],
     ["incident-evidence-normalizer", incidentEvidenceNormalizationAgent],
     ["maintenance-intake", maintenanceIntakeAgent],
+    ["maintenance-evidence-normalizer", maintenanceEvidenceNormalizerAgent],
     ["maintenance-analyst", maintenanceAnalystAgent],
     ["incident-analyst", incidentAnalystAgent],
     ["release-intake", releaseIntakeAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -18,6 +18,7 @@ import {
   incidentRequestSchema,
   lifecycleArtifactEnvelopeSchema,
   maintenanceArtifactSchema,
+  maintenanceEvidenceNormalizationSchema,
   normalizedValidationCommandSchema,
   policyDocumentSchema,
   qaArtifactSchema,
@@ -61,6 +62,7 @@ describe("schema fixtures", () => {
     expect(() => qaEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization)).not.toThrow();
     expect(() => securityEvidenceNormalizationSchema.parse(schemaFixtures.securityEvidenceNormalization)).not.toThrow();
     expect(() => releaseEvidenceNormalizationSchema.parse(schemaFixtures.releaseEvidenceNormalization)).not.toThrow();
+    expect(() => maintenanceEvidenceNormalizationSchema.parse(schemaFixtures.maintenanceEvidenceNormalization)).not.toThrow();
   });
 
   it("rejects invalid manifests", () => {
@@ -93,6 +95,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.implementationInventory).toBeDefined();
     expect(jsonSchemas.qaEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.securityEvidenceNormalization).toBeDefined();
+    expect(jsonSchemas.maintenanceEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.releaseEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
     expect(jsonSchemas.planningArtifact).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -447,6 +447,21 @@ export const incidentEvidenceNormalizationSchema = z.object({
   referencedArtifactKinds: z.array(z.string().min(1)).default([])
 });
 
+export const maintenanceEvidenceNormalizationSchema = z.object({
+  maintenanceGoal: z.string().min(1),
+  dependencyAlertRefs: z.array(z.string().min(1)).default([]),
+  docsTaskRefs: z.array(z.string().min(1)).default([]),
+  releaseReportRefs: z.array(z.string().min(1)).default([]),
+  normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
+  missingEvidenceSources: z.array(z.string().min(1)).default([]),
+  referencedArtifactKinds: z.array(z.string().min(1)).default([]),
+  affectedPackagesOrDocs: z.array(z.string().min(1)).default([]),
+  maintenanceSignals: z.array(z.string().min(1)).default([]),
+  followUpWorkflowRefs: z.array(z.string().min(1)).default([]),
+  routingRecommendation: z.string().min(1),
+  provenanceRefs: z.array(z.string().min(1)).default([])
+});
+
 export const repoMetadataSchema = z.object({
   root: z.string().min(1),
   name: z.string().min(1),
@@ -775,8 +790,13 @@ export const releaseArtifactPayloadSchema = z.object({
 
 export const maintenanceArtifactPayloadSchema = z.object({
   maintenanceScope: z.string().min(1),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  affectedPackagesOrDocs: z.array(z.string().min(1)).default([]),
   currentFindings: z.array(z.string().min(1)).default([]),
   recommendedActions: z.array(z.string().min(1)).default([]),
+  routingRecommendation: z.string().min(1),
+  followUpWorkflowRefs: z.array(z.string().min(1)).default([]),
+  risks: z.array(z.string().min(1)).default([]),
   priorityAssessment: z.string().min(1),
   dependencyUpdates: z.array(z.string().min(1)).default([]),
   docsUpdates: z.array(z.string().min(1)).default([]),
@@ -939,6 +959,7 @@ export const schemaRegistry = {
   qaEvidenceNormalization: qaEvidenceNormalizationSchema,
   securityEvidenceNormalization: securityEvidenceNormalizationSchema,
   incidentEvidenceNormalization: incidentEvidenceNormalizationSchema,
+  maintenanceEvidenceNormalization: maintenanceEvidenceNormalizationSchema,
   policyDocument: policyDocumentSchema,
   effectivePolicySnapshot: effectivePolicySnapshotSchema,
   workflowDefinition: workflowDefinitionSchema,
@@ -1211,8 +1232,20 @@ const maintenanceArtifactFixture = {
   summary: "Maintenance report for documentation and dependency hygiene.",
   payload: {
     maintenanceScope: "Docs and dependency hygiene",
+    evidenceSources: [
+      ".agentops/evidence/dependency-alerts.json",
+      ".agentops/evidence/docs-task.md",
+      ".agentops/runs/run-release/bundle.json"
+    ],
+    affectedPackagesOrDocs: ["docs/quickstart.md", "packages/cli"],
     currentFindings: ["README needs clearer first-run guidance"],
     recommendedActions: ["Rewrite quickstart", "Refresh sample repo docs"],
+    routingRecommendation: "implementation-proposal",
+    followUpWorkflowRefs: ["implementation-proposal", "release-readiness"],
+    risks: [
+      "Release-linked maintenance follow-up may drift if the latest release report is not revisited.",
+      "Docs debt can diverge from implemented behavior if maintenance triage is deferred."
+    ],
     priorityAssessment: "high",
     dependencyUpdates: ["vitest@4.1.0"],
     docsUpdates: ["docs/quickstart.md"],
@@ -1473,6 +1506,34 @@ const incidentEvidenceNormalizationFixture = {
   referencedArtifactKinds: ["release-report"]
 } as const;
 
+const maintenanceEvidenceNormalizationFixture = {
+  maintenanceGoal: "Triage dependency and docs hygiene follow-up after the latest release.",
+  dependencyAlertRefs: [".agentops/evidence/dependency-alerts.json"],
+  docsTaskRefs: [".agentops/evidence/docs-task.md"],
+  releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+  normalizedEvidenceSources: [
+    ".agentops/evidence/dependency-alerts.json",
+    ".agentops/evidence/docs-task.md",
+    ".agentops/runs/run-release/bundle.json"
+  ],
+  missingEvidenceSources: [],
+  referencedArtifactKinds: ["release-report"],
+  affectedPackagesOrDocs: ["docs/quickstart.md", "packages/cli"],
+  maintenanceSignals: [
+    "Observed source .agentops/evidence/dependency-alerts.json during deterministic intake.",
+    "Observed source .agentops/evidence/docs-task.md during deterministic intake.",
+    "Observed source .agentops/runs/run-release/bundle.json during deterministic intake.",
+    "Release report references contribute bounded maintenance follow-up context."
+  ],
+  followUpWorkflowRefs: ["implementation-proposal", "release-readiness"],
+  routingRecommendation: "implementation-proposal",
+  provenanceRefs: [
+    ".agentops/evidence/dependency-alerts.json",
+    ".agentops/evidence/docs-task.md",
+    ".agentops/runs/run-release/bundle.json#release-report"
+  ]
+} as const;
+
 const releaseEvidenceNormalizationFixture = {
   qaReportRefs: [".agentops/runs/run-789/bundle.json"],
   securityReportRefs: [".agentops/runs/run-790/bundle.json"],
@@ -1635,6 +1696,7 @@ export const schemaFixtures = {
   qaEvidenceNormalization: qaEvidenceNormalizationFixture,
   securityEvidenceNormalization: securityEvidenceNormalizationFixture,
   incidentEvidenceNormalization: incidentEvidenceNormalizationFixture,
+  maintenanceEvidenceNormalization: maintenanceEvidenceNormalizationFixture,
   releaseEvidenceNormalization: releaseEvidenceNormalizationFixture,
   lifecycleArtifactEnvelope: planningArtifactFixture,
   planningArtifact: planningArtifactFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -43,6 +43,7 @@ import {
   incidentRequestSchema,
   maintenanceArtifactPayloadSchema,
   maintenanceArtifactSchema,
+  maintenanceEvidenceNormalizationSchema,
   maintenanceRequestSchema,
   normalizedValidationCommandSchema,
   policyDocumentSchema,
@@ -137,6 +138,7 @@ export type ReleaseArtifactPayload = Infer<typeof releaseArtifactPayloadSchema>;
 export type ReleaseArtifact = Infer<typeof releaseArtifactSchema>;
 export type MaintenanceArtifactPayload = Infer<typeof maintenanceArtifactPayloadSchema>;
 export type MaintenanceArtifact = Infer<typeof maintenanceArtifactSchema>;
+export type MaintenanceEvidenceNormalization = Infer<typeof maintenanceEvidenceNormalizationSchema>;
 export type MaintenanceRequest = Infer<typeof maintenanceRequestSchema>;
 export type AgentOutput = Infer<typeof agentOutputSchema>;
 export type AgentManifest = Infer<typeof agentManifestSchema>;


### PR DESCRIPTION
## Summary
- add deterministic maintenance evidence normalization before maintenance reasoning
- extend `maintenance-report` so deterministic evidence and synthesized routing are separated explicitly
- keep `maintenance-triage` read-only and bounded while updating maintenance docs and fixtures

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts`
- `pnpm exec vitest run agents/maintenance-analyst/src/index.test.ts`
- `pnpm exec vitest run packages/cli/src/internal/builtin-agents.test.ts -t "maintenance"`
- `pnpm exec vitest run packages/cli/src/index.test.ts -t "maintenance-triage"`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- disposable repo smoke run for `node packages/cli/dist/bin.js run maintenance-triage --json`

## Notes
- `#191` still reproduces and remains a separate blocker before maintenance can be promoted as official.
- `pnpm test; echo EXIT:$?` continues to be wrapper-ambiguous in this environment, so this slice relies on focused passing suites plus the standard build and smoke gates.