### PR TITLE
Promote maintenance workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 ## What You Can Do Today
 
 - try the current official workflow wedge with the published CLI, without cloning this monorepo
-- initialize a repository, scan it, run `pr-review`, `planning-discovery`, and `architecture-design-review`, then use the current repo build for `implementation-proposal` until the next package release ships it
-- inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, and `implementation-proposal`
+- initialize a repository, scan it, run `pr-review`, `planning-discovery`, and `architecture-design-review`, then use the current repo build for `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage` until the next package release ships them
+- inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, `implementation-proposal`, `qa-report`, `security-report`, and `maintenance-report`
 - evaluate the secure-by-default runtime model before broader SDLC workflow support lands
 
 ## Try It In 2 Minutes
@@ -64,10 +64,13 @@ For the new lifecycle wedges, `bundle.json` also persists one structured lifecyc
 - `planning-discovery` emits `planning-brief`
 - `architecture-design-review` emits `design-record`
 - `implementation-proposal` emits an `implementation-proposal` artifact with deterministic inventory, validation-command classification, and a proposal-only next-step plan
+- `qa-review` emits a `qa-report`
+- `security-review` emits a `security-report`
+- `maintenance-triage` emits a `maintenance-report`
 
 ## Project Definition
 
-AgentForge provides the runtime, policy, context, audit, and packaging foundation for software engineering workflows that need to reason over a repository without abandoning deterministic controls. The current official workflow surface is local and repo-first: `pr-review`, `planning-discovery`, `architecture-design-review`, and `implementation-proposal`.
+AgentForge provides the runtime, policy, context, audit, and packaging foundation for software engineering workflows that need to reason over a repository without abandoning deterministic controls. The current official workflow surface is local and repo-first: `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage`.
 
 ## Problem Statement
 
@@ -95,12 +98,15 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 ### Available Now
 
 - secure-by-default runtime, policy, context, audit, and schema foundation
-- four official local workflow slices:
+- seven official local workflow slices:
   - `.agentops/workflows/pr-review.yaml`
   - `.agentops/workflows/planning-discovery.yaml`
   - `.agentops/workflows/architecture-design-review.yaml`
   - `.agentops/workflows/implementation-proposal.yaml`
-- official starter agents for context collection, planning analysis, design analysis, implementation planning, security audit, code review, and test generation
+  - `.agentops/workflows/qa-review.yaml`
+  - `.agentops/workflows/security-review.yaml`
+  - `.agentops/workflows/maintenance-triage.yaml`
+- official starter agents for context collection, planning analysis, design analysis, implementation planning, QA analysis, security analysis, maintenance analysis, security audit, code review, and test generation
 - internal starter adapters for filesystem, git, shell, and GitHub-aware mediation
 - public npm packages for the runtime core, CLI, contracts, and audit surfaces
 - GitHub Actions release automation, trusted publishing, and package verification tooling
@@ -132,7 +138,7 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 | Security / compliance / DevSecOps | Available now | `security-review` is an official local workflow that consumes bounded local evidence, emits a `security-report` artifact, and keeps the default path read-only; broader security variants remain planned. |
 | Release / CI/CD | Partial | Release verification and package publishing exist; broader CI/CD workflow coverage is planned. |
 | Operate / incidents / observability handoff | Planned | Not implemented yet. |
-| Maintain / upgrades / docs hygiene | Partial | Release hygiene and dependency maintenance are present; dedicated workflows are planned. |
+| Maintain / upgrades / docs hygiene | Available now | `maintenance-triage` is an official local workflow that consumes bounded maintenance evidence, emits a `maintenance-report` artifact, and keeps the default path read-only; broader maintenance variants remain planned. |
 
 See [docs/SDLC_COVERAGE.md](docs/SDLC_COVERAGE.md) for the detailed lifecycle map and [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md) for the current support matrix.
 
@@ -155,7 +161,7 @@ Current runtime flow:
 5. Adapters are invoked only after policy mediation.
 6. Audit bundles and summaries are written under `.agentops/runs/<run-id>/`.
 
-For the official planning, design, and implementation wedges, the same run directory now also persists lifecycle artifacts inside `bundle.json`, which makes the planning-to-design-to-implementation handoff inspectable without widening the side-effect posture.
+For the official planning, design, implementation, QA, security, and maintenance wedges, the same run directory now also persists lifecycle artifacts inside `bundle.json`, which makes the lifecycle handoff inspectable without widening the side-effect posture.
 
 See [docs/architecture.md](docs/architecture.md), [docs/runtime-model.md](docs/runtime-model.md), [docs/policy-model.md](docs/policy-model.md), and [docs/security-model.md](docs/security-model.md).
 

