### PR TITLE
Add eval spec fixture corpus

### DIFF
--- a/.changeset/eval-spec-fixture-corpus.md
+++ b/.changeset/eval-spec-fixture-corpus.md
@@ -1,0 +1,6 @@
+---
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add provider-agnostic `eval-spec` contracts and a deterministic local fixture corpus for the current official workflow surface.

--- a/docs/EVALS_BENCHMARKS_FRAMEWORK.md
+++ b/docs/EVALS_BENCHMARKS_FRAMEWORK.md
@@ -33,14 +33,15 @@ Available now:
 - schema fixtures and runtime tests
 - release verification
 - local dogfooding for `pr-review`
+- `eval-spec` schema plus a deterministic local fixture corpus for the current official workflow surface
 - support matrix and roadmap framing
 
 Not yet available:
 
-- eval spec schema
-- benchmark dataset or fixture corpus
 - workflow-scoring contracts
 - repeatable regression comparison across workflow versions
+- local eval runner and `eval-result` artifact emission
+- benchmark comparison and regression reporting
 
 ## Framework Layers
 
@@ -101,7 +102,7 @@ The roadmap should eventually introduce:
 - `eval-result`
 - `benchmark-summary`
 
-The first phase should define these as schema and reporting targets before implementation.
+The first phase now defines `eval-spec` plus a deterministic fixture corpus. The later phases still need to implement `eval-result` and `benchmark-summary` behavior.
 
 ## Relationship To Workflow Growth
 
@@ -120,4 +121,3 @@ This epic should be decomposed into at least:
 1. eval-spec schema and deterministic fixture corpus for core workflows
 2. local eval runner with score normalization and artifact emission
 3. benchmark comparison and regression-reporting surface for workflow and agent variants
-

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -120,7 +120,7 @@ If the published CLI reports `packageManager: "unknown"` in a generic repo, omit
 
 ## Run The Official QA Workflow
 
-`qa-review` is official on current `main`, but until the next npm release includes the latest QA slices you should run it from the source build even if you used the published CLI for the earlier evaluator steps.
+`qa-review` is now available in the published CLI as part of the official local workflow surface.
 
 Create a QA request that points at the prior implementation bundle:
 
@@ -135,11 +135,11 @@ releaseContext: candidate
 EOF
 ```
 
-Run the official QA wedge from the current repo build:
+Run the official QA wedge:
 
 ```bash
-node packages/cli/dist/bin.js run qa-review --json
-node packages/cli/dist/bin.js explain last-run --json
+npx @h9-foundry/agentforge-cli run qa-review --json
+npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 The QA bundle should include one `qa-report` lifecycle artifact with normalized evidence sources, normalized executed checks, coverage gaps, findings, and recommended next checks. The default path remains read-only and bounded to local evidence.
@@ -148,7 +148,7 @@ If package-manager detection is unavailable in the published generic-repo path, 
 
 ## Run The Official Security Workflow
 
-`security-review` is official on current `main`, but until the next npm release includes the latest security slices you should run it from the source build even if you used the published CLI for the earlier evaluator steps.
+`security-review` is now available in the published CLI as part of the official local workflow surface.
 
 Create a security request that points at the prior QA or implementation bundle:
 
@@ -165,18 +165,18 @@ releaseContext: candidate
 EOF
 ```
 
-Run the official security wedge from the current repo build:
+Run the official security wedge:
 
 ```bash
-node packages/cli/dist/bin.js run security-review --json
-node packages/cli/dist/bin.js explain last-run --json
+npx @h9-foundry/agentforge-cli run security-review --json
+npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 The security bundle should include one `security-report` lifecycle artifact with normalized security evidence provenance, findings, severity summary, mitigations, release impact, and follow-up work. The default path remains read-only and more restrictive than the generic review wedges.
 
 ## Run The Official Maintenance Workflow
 
-`maintenance-triage` is official on current `main`, but until the next npm release includes the latest maintenance slices you should run it from the source build even if you used the published CLI for the earlier evaluator steps.
+`maintenance-triage` is now available in the published CLI as part of the official local workflow surface.
 
 Create a maintenance request that points at the prior security or release bundle:
 
