### PR TITLE
Fix explain last-run selection

### DIFF
--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
@@ -373,6 +373,60 @@ describe("cli smoke flows", () => {
     expect(explanation.runId).toBe(secondRun.runId);
     expect(explanation.runId).not.toBe(firstRun.runId);
     expect(explanation.jsonPath).toBe(secondRun.jsonPath);
+  });
+
+  it("prefers bundle completion timestamps over misleading bundle mtimes", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentops-cli-explain-finished-at-"));
+    writeFileSync(join(root, "package.json"), '{"name":"fixture"}');
+    initProject(root);
+
+    const olderRunRoot = join(root, ".agentops", "runs", "1773850000000-old");
+    mkdirSync(olderRunRoot, { recursive: true });
+    writeFileSync(
+      join(olderRunRoot, "bundle.json"),
+      JSON.stringify(
+        {
+          runId: "1773850000000-old",
+          startedAt: "2026-03-18T17:00:00.000Z",
+          finishedAt: "2026-03-18T17:00:01.000Z",
+          status: "success",
+          findings: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [],
+          entries: []
+        },
+        null,
+        2
+      )
+    );
+
+    const newerRunRoot = join(root, ".agentops", "runs", "1773850001000-new");
+    mkdirSync(newerRunRoot, { recursive: true });
+    const newerBundlePath = join(newerRunRoot, "bundle.json");
+    writeFileSync(
+      newerBundlePath,
+      JSON.stringify(
+        {
+          runId: "1773850001000-new",
+          startedAt: "2026-03-18T17:00:02.000Z",
+          finishedAt: "2026-03-18T17:00:03.000Z",
+          status: "success",
+          findings: [],
+          blockedPlugins: [],
+          lifecycleArtifacts: [],
+          entries: []
+        },
+        null,
+        2
+      )
+    );
+
+    const staleTime = new Date("2026-03-18T16:59:00.000Z");
+    utimesSync(newerBundlePath, staleTime, staleTime);
+
+    const explanation = explainLastRun(root);
+    expect(explanation.runId).toBe("1773850001000-new");
+    expect(explanation.jsonPath).toBe(newerBundlePath);
   });
 
   it("maps bounded local workflow outcomes to GitHub handoff statuses", () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1087,6 +1087,20 @@ function readLatestCompleteRunBundle(runsRoot: string): { runDir: string; bundle
     return undefined;
   }
 
+  const parseRunTimestampMs = (value: unknown): number | undefined => {
+    if (typeof value !== "string" || value.length === 0) {
+      return undefined;
+    }
+
+    const parsedDate = Date.parse(value);
+    if (!Number.isNaN(parsedDate)) {
+      return parsedDate;
+    }
+
+    const timestampPrefix = Number.parseInt(value.split("-")[0] ?? "", 10);
+    return Number.isNaN(timestampPrefix) ? undefined : timestampPrefix;
+  };
+
   const candidates = readdirSync(runsRoot)
     .map((entry) => {
       const bundlePath = join(runsRoot, entry, "bundle.json");
@@ -1097,12 +1111,18 @@ function readLatestCompleteRunBundle(runsRoot: string): { runDir: string; bundle
       const stats = statSync(bundlePath);
       const bundle = JSON.parse(readFileSync(bundlePath, "utf8")) as Record<string, unknown>;
       const bundleRunId = typeof bundle.runId === "string" ? bundle.runId : entry;
+      const completedAtMs =
+        parseRunTimestampMs(bundle.finishedAt) ??
+        parseRunTimestampMs(bundle.startedAt) ??
+        parseRunTimestampMs(bundleRunId) ??
+        parseRunTimestampMs(entry) ??
+        stats.mtimeMs;
 
       return {
         runDir: entry,
         bundle,
         bundleRunId,
-        completedAtMs: stats.mtimeMs
+        completedAtMs
       };
     })
     .filter((candidate): candidate is { runDir: string; bundle: Record<string, unknown>; bundleRunId: string; completedAtMs: number } =>


### PR DESCRIPTION
## Summary
- make `explain last-run` prefer explicit run completion timestamps over filesystem mtimes
- keep the fix limited to latest-run resolution and regression coverage
- preserve the CLI shape and output contract

## Validation
- `pnpm exec vitest run packages/cli/src/index.test.ts -t "explain"`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- direct reproduction now returns the fresh run id from `explain last-run --json`
- `pnpm test; echo EXIT:$?` remains wrapper-ambiguous in this environment and was not used as the deciding gate for this narrow CLI slice