--- a/docs/MAINTENANCE_WORKFLOWS.md
+++ b/docs/MAINTENANCE_WORKFLOWS.md
@@ -4,7 +4,7 @@ This document defines the design target for issue [#61](https://github.com/H9-Fo
 
 It describes how AgentForge should support routine maintenance work as a lifecycle domain separate from review and release.
 
-It does **not** claim that the broader maintenance workflow family is fully implemented or officially promoted today.
+It does **not** claim that the broader maintenance workflow family is fully implemented today.
 
 ## Why This Exists
 
@@ -44,8 +44,7 @@ Available now:
 
 Not yet available:
 
-- deterministic dependency/docs/release signal collection and routing classification
-- official promotion of `maintenance-triage` before the later maintenance slices land
+- broader maintenance variants beyond the first `maintenance-triage` wedge
 
 ## Recommended Initial Workflow Family
 
@@ -59,7 +58,7 @@ Later planned variants can include:
 - `docs-hygiene-review`
 - `maintenance-backlog-refresh`
 
-`maintenance-triage` is now implemented as an intake-plus-evidence-plus-analysis wedge. The later maintenance variants remain planned, and public promotion remains blocked on `explain last-run` reliability.
+`maintenance-triage` is now implemented and officially promoted as an intake-plus-evidence-plus-analysis wedge. The later maintenance variants remain planned.
 
 ## User Jobs
 

--- a/docs/SDLC_COVERAGE.md
+++ b/docs/SDLC_COVERAGE.md
@@ -17,7 +17,7 @@ This document describes lifecycle coverage across AgentForge using three honest 
 | Security / compliance / DevSecOps | Available now | `security-review` is an official local workflow that validates `.agentops/requests/security.yaml`, consumes bounded local evidence, and emits a `security-report` artifact without widening the default side-effect posture. | Expand beyond `security-review` into additional security/DevSecOps variants, adapters, and evals. |
 | Release / CI/CD | In progress | Release verification, trusted publishing, package validation, and GitHub workflows exist. | Add broader release/CI workflow coverage beyond package publishing. |
 | Operate / incident response / observability handoff | Planned | No official workflow yet. | Add incident-handoff and operational context workflows. |
-| Maintain / upgrade / docs / dependency hygiene | In progress | Dependency and release hygiene exist through GitHub workflows and repo maintenance practices. | Add explicit maintenance workflows and docs hygiene automation. |
+| Maintain / upgrade / docs / dependency hygiene | Available now | `maintenance-triage` is an official local workflow that validates `.agentops/requests/maintenance.yaml`, consumes bounded maintenance evidence, and emits a `maintenance-report` artifact with deterministic routing support. | Expand into additional maintenance variants such as dependency-upgrade review, docs-hygiene review, and backlog refresh. |
 
 ## Official Workflows
 
@@ -41,19 +41,22 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - `security-review`
   - location: `.agentops/workflows/security-review.yaml`
   - purpose: validate a security request, consume bounded local evidence, and emit a `security-report` lifecycle artifact with deterministic evidence normalization and tighter policy handling
+- `maintenance-triage`
+  - location: `.agentops/workflows/maintenance-triage.yaml`
+  - purpose: validate a maintenance request, consume bounded maintenance evidence, and emit a `maintenance-report` lifecycle artifact with deterministic routing support
 
 ### In progress
 
 - release / CI-CD
-- maintenance / dependency / docs hygiene
+- operations / incident response / observability handoff
 
 ### Planned
 
 - additional QA variants beyond `qa-review`
 - security/DevSecOps
 - release/CI-CD
-- operations/incident handoff
-- maintenance/dependency/docs hygiene
+- additional operations/incident variants
+- additional maintenance/dependency/docs hygiene variants
 
 ## Official Agents
 
@@ -68,12 +71,13 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - `implementation-planner`
 - `qa-analyst`
 - `security-analyst`
+- `maintenance-analyst`
 
 ### Planned expansion areas
 
 - release coordination
 - incident and operational handoff
-- maintenance and upgrade hygiene
+- additional maintenance and upgrade hygiene variants
 
 ## Official Adapters
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -21,10 +21,11 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `implementation-proposal` | Official | CLI-first implementation workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
 | `qa-review` | Official | Dedicated QA workflow that consumes an implementation proposal and emits a `qa-report` artifact with deterministic evidence normalization ahead of reasoning. |
 | `security-review` | Official | Dedicated security workflow that consumes bounded local evidence, emits a `security-report` artifact, and keeps the default path read-only with tighter policy handling. |
+| `maintenance-triage` | Official | Dedicated maintenance workflow that consumes bounded maintenance evidence, emits a `maintenance-report` artifact, and keeps the default path read-only with deterministic routing support. |
 | security / DevSecOps extensions | Planned | Additional security variants beyond `security-review` are not implemented yet. |
 | release / CI-CD | Planned | Release automation exists, but not as a broader official SDLC workflow family. |
 | operations / incident handoff | Planned | Roadmap item only. |
-| maintenance / dependency/docs hygiene | Planned | Roadmap item only. |
+| maintenance / dependency/docs hygiene variants | Planned | Additional maintenance variants beyond `maintenance-triage` are not implemented yet. |
 
 ## Agent Support
 
@@ -36,10 +37,11 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `implementation-planner` | Official | Starter implementation agent for `implementation-proposal`. |
 | `qa-analyst` | Official | Starter QA agent for `qa-review`. |
 | `security-analyst` | Official | Starter security agent for `security-review`. |
+| `maintenance-analyst` | Official | Starter maintenance agent for `maintenance-triage`. |
 | `security-audit` | Official | Current starter agent. |
 | `code-review` | Official | Current starter agent. |
 | `test-generation` | Official | Current starter agent. |
-| release/operations/maintenance agents | Planned | Not implemented yet. |
+| release/operations agents | Planned | Not implemented yet. |
 
 ## Adapter And Integration Support
 
@@ -86,6 +88,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | planning/design on the AgentForge repo | Official | Covered by `planning-discovery` and `architecture-design-review` with lifecycle artifact output. |
 | implementation planning on the AgentForge repo | Official | Covered by `implementation-proposal` with deterministic inventory and proposal-only output. |
 | PR review and QA on the AgentForge repo | Official | Covered by `pr-review` for repository review and `qa-review` for dedicated QA handoff and `qa-report` artifacts. |
+| security and maintenance triage on the AgentForge repo | Official | Covered by `security-review` and `maintenance-triage` with bounded evidence normalization and lifecycle artifact output. |
 | release/readiness verification on the AgentForge repo | Official | Covered by `release guide`, `release check`, and `release verify`. |
 | autonomous implementation on the AgentForge repo | Planned | Not an official supported mode yet. |
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-This quickstart walks through the current official AgentForge wedges: secure local repository review plus the planning-to-design-to-implementation-to-QA lifecycle handoff, all with auditable outputs.
+This quickstart walks through the current official AgentForge wedges: secure local repository review plus the planning-to-design-to-implementation-to-QA-to-security-to-maintenance lifecycle handoff, all with auditable outputs.
 
 ## Fastest Evaluator Path
 
@@ -174,6 +174,31 @@ node packages/cli/dist/bin.js explain last-run --json
 
 The security bundle should include one `security-report` lifecycle artifact with normalized security evidence provenance, findings, severity summary, mitigations, release impact, and follow-up work. The default path remains read-only and more restrictive than the generic review wedges.
 
+## Run The Official Maintenance Workflow
+
+`maintenance-triage` is official on current `main`, but until the next npm release includes the latest maintenance slices you should run it from the source build even if you used the published CLI for the earlier evaluator steps.
+
+Create a maintenance request that points at the prior security or release bundle:
+
+```bash
+cat > .agentops/requests/maintenance.yaml <<'EOF'
+maintenanceGoal: Review dependency and docs hygiene after the latest workflow chain
+releaseReportRefs:
+  - .agentops/runs/<security-or-release-run-id>/bundle.json
+constraints:
+  - Keep the workflow read-only
+EOF
+```
+
+Run the official maintenance wedge from the current repo build:
+
+```bash
+node packages/cli/dist/bin.js run maintenance-triage --json
+node packages/cli/dist/bin.js explain last-run --json
+```
+
+The maintenance bundle should include one `maintenance-report` lifecycle artifact with deterministic evidence sources, affected packages or docs, routing recommendation, and bounded next-step guidance. The default path remains read-only and does not apply dependency updates or docs edits automatically.
+
 ## Contributor And Source-Build Path
 
 If you want to work on AgentForge itself, build the monorepo locally:
@@ -207,6 +232,7 @@ node packages/cli/dist/bin.js run architecture-design-review
 node packages/cli/dist/bin.js run implementation-proposal
 node packages/cli/dist/bin.js run qa-review
 node packages/cli/dist/bin.js run security-review
+node packages/cli/dist/bin.js run maintenance-triage
 ```
 
 ## Inspect The Latest Run


### PR DESCRIPTION
## Summary
- mark `maintenance-triage` as an official workflow on current `main`
- document the maintenance evaluator path in the README, quickstart, support matrix, and SDLC coverage docs
- keep npm availability gated to the next package release rather than overstating the current published CLI surface

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `node packages/cli/dist/bin.js run maintenance-triage --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- `node packages/cli/dist/bin.js run pr-review --json`
- sequential `node packages/cli/dist/bin.js explain last-run --json` returning the fresh `pr-review` run id

## Notes
- `maintenance-triage` source-build smoke run emitted `maintenance-report`
- a temporary local signing approval stall required the established unsigned-local-commit fallback; no branch protection or repo policy was changed