@@ -190,11 +190,11 @@ constraints:
 EOF
 ```
 
-Run the official maintenance wedge from the current repo build:
+Run the official maintenance wedge:
 
 ```bash
-node packages/cli/dist/bin.js run maintenance-triage --json
-node packages/cli/dist/bin.js explain last-run --json
+npx @h9-foundry/agentforge-cli run maintenance-triage --json
+npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 The maintenance bundle should include one `maintenance-report` lifecycle artifact with deterministic evidence sources, affected packages or docs, routing recommendation, and bounded next-step guidance. The default path remains read-only and does not apply dependency updates or docs edits automatically.

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -5,6 +5,8 @@ import {
   auditBundleSchema,
   designArtifactSchema,
   designRequestSchema,
+  evalFixtureCorpusSchema,
+  evalSpecSchema,
   githubActionsEvidenceNormalizationSchema,
   githubActionsEvidenceSchema,
   githubHandoffSummarySchema,
@@ -48,6 +50,8 @@ describe("schema fixtures", () => {
     expect(() => incidentRequestSchema.parse(schemaFixtures.incidentRequest)).not.toThrow();
     expect(() => qaRequestSchema.parse(schemaFixtures.qaRequest)).not.toThrow();
     expect(() => securityRequestSchema.parse(schemaFixtures.securityRequest)).not.toThrow();
+    expect(() => evalSpecSchema.parse(schemaFixtures.evalSpec)).not.toThrow();
+    expect(() => evalFixtureCorpusSchema.parse(schemaFixtures.evalFixtureCorpus)).not.toThrow();
     expect(() => releaseRequestSchema.parse(schemaFixtures.releaseRequest)).not.toThrow();
     expect(() => githubReferenceSchema.parse(schemaFixtures.githubReference)).not.toThrow();
     expect(() => githubActionsEvidenceSchema.parse(schemaFixtures.githubActionsEvidence)).not.toThrow();
@@ -85,6 +89,8 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.incidentRequest).toBeDefined();
     expect(jsonSchemas.qaRequest).toBeDefined();
     expect(jsonSchemas.securityRequest).toBeDefined();
+    expect(jsonSchemas.evalSpec).toBeDefined();
+    expect(jsonSchemas.evalFixtureCorpus).toBeDefined();
     expect(jsonSchemas.releaseRequest).toBeDefined();
     expect(jsonSchemas.githubReference).toBeDefined();
     expect(jsonSchemas.githubActionsEvidence).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -54,6 +54,16 @@ export const catalogDomainSchema = z.enum([
 ]);
 export const supportLevelSchema = z.enum(["official", "partial", "planned", "internal"]);
 export const maturitySchema = z.enum(["concept", "prototype", "mvp", "expanding", "stable"]);
+export const evalRepoFixtureSchema = z.enum(["agentforge-monorepo", "blank-local"]);
+export const evalWorkflowSchema = z.enum([
+  "pr-review",
+  "planning-discovery",
+  "architecture-design-review",
+  "implementation-proposal",
+  "qa-review",
+  "security-review",
+  "maintenance-triage"
+]);
 export const trustScopeSchema = z.enum([
   "core-only",
   "official-core-only",
@@ -760,6 +770,95 @@ export const maintenanceRequestSchema = z.object({
   constraints: z.array(z.string().min(1)).default([])
 });
 
+export const evalPolicyExpectationSchema = z.object({
+  executionMode: executionModeSchema.default("inspect"),
+  readOnly: z.boolean().default(true),
+  sideEffectClasses: z.array(sideEffectClassSchema).default(["observe", "suggest"]),
+  approvalRequiredActions: z.array(z.string().min(1)).default([])
+});
+
+export const evalRedactionExpectationSchema = z.object({
+  applied: z.boolean().default(true),
+  expectedCategories: z.array(z.string().min(1)).default([])
+});
+
+export const evalArtifactExpectationSchema = z.object({
+  artifactKind: lifecycleArtifactKindSchema,
+  lifecycleDomain: lifecycleDomainSchema,
+  requiredPayloadFields: z.array(z.string().min(1)).default([]),
+  requiredSummaryTerms: z.array(z.string().min(1)).default([])
+});
+
+const evalSpecBaseShape = {
+  schemaVersion: z.string().min(1),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  repoFixture: evalRepoFixtureSchema,
+  expectedStatus: runStatusSchema.default("success"),
+  notes: z.array(z.string().min(1)).default([]),
+  policyExpectations: evalPolicyExpectationSchema,
+  redactionExpectations: evalRedactionExpectationSchema,
+  artifactExpectations: z.array(evalArtifactExpectationSchema).default([])
+} as const;
+
+export const prReviewEvalSpecSchema = z.object({
+  ...evalSpecBaseShape,
+  workflow: z.literal("pr-review")
+});
+
+export const planningEvalSpecSchema = z.object({
+  ...evalSpecBaseShape,
+  workflow: z.literal("planning-discovery"),
+  request: planningRequestSchema
+});
+
+export const designEvalSpecSchema = z.object({
+  ...evalSpecBaseShape,
+  workflow: z.literal("architecture-design-review"),
+  request: designRequestSchema
+});
+
+export const implementationEvalSpecSchema = z.object({
+  ...evalSpecBaseShape,
+  workflow: z.literal("implementation-proposal"),
+  request: implementationRequestSchema
+});
+
+export const qaEvalSpecSchema = z.object({
+  ...evalSpecBaseShape,
+  workflow: z.literal("qa-review"),
+  request: qaRequestSchema
+});
+
+export const securityEvalSpecSchema = z.object({
+  ...evalSpecBaseShape,
+  workflow: z.literal("security-review"),
+  request: securityRequestSchema
+});
+
+export const maintenanceEvalSpecSchema = z.object({
+  ...evalSpecBaseShape,
+  workflow: z.literal("maintenance-triage"),
+  request: maintenanceRequestSchema
+});
+
+export const evalSpecSchema = z.discriminatedUnion("workflow", [
+  prReviewEvalSpecSchema,
+  planningEvalSpecSchema,
+  designEvalSpecSchema,
+  implementationEvalSpecSchema,
+  qaEvalSpecSchema,
+  securityEvalSpecSchema,
+  maintenanceEvalSpecSchema
+]);
+
+export const evalFixtureCorpusSchema = z.object({
+  schemaVersion: z.string().min(1),
+  generatedAt: z.string().datetime(),
+  specs: z.array(evalSpecSchema).min(1)
+});
+
 export const releaseEvidenceNormalizationSchema = z.object({
   qaReportRefs: z.array(z.string().min(1)).default([]),
   securityReportRefs: z.array(z.string().min(1)).default([]),
@@ -954,6 +1053,11 @@ export const schemaRegistry = {
   releaseRequest: releaseRequestSchema,
   incidentRequest: incidentRequestSchema,
   maintenanceRequest: maintenanceRequestSchema,
+  evalPolicyExpectation: evalPolicyExpectationSchema,
+  evalRedactionExpectation: evalRedactionExpectationSchema,
+  evalArtifactExpectation: evalArtifactExpectationSchema,
+  evalSpec: evalSpecSchema,
+  evalFixtureCorpus: evalFixtureCorpusSchema,
   normalizedValidationCommand: normalizedValidationCommandSchema,
   implementationInventory: implementationInventorySchema,
   qaEvidenceNormalization: qaEvidenceNormalizationSchema,
@@ -1534,6 +1638,222 @@ const maintenanceEvidenceNormalizationFixture = {
   ]
 } as const;
 
+const evalFixtureCorpusFixture = {
+  schemaVersion: "1.0.0",
+  generatedAt: "2026-03-18T12:00:00.000Z",
+  specs: [
+    {
+      schemaVersion: "1.0.0",
+      id: "pr-review-local-baseline",
+      name: "PR review local baseline",
+      workflow: "pr-review",
+      description: "Baseline deterministic expectations for the official PR review wedge.",
+      repoFixture: "agentforge-monorepo",
+      expectedStatus: "success",
+      notes: ["No lifecycle artifact is emitted in the current official PR review wedge."],
+      policyExpectations: {
+        executionMode: "inspect",
+        readOnly: true,
+        sideEffectClasses: ["observe", "suggest"],
+        approvalRequiredActions: []
+      },
+      redactionExpectations: {
+        applied: true,
+        expectedCategories: ["secrets"]
+      },
+      artifactExpectations: []
+    },
+    {
+      schemaVersion: "1.0.0",
+      id: "planning-discovery-local-brief",
+      name: "Planning discovery emits planning brief",
+      workflow: "planning-discovery",
+      description: "Deterministic expectations for the first official planning workflow.",
+      repoFixture: "blank-local",
+      expectedStatus: "success",
+      request: {
+        problemStatement: "Define the first planning-discovery workflow wedge.",
+        goals: ["Produce one planning brief artifact"],
+        constraints: ["Keep the workflow local-first and read-only"],
+        issueRefs: ["#127", "#128"],
+        pathHints: ["packages/cli", "packages/runtime", "docs/PLANNING_DISCOVERY_WORKFLOW.md"],
+        assumptions: ["CLI-first execution remains the evaluator path"]
+      },
+      notes: ["The CLI-first local path should remain read-only by default."],
+      policyExpectations: {
+        executionMode: "inspect",
+        readOnly: true,
+        sideEffectClasses: ["observe", "suggest"],
+        approvalRequiredActions: []
+      },
+      redactionExpectations: {
+        applied: true,
+        expectedCategories: ["secrets"]
+      },
+      artifactExpectations: [
+        {
+          artifactKind: "planning-brief",
+          lifecycleDomain: "plan",
+          requiredPayloadFields: ["problemStatement", "objectives", "recommendedNextSteps"],
+          requiredSummaryTerms: ["planning", "brief"]
+        }
+      ]
+    },
+    {
+      schemaVersion: "1.0.0",
+      id: "architecture-design-review-local-record",
+      name: "Architecture design review emits design record",
+      workflow: "architecture-design-review",
+      description: "Deterministic expectations for the first official design workflow.",
+      repoFixture: "blank-local",
+      expectedStatus: "success",
+      request: {
+        planningBriefRef: ".agentops/runs/run-123/bundle.json",
+        decisionTarget: "Choose the first planning workflow implementation shape.",
+        constraints: ["Keep deterministic intake validation before reasoning"],
+        pathHints: ["packages/schemas", "packages/runtime", "packages/cli"],
+        alternatives: ["single-agent workflow", "deterministic intake plus reasoning"],
+        questions: ["How should planning artifacts be referenced downstream?"]
+      },
+      notes: ["Design review requires a prior planning brief reference."],
+      policyExpectations: {
+        executionMode: "inspect",
+        readOnly: true,
+        sideEffectClasses: ["observe", "suggest"],
+        approvalRequiredActions: []
+      },
+      redactionExpectations: {
+        applied: true,
+        expectedCategories: ["secrets"]
+      },
+      artifactExpectations: [
+        {
+          artifactKind: "design-record",
+          lifecycleDomain: "design",
+          requiredPayloadFields: ["decisionSummary", "chosenApproach", "optionsConsidered"],
+          requiredSummaryTerms: ["design", "record"]
+        }
+      ]
+    },
+    {
+      schemaVersion: "1.0.0",
+      id: "implementation-proposal-local-plan",
+      name: "Implementation proposal emits implementation artifact",
+      workflow: "implementation-proposal",
+      description: "Deterministic expectations for the official implementation workflow.",
+      repoFixture: "blank-local",
+      expectedStatus: "success",
+      request: implementationRequestFixture,
+      notes: ["The initial implementation wedge is proposal-only and read-only."],
+      policyExpectations: {
+        executionMode: "inspect",
+        readOnly: true,
+        sideEffectClasses: ["observe", "suggest"],
+        approvalRequiredActions: ["Any validation command execution remains approval-gated."]
+      },
+      redactionExpectations: {
+        applied: true,
+        expectedCategories: ["secrets"]
+      },
+      artifactExpectations: [
+        {
+          artifactKind: "implementation-proposal",
+          lifecycleDomain: "build",
+          requiredPayloadFields: ["designRecordRef", "implementationGoal", "validationPlan"],
+          requiredSummaryTerms: ["implementation", "proposal"]
+        }
+      ]
+    },
+    {
+      schemaVersion: "1.0.0",
+      id: "qa-review-local-report",
+      name: "QA review emits qa report",
+      workflow: "qa-review",
+      description: "Deterministic expectations for the official QA workflow.",
+      repoFixture: "blank-local",
+      expectedStatus: "success",
+      request: qaRequestFixture,
+      notes: ["QA remains bounded to validated local evidence and normalized check references."],
+      policyExpectations: {
+        executionMode: "inspect",
+        readOnly: true,
+        sideEffectClasses: ["observe", "suggest"],
+        approvalRequiredActions: ["Executing new validation commands remains approval-gated."]
+      },
+      redactionExpectations: {
+        applied: true,
+        expectedCategories: ["secrets"]
+      },
+      artifactExpectations: [
+        {
+          artifactKind: "qa-report",
+          lifecycleDomain: "test",
+          requiredPayloadFields: ["targetRef", "evidenceSources", "recommendedNextChecks"],
+          requiredSummaryTerms: ["QA", "report"]
+        }
+      ]
+    },
+    {
+      schemaVersion: "1.0.0",
+      id: "security-review-local-report",
+      name: "Security review emits security report",
+      workflow: "security-review",
+      description: "Deterministic expectations for the official security workflow.",
+      repoFixture: "blank-local",
+      expectedStatus: "success",
+      request: securityRequestFixture,
+      notes: ["Security review remains read-only and more restrictive than generic review wedges."],
+      policyExpectations: {
+        executionMode: "inspect",
+        readOnly: true,
+        sideEffectClasses: ["observe", "suggest"],
+        approvalRequiredActions: []
+      },
+      redactionExpectations: {
+        applied: true,
+        expectedCategories: ["secrets"]
+      },
+      artifactExpectations: [
+        {
+          artifactKind: "security-report",
+          lifecycleDomain: "security",
+          requiredPayloadFields: ["targetRef", "severitySummary", "releaseImpact"],
+          requiredSummaryTerms: ["security", "report"]
+        }
+      ]
+    },
+    {
+      schemaVersion: "1.0.0",
+      id: "maintenance-triage-local-report",
+      name: "Maintenance triage emits maintenance report",
+      workflow: "maintenance-triage",
+      description: "Deterministic expectations for the official maintenance workflow.",
+      repoFixture: "blank-local",
+      expectedStatus: "success",
+      request: maintenanceRequestFixture,
+      notes: ["Maintenance triage stays read-only and routes work without applying dependency or docs changes."],
+      policyExpectations: {
+        executionMode: "inspect",
+        readOnly: true,
+        sideEffectClasses: ["observe", "suggest"],
+        approvalRequiredActions: []
+      },
+      redactionExpectations: {
+        applied: true,
+        expectedCategories: ["secrets"]
+      },
+      artifactExpectations: [
+        {
+          artifactKind: "maintenance-report",
+          lifecycleDomain: "maintain",
+          requiredPayloadFields: ["maintenanceScope", "routingRecommendation", "priorityAssessment"],
+          requiredSummaryTerms: ["maintenance", "report"]
+        }
+      ]
+    }
+  ]
+} as const;
+
 const releaseEvidenceNormalizationFixture = {
   qaReportRefs: [".agentops/runs/run-789/bundle.json"],
   securityReportRefs: [".agentops/runs/run-790/bundle.json"],
@@ -1687,6 +2007,8 @@ export const schemaFixtures = {
   releaseRequest: releaseRequestFixture,
   incidentRequest: incidentRequestFixture,
   maintenanceRequest: maintenanceRequestFixture,
+  evalSpec: evalFixtureCorpusFixture.specs[1],
+  evalFixtureCorpus: evalFixtureCorpusFixture,
   githubReference: githubReferenceFixture,
   githubActionsEvidence: githubActionsEvidenceFixture,
   githubHandoffSummary: githubHandoffSummaryFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -4,6 +4,11 @@ import type {
   DesignArtifact,
   DesignArtifactOption,
   DesignRequest,
+  EvalArtifactExpectation,
+  EvalFixtureCorpus,
+  EvalPolicyExpectation,
+  EvalRedactionExpectation,
+  EvalSpec,
   ImplementationArtifact,
   ImplementationInventory,
   ImplementationRequest,
@@ -64,6 +69,12 @@ describe("shared lifecycle artifact types", () => {
   it("exports workflow request helper types", () => {
     expectTypeOf<PlanningRequest["problemStatement"]>().toEqualTypeOf<string>();
     expectTypeOf<DesignRequest["planningBriefRef"]>().toEqualTypeOf<string>();
+    expectTypeOf<EvalSpec["schemaVersion"]>().toEqualTypeOf<string>();
+    expectTypeOf<EvalSpec["expectedStatus"]>().toEqualTypeOf<"success" | "partial" | "failed">();
+    expectTypeOf<EvalFixtureCorpus["specs"]>().toEqualTypeOf<EvalSpec[]>();
+    expectTypeOf<EvalArtifactExpectation["requiredPayloadFields"]>().toEqualTypeOf<string[]>();
+    expectTypeOf<EvalPolicyExpectation["readOnly"]>().toEqualTypeOf<boolean>();
+    expectTypeOf<EvalRedactionExpectation["expectedCategories"]>().toEqualTypeOf<string[]>();
     expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
     expectTypeOf<IncidentRequest["incidentSummary"]>().toEqualTypeOf<string>();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -23,6 +23,11 @@ import {
   designArtifactPayloadSchema,
   designArtifactSchema,
   designRequestSchema,
+  evalArtifactExpectationSchema,
+  evalFixtureCorpusSchema,
+  evalPolicyExpectationSchema,
+  evalRedactionExpectationSchema,
+  evalSpecSchema,
   effectivePolicySnapshotSchema,
   findingSchema,
   githubActionsCheckRunEvidenceSchema,
@@ -109,6 +114,11 @@ export type DesignArtifactOption = Infer<typeof designArtifactOptionSchema>;
 export type DesignArtifactPayload = Infer<typeof designArtifactPayloadSchema>;
 export type DesignArtifact = Infer<typeof designArtifactSchema>;
 export type DesignRequest = Infer<typeof designRequestSchema>;
+export type EvalArtifactExpectation = Infer<typeof evalArtifactExpectationSchema>;
+export type EvalPolicyExpectation = Infer<typeof evalPolicyExpectationSchema>;
+export type EvalRedactionExpectation = Infer<typeof evalRedactionExpectationSchema>;
+export type EvalSpec = Infer<typeof evalSpecSchema>;
+export type EvalFixtureCorpus = Infer<typeof evalFixtureCorpusSchema>;
 export type ImplementationArtifactPayload = Infer<typeof implementationArtifactPayloadSchema>;
 export type ImplementationArtifact = Infer<typeof implementationArtifactSchema>;
 export type ImplementationInventory = Infer<typeof implementationInventorySchema>;


### PR DESCRIPTION
## Summary
- add provider-agnostic `eval-spec` contracts and an `evalFixtureCorpus` for the current official workflow surface
- export the new eval schema-derived shared types and validate them in schema/type tests
- reconcile `docs/quickstart.md` and the evals roadmap doc with the published `0.7.1` npm surface

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- This closes the first eval infrastructure slice for `#164` without introducing a runner, scoring, or benchmark claims.
- The quickstart wording is updated because the published `0.7.1` CLI verification succeeded for the official workflow surface, including `maintenance-triage`.