### PR TITLE
Add local eval runner

### DIFF
--- a/.changeset/local-eval-runner.md
+++ b/.changeset/local-eval-runner.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add a bounded local eval runner with `agentforge eval run <spec-id>` and emit `eval-result` artifacts for deterministic workflow fixture checks.

--- a/docs/EVALS_BENCHMARKS_FRAMEWORK.md
+++ b/docs/EVALS_BENCHMARKS_FRAMEWORK.md
@@ -4,7 +4,7 @@ This document defines the design target for issue [#63](https://github.com/H9-Fo
 
 It describes how AgentForge should measure workflow quality, safety, and regression over time.
 
-It does **not** claim that a first-class eval runner or benchmark harness is implemented today.
+It does **not** claim that benchmark comparison or hosted eval orchestration is implemented today.
 
 ## Why This Exists
 
@@ -34,13 +34,14 @@ Available now:
 - release verification
 - local dogfooding for `pr-review`
 - `eval-spec` schema plus a deterministic local fixture corpus for the current official workflow surface
+- local eval runner via `agentforge eval run <spec-id>`
+- `eval-result` lifecycle artifact emission for deterministic local evals
 - support matrix and roadmap framing
 
 Not yet available:
 
 - workflow-scoring contracts
 - repeatable regression comparison across workflow versions
-- local eval runner and `eval-result` artifact emission
 - benchmark comparison and regression reporting
 
 ## Framework Layers
@@ -56,7 +57,28 @@ Define a contract for:
 
 This layer should be provider-agnostic and CI-friendly.
 
-### Layer 2: Model-Dependent Eval Runs
+### Layer 2: Local Eval Runs
+
+The first implemented eval runner is intentionally narrow:
+
+- local-first only
+- deterministic fixture execution only
+- no provider scoring
+- no hosted orchestration
+- one `eval-result` artifact per eval run
+
+The initial CLI surface is:
+
+- `agentforge eval run <spec-id>`
+
+Each eval run should:
+
+- resolve one built-in eval spec
+- execute the referenced workflow locally
+- compare deterministic expectations against the resulting workflow bundle
+- emit `eval-result` into the normal run bundle for later comparison
+
+### Layer 3: Model-Dependent Eval Runs
 
 Define a contract for:
 
@@ -67,7 +89,7 @@ Define a contract for:
 
 This layer should keep scoring explicit and comparable, not magical.
 
-### Layer 3: Benchmarks And Trend Reporting
+### Layer 4: Benchmarks And Trend Reporting
 
 Define how AgentForge should compare:
 
@@ -102,7 +124,7 @@ The roadmap should eventually introduce:
 - `eval-result`
 - `benchmark-summary`
 
-The first phase now defines `eval-spec` plus a deterministic fixture corpus. The later phases still need to implement `eval-result` and `benchmark-summary` behavior.
+The first phase now defines `eval-spec`, a deterministic fixture corpus, and a bounded local eval runner that emits `eval-result`. The later phase still needs to implement `benchmark-summary` behavior.
 
 ## Relationship To Workflow Growth
 
@@ -119,5 +141,5 @@ The eval framework should never assume a broader workflow surface than the suppo
 This epic should be decomposed into at least:
 
 1. eval-spec schema and deterministic fixture corpus for core workflows
-2. local eval runner with score normalization and artifact emission
+2. local eval runner with deterministic expectation checks and `eval-result` artifact emission
 3. benchmark comparison and regression-reporting surface for workflow and agent variants

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 
 import {
   checkReleaseReadiness,
+  runLocalEval,
   explainLastRun,
   initProject,
   renderReleaseGuide,
@@ -65,6 +66,32 @@ program
     }
     console.log("Next: run `agentforge explain last-run` for a compact summary of this workflow run.");
     console.log(`Blocked plugins: ${result.blockedPlugins}`);
+  });
+
+const evalCommand = program.command("eval").description("Run bounded local eval specs against the official workflow surface.");
+
+evalCommand
+  .command("run")
+  .description("Execute one built-in local eval spec and emit an eval-result artifact.")
+  .argument("<spec-id>", "Eval spec id from the built-in deterministic fixture corpus.")
+  .option("--json", "Print machine-readable JSON output.")
+  .action(async (specId, options: { json?: boolean }) => {
+    const result = await runLocalEval(specId);
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+    console.log(`Completed eval ${result.runId} for spec ${result.specId}`);
+    console.log(`Workflow: ${result.workflow}`);
+    console.log(`Artifacts: ${result.outputDir}`);
+    console.log(`Audit bundle: ${result.jsonPath}`);
+    console.log(`Summary: ${result.markdownPath}`);
+    console.log(`Deterministic checks: ${result.deterministicCheckCount}`);
+    console.log(`Deterministic failures: ${result.deterministicFailures}`);
+    if (result.evaluatedRunId) {
+      console.log(`Evaluated run: ${result.evaluatedRunId}`);
+    }
+    console.log("Next: run `agentforge explain last-run` for a compact summary of this eval run.");
   });
 
 program

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -7,7 +7,7 @@ import yaml from "js-yaml";
 import { describe, expect, it } from "vitest";
 import { schemaFixtures } from "@h9-foundry/agentforge-schemas";
 
-import { explainLastRun, initProject, mapWorkflowRunStatusToGitHubStatus, runLocalWorkflow, scanProject } from "./index.js";
+import { explainLastRun, initProject, mapWorkflowRunStatusToGitHubStatus, runLocalEval, runLocalWorkflow, scanProject } from "./index.js";
 
 function createGitFixture(prefix: string): string {
   const root = mkdtempSync(join(tmpdir(), prefix));
@@ -444,8 +444,8 @@ describe("cli smoke flows", () => {
     const root = createGitFixture("agentops-cli-guidance-");
     ensureBuiltCli();
 
-    const cliEntry = join(process.cwd(), "packages", "cli", "src", "bin.ts");
-    const run = spawnSync("pnpm", ["exec", "tsx", cliEntry, "run", "pr-review"], {
+    const cliEntry = join(process.cwd(), "packages", "cli", "dist", "bin.js");
+    const run = spawnSync("node", [cliEntry, "run", "pr-review"], {
       cwd: root,
       encoding: "utf8"
     });
@@ -1677,6 +1677,63 @@ describe("cli smoke flows", () => {
     expect(bundle.lifecycleArtifacts[0]?.payload?.followUpIssues).toContain("#145");
     expect(bundle.lifecycleArtifacts[0]?.payload?.dependencyUpdates).toContain(".agentops/evidence/dependency-alerts.json");
     expect(bundle.lifecycleArtifacts[0]?.payload?.docsUpdates).toContain(".agentops/evidence/docs-task.md");
+  });
+
+  it("runs a local eval spec for planning-discovery and emits an eval-result artifact", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+
+    const evalRun = await runLocalEval("planning-discovery-local-brief", root);
+
+    expect(evalRun.status).toBe("success");
+    expect(evalRun.specId).toBe("planning-discovery-local-brief");
+    expect(evalRun.workflow).toBe("planning-discovery");
+    expect(evalRun.artifactKinds).toContain("eval-result");
+    expect(evalRun.deterministicFailures).toBe(0);
+
+    const bundle = readJson<{
+      workflow: string;
+      lifecycleArtifacts: Array<{
+        artifactKind?: string;
+        payload?: {
+          specId?: string;
+          workflow?: string;
+          passed?: boolean;
+          deterministicChecks?: Array<{ status?: string }>;
+        };
+      }>;
+    }>(evalRun.jsonPath);
+    expect(bundle.workflow).toBe("eval:planning-discovery-local-brief");
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("eval-result");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.specId).toBe("planning-discovery-local-brief");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.workflow).toBe("planning-discovery");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.passed).toBe(true);
+    expect(bundle.lifecycleArtifacts[0]?.payload?.deterministicChecks?.every((check) => check.status !== "failed")).toBe(true);
+  });
+
+  it("runs a chained local eval spec for maintenance-triage with prerequisite setup runs", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+
+    const evalRun = await runLocalEval("maintenance-triage-local-report", root);
+
+    expect(evalRun.status).toBe("success");
+    expect(evalRun.workflow).toBe("maintenance-triage");
+    expect(evalRun.setupRunCount).toBeGreaterThan(0);
+    expect(evalRun.evaluatedRunId).toBeDefined();
+
+    const bundle = readJson<{
+      lifecycleArtifacts: Array<{
+        artifactKind?: string;
+        payload?: {
+          setupRuns?: Array<{ workflow?: string }>;
+          evaluatedRunId?: string;
+        };
+      }>;
+    }>(evalRun.jsonPath);
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("eval-result");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.evaluatedRunId).toBe(evalRun.evaluatedRunId);
+    expect(bundle.lifecycleArtifacts[0]?.payload?.setupRuns?.some((run) => run.workflow === "release-readiness")).toBe(true);
   });
 
   it("propagates normalized GitHub references through downstream lifecycle artifacts", async () => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 
 import yaml from "js-yaml";
 
-import { renderAuditBundleMarkdown } from "@h9-foundry/agentforge-audit";
+import { buildAuditBundle, createAuditEntry, renderAuditBundleMarkdown } from "@h9-foundry/agentforge-audit";
 import { createWorkflowState, findWorkspaceRoot } from "@h9-foundry/agentforge-context-engine";
 import { createPolicyEngine, loadPolicyDocument, resolvePolicy } from "@h9-foundry/agentforge-policy-engine";
 import { runWorkflow } from "@h9-foundry/agentforge-runtime";
@@ -13,6 +13,8 @@ import {
   auditBundleSchema,
   designArtifactSchema,
   designRequestSchema,
+  evalArtifactSchema,
+  evalFixtureCorpusSchema,
   implementationRequestSchema,
   incidentRequestSchema,
   maintenanceRequestSchema,
@@ -20,6 +22,7 @@ import {
   planningRequestSchema,
   qaRequestSchema,
   releaseRequestSchema,
+  schemaFixtures,
   securityRequestSchema,
   workflowDefinitionSchema
 } from "@h9-foundry/agentforge-schemas";
@@ -29,6 +32,11 @@ import type {
   BlockedPlugin,
   DesignArtifact,
   DesignRequest,
+  EvalDeterministicCheck,
+  EvalFixtureCorpus,
+  EvalModelDependentCheck,
+  EvalSpec,
+  EvalSetupRun,
   GithubReference,
   GithubWorkflowStatusMapping,
   ImplementationRequest,
@@ -1070,6 +1078,22 @@ export interface WorkflowRunResult {
   artifactKinds: string[];
 }
 
+export interface EvalRunResult {
+  runId: string;
+  specId: string;
+  workflow: string;
+  outputDir: string;
+  jsonPath: string;
+  markdownPath: string;
+  status: string;
+  evaluatedRunId?: string;
+  evaluatedBundlePath?: string;
+  setupRunCount: number;
+  deterministicCheckCount: number;
+  deterministicFailures: number;
+  artifactKinds: string[];
+}
+
 export interface LastRunExplanation {
   runId: string;
   status: string;
@@ -1092,6 +1116,16 @@ function readLatestCompleteRunBundle(runsRoot: string): { runDir: string; bundle
       return undefined;
     }
 
+    const compactDateTimeMatch = value.match(/^(\d{4})-(\d{2})-(\d{2})-(\d{2})(\d{2})(\d{2})$/);
+    if (compactDateTimeMatch) {
+      const [, year, month, day, hour, minute, second] = compactDateTimeMatch;
+      const isoCandidate = `${year}-${month}-${day}T${hour}:${minute}:${second}Z`;
+      const parsedCompactDateTime = Date.parse(isoCandidate);
+      if (!Number.isNaN(parsedCompactDateTime)) {
+        return parsedCompactDateTime;
+      }
+    }
+
     const parsedDate = Date.parse(value);
     if (!Number.isNaN(parsedDate)) {
       return parsedDate;
@@ -1111,24 +1145,35 @@ function readLatestCompleteRunBundle(runsRoot: string): { runDir: string; bundle
       const stats = statSync(bundlePath);
       const bundle = JSON.parse(readFileSync(bundlePath, "utf8")) as Record<string, unknown>;
       const bundleRunId = typeof bundle.runId === "string" ? bundle.runId : entry;
-      const completedAtMs =
+      const parsedCompletedAtMs =
         parseRunTimestampMs(bundle.finishedAt) ??
         parseRunTimestampMs(bundle.startedAt) ??
         parseRunTimestampMs(bundleRunId) ??
-        parseRunTimestampMs(entry) ??
-        stats.mtimeMs;
+        parseRunTimestampMs(entry);
+      const completedAtMs = parsedCompletedAtMs ?? stats.mtimeMs;
 
       return {
         runDir: entry,
         bundle,
         bundleRunId,
-        completedAtMs
+        completedAtMs,
+        hasExplicitTimestamp: typeof parsedCompletedAtMs === "number"
       };
     })
-    .filter((candidate): candidate is { runDir: string; bundle: Record<string, unknown>; bundleRunId: string; completedAtMs: number } =>
+    .filter((candidate): candidate is {
+      runDir: string;
+      bundle: Record<string, unknown>;
+      bundleRunId: string;
+      completedAtMs: number;
+      hasExplicitTimestamp: boolean;
+    } =>
       Boolean(candidate)
     )
     .sort((left, right) => {
+      if (left.hasExplicitTimestamp !== right.hasExplicitTimestamp) {
+        return left.hasExplicitTimestamp ? -1 : 1;
+      }
+
       if (left.completedAtMs !== right.completedAtMs) {
         return right.completedAtMs - left.completedAtMs;
       }
@@ -1168,6 +1213,247 @@ function loadAgentForgeConfig(root: string): AgentForgeConfig {
 
 function ensureDirectory(pathValue: string): void {
   mkdirSync(pathValue, { recursive: true });
+}
+
+function writeYamlFile(filePath: string, value: unknown): void {
+  writeFileSync(filePath, yaml.dump(value), "utf8");
+}
+
+function loadEvalFixtureCorpus(): EvalFixtureCorpus {
+  return evalFixtureCorpusSchema.parse(schemaFixtures.evalFixtureCorpus);
+}
+
+function getEvalSpec(specId: string): EvalSpec {
+  const corpus = loadEvalFixtureCorpus();
+  const spec = corpus.specs.find((candidate) => candidate.id === specId);
+  if (!spec) {
+    throw new Error(`Unknown eval spec: ${specId}`);
+  }
+
+  return spec;
+}
+
+function toBundleRef(run: WorkflowRunResult): string {
+  return `.agentops/runs/${run.runId}/bundle.json`;
+}
+
+function toSummaryRef(run: WorkflowRunResult): string {
+  return `.agentops/runs/${run.runId}/summary.md`;
+}
+
+function toSetupRun(workflow: string, run: WorkflowRunResult): EvalSetupRun {
+  return {
+    workflow,
+    runId: run.runId,
+    bundlePath: toBundleRef(run)
+  };
+}
+
+function createBlankEvalWorkspace(root: string, evalRunId: string, specId: string): string {
+  const workspaceRoot = join(root, ".agentops", "evals", specId, evalRunId, "workspace");
+  ensureDirectory(workspaceRoot);
+  const evidenceRoot = join(workspaceRoot, ".agentops", "evidence");
+  ensureDirectory(evidenceRoot);
+  execFileSync("git", ["init"], { cwd: workspaceRoot, stdio: "ignore" });
+  execFileSync("git", ["config", "user.email", "eval@example.com"], { cwd: workspaceRoot, stdio: "ignore" });
+  execFileSync("git", ["config", "user.name", "AgentForge Eval"], { cwd: workspaceRoot, stdio: "ignore" });
+  writeFileSync(
+    join(workspaceRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "fixture",
+        repository: {
+          type: "git",
+          url: "https://github.com/H9-Foundry/fixture.git"
+        },
+        scripts: {
+          test: "echo test",
+          lint: "echo lint",
+          typecheck: "echo typecheck",
+          build: "echo build"
+        }
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  writeFileSync(join(workspaceRoot, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n", "utf8");
+  writeFileSync(join(workspaceRoot, "src.ts"), "export const value = 1;\n", "utf8");
+  writeFileSync(
+    join(evidenceRoot, "dependency-alerts.json"),
+    JSON.stringify(
+      {
+        alerts: [
+          {
+            package: "example-dependency",
+            severity: "moderate",
+            summary: "Upgrade pending review for deterministic eval coverage."
+          }
+        ]
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  writeFileSync(
+    join(evidenceRoot, "docs-task.md"),
+    "# Docs follow-up\n\n- Align workflow documentation after maintenance triage.\n",
+    "utf8"
+  );
+  execFileSync("git", ["add", "."], { cwd: workspaceRoot, stdio: "ignore" });
+  execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "init"], { cwd: workspaceRoot, stdio: "ignore" });
+  writeFileSync(join(workspaceRoot, "src.ts"), "export const value = 2;\n", "utf8");
+  initProject(workspaceRoot);
+  return workspaceRoot;
+}
+
+function evalRedactionCategories(): string[] {
+  return ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"];
+}
+
+function createEvalBundle(
+  root: string,
+  spec: EvalSpec,
+  evaluatedRun: WorkflowRunResult | undefined,
+  workspacePath: string,
+  setupRuns: readonly EvalSetupRun[],
+  deterministicChecks: readonly EvalDeterministicCheck[],
+  modelDependentChecks: readonly EvalModelDependentCheck[]
+): { bundle: ReturnType<typeof auditBundleSchema.parse>; jsonPath: string; markdownPath: string; outputDir: string } {
+  const config = loadAgentForgeConfig(root);
+  const policy = resolvePolicy(loadPolicyDocument(join(root, ".agentops", "policy.yaml")), process.env.CI ? "ci" : "local");
+  const state = createWorkflowState({
+    cwd: root,
+    workflow: `eval:${spec.id}`,
+    mode: "inspect",
+    policy
+  });
+  const runsRoot = join(root, config.runtime.runsPath);
+  const outputDir = join(runsRoot, state.runId);
+  ensureDirectory(outputDir);
+  const jsonPath = join(outputDir, "bundle.json");
+  const markdownPath = join(outputDir, "summary.md");
+  const failureCount = deterministicChecks.filter((check) => check.status === "failed").length;
+  const passed = failureCount === 0;
+  const startedAt = new Date().toISOString();
+  const evalArtifact = evalArtifactSchema.parse({
+    schemaVersion: state.version,
+    artifactKind: "eval-result",
+    lifecycleDomain: "evaluate",
+    workflow: {
+      name: state.workflow,
+      displayName: "Eval Runner"
+    },
+    source: {
+      sourceType: "workflow-run",
+      runId: state.runId,
+      inputRefs: [
+        ...(evaluatedRun?.jsonPath ? [evaluatedRun.jsonPath] : []),
+        ...setupRuns.map((setup) => setup.bundlePath)
+      ],
+      issueRefs: ["#165"],
+      githubRefs: []
+    },
+    status: passed ? "complete" : "draft",
+    generatedAt: startedAt,
+    repo: {
+      root: state.repo.root,
+      name: state.repo.name,
+      branch: state.repo.branch
+    },
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" : "local",
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: evalRedactionCategories()
+    },
+    auditLink: {
+      bundlePath: jsonPath,
+      entryIds: [`${state.runId}-eval-runner`],
+      findingIds: [],
+      proposedActionIds: []
+    },
+    summary: passed
+      ? `Eval result for ${spec.id} passed ${deterministicChecks.length} deterministic check(s).`
+      : `Eval result for ${spec.id} failed ${failureCount} deterministic check(s).`,
+    payload: {
+      specId: spec.id,
+      specName: spec.name,
+      workflow: spec.workflow,
+      repoFixture: spec.repoFixture,
+      workspacePath,
+      evaluatedRunId: evaluatedRun?.runId,
+      evaluatedBundlePath: evaluatedRun ? toBundleRef(evaluatedRun) : undefined,
+      setupRuns,
+      deterministicChecks,
+      modelDependentChecks,
+      passed,
+      failureCount,
+      warningCount: 0
+    }
+  });
+
+  state.lifecycleArtifacts = [evalArtifact];
+  state.auditTrail = [
+    createAuditEntry({
+      id: `${state.runId}-eval-runner`,
+      nodeId: "eval-runner",
+      nodeName: "eval-runner",
+      kind: "deterministic",
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: passed ? "success" : "failed",
+      summary: evalArtifact.summary,
+      toolsRequested: [],
+      toolsExecuted: [],
+      blockedActions: [],
+      validationPassed: passed
+    }),
+    createAuditEntry({
+      id: `${state.runId}-report`,
+      nodeId: "report",
+      nodeName: "final-report",
+      kind: "report",
+      startedAt,
+      completedAt: new Date().toISOString(),
+      status: "success",
+      summary: "Generated eval result artifacts.",
+      toolsRequested: [],
+      toolsExecuted: [],
+      blockedActions: [],
+      validationPassed: true
+    })
+  ];
+
+  const bundle = buildAuditBundle(state, {
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    status: passed ? "success" : "partial",
+    jsonPath,
+    markdownPath,
+    provenance: {
+      generatedBy: "agentforge-runtime",
+      schemaVersion: state.version,
+      executionEnvironment: state.context.ciExecution ? "ci" : "local",
+      repoRoot: state.repo.root
+    },
+    redaction: {
+      applied: true,
+      strategyVersion: "1.0.0",
+      categories: evalRedactionCategories()
+    },
+    components: []
+  });
+  writeFileSync(jsonPath, JSON.stringify(bundle, null, 2), "utf8");
+  writeFileSync(markdownPath, renderAuditBundleMarkdown(bundle), "utf8");
+  return { bundle, jsonPath, markdownPath, outputDir };
 }
 
 function ensureInitFiles(root: string): string[] {
@@ -1420,6 +1706,351 @@ export async function runLocalWorkflow(workflowName: string, cwd = process.cwd()
     blockedActions,
     blockedPlugins: bundle.blockedPlugins.length,
     artifactCount: bundle.lifecycleArtifacts.length,
+    artifactKinds: bundle.lifecycleArtifacts.map((artifact) => artifact.artifactKind)
+  };
+}
+
+function checkResult(status: "passed" | "failed" | "not_applicable", name: string, expected: string, actual?: string, details?: string): EvalDeterministicCheck {
+  return {
+    name,
+    status,
+    expected,
+    actual,
+    ...(details ? { details } : {})
+  };
+}
+
+function compareEvalSpec(
+  spec: EvalSpec,
+  bundle: ReturnType<typeof auditBundleSchema.parse> | undefined,
+  executionError?: string
+): { deterministicChecks: EvalDeterministicCheck[]; modelDependentChecks: EvalModelDependentCheck[] } {
+  const checks: EvalDeterministicCheck[] = [];
+
+  if (!bundle) {
+    checks.push(
+      checkResult(
+        "failed",
+        "workflow-execution",
+        "successful workflow execution",
+        executionError ?? "unknown failure",
+        "The eval runner could not produce an evaluated workflow bundle."
+      )
+    );
+    return {
+      deterministicChecks: checks,
+      modelDependentChecks: [
+        {
+          name: "rubric-scoring",
+          status: "not_executed",
+          details: "Provider-dependent scoring is out of scope for the first local eval runner slice."
+        }
+      ]
+    };
+  }
+
+  checks.push(
+    checkResult(
+      bundle.status === spec.expectedStatus ? "passed" : "failed",
+      "run-status",
+      spec.expectedStatus,
+      bundle.status,
+      "The evaluated workflow status should match the deterministic eval spec."
+    )
+  );
+
+  checks.push(
+    checkResult(
+      bundle.redaction.applied === spec.redactionExpectations.applied ? "passed" : "failed",
+      "redaction-applied",
+      String(spec.redactionExpectations.applied),
+      String(bundle.redaction.applied)
+    )
+  );
+
+  for (const category of spec.redactionExpectations.expectedCategories) {
+    checks.push(
+      checkResult(
+        bundle.redaction.categories.includes(category) ? "passed" : "failed",
+        `redaction-category:${category}`,
+        category,
+        bundle.redaction.categories.join(", ")
+      )
+    );
+  }
+
+  checks.push(
+    checkResult(
+      bundle.policy.defaults.executionMode === spec.policyExpectations.executionMode ? "passed" : "failed",
+      "policy-execution-mode",
+      spec.policyExpectations.executionMode,
+      bundle.policy.defaults.executionMode
+    )
+  );
+
+  if (spec.policyExpectations.readOnly) {
+    checks.push(
+      checkResult(
+        bundle.policy.defaults.writes !== "allow" ? "passed" : "failed",
+        "policy-read-only",
+        "writes not equal allow",
+        bundle.policy.defaults.writes
+      )
+    );
+  }
+
+  for (const sideEffectClass of spec.policyExpectations.sideEffectClasses) {
+    checks.push(
+      checkResult(
+        "not_applicable",
+        `side-effect-class:${sideEffectClass}`,
+        sideEffectClass,
+        undefined,
+        "The first eval runner records policy posture and workflow outputs but does not inspect adapter-level side-effect execution traces."
+      )
+    );
+  }
+
+  for (const expectedArtifact of spec.artifactExpectations) {
+    const actualArtifact = bundle.lifecycleArtifacts.find((artifact) => artifact.artifactKind === expectedArtifact.artifactKind);
+    checks.push(
+      checkResult(
+        actualArtifact ? "passed" : "failed",
+        `artifact-kind:${expectedArtifact.artifactKind}`,
+        expectedArtifact.artifactKind,
+        actualArtifact?.artifactKind
+      )
+    );
+
+    if (!actualArtifact || typeof actualArtifact.payload !== "object" || actualArtifact.payload === null) {
+      continue;
+    }
+
+    const payload = actualArtifact.payload as Record<string, unknown>;
+    for (const field of expectedArtifact.requiredPayloadFields) {
+      checks.push(
+        checkResult(
+          field in payload ? "passed" : "failed",
+          `payload-field:${expectedArtifact.artifactKind}:${field}`,
+          field,
+          Object.keys(payload).join(", ")
+        )
+      );
+    }
+
+    for (const term of expectedArtifact.requiredSummaryTerms) {
+      const summary = actualArtifact.summary.toLowerCase();
+      checks.push(
+        checkResult(
+          summary.includes(term.toLowerCase()) ? "passed" : "failed",
+          `summary-term:${expectedArtifact.artifactKind}:${term}`,
+          term,
+          actualArtifact.summary
+        )
+      );
+    }
+  }
+
+  if (spec.artifactExpectations.length === 0) {
+    checks.push(
+      checkResult(
+        bundle.lifecycleArtifacts.length === 0 ? "passed" : "failed",
+        "artifact-count",
+        "0",
+        String(bundle.lifecycleArtifacts.length)
+      )
+    );
+  }
+
+  return {
+    deterministicChecks: checks,
+    modelDependentChecks: [
+      {
+        name: "rubric-scoring",
+        status: "not_executed",
+        details: "Provider-dependent scoring is out of scope for the first local eval runner slice."
+      }
+    ]
+  };
+}
+
+async function executeEvalWorkflow(spec: EvalSpec, workspaceRoot: string): Promise<{ evaluatedRun: WorkflowRunResult; setupRuns: EvalSetupRun[] }> {
+  const setupRuns: EvalSetupRun[] = [];
+  const requestsRoot = join(workspaceRoot, ".agentops", "requests");
+  ensureDirectory(requestsRoot);
+
+  const runPlanning = async (): Promise<WorkflowRunResult> => {
+    writeYamlFile(join(requestsRoot, "planning.yaml"), schemaFixtures.planningRequest);
+    return runLocalWorkflow("planning-discovery", workspaceRoot);
+  };
+
+  const runDesign = async (): Promise<WorkflowRunResult> => {
+    const planningRun = await runPlanning();
+    setupRuns.push(toSetupRun("planning-discovery", planningRun));
+    writeYamlFile(join(requestsRoot, "design.yaml"), {
+      ...schemaFixtures.designRequest,
+      planningBriefRef: toBundleRef(planningRun)
+    });
+    return runLocalWorkflow("architecture-design-review", workspaceRoot);
+  };
+
+  const runImplementation = async (): Promise<WorkflowRunResult> => {
+    const designRun = await runDesign();
+    setupRuns.push(toSetupRun("architecture-design-review", designRun));
+    writeYamlFile(join(requestsRoot, "implementation.yaml"), {
+      ...schemaFixtures.implementationRequest,
+      designRecordRef: toBundleRef(designRun)
+    });
+    return runLocalWorkflow("implementation-proposal", workspaceRoot);
+  };
+
+  const runQa = async (): Promise<WorkflowRunResult> => {
+    const implementationRun = await runImplementation();
+    setupRuns.push(toSetupRun("implementation-proposal", implementationRun));
+    writeYamlFile(join(requestsRoot, "qa.yaml"), {
+      ...schemaFixtures.qaRequest,
+      targetRef: toBundleRef(implementationRun),
+      evidenceSources: [toSummaryRef(implementationRun)]
+    });
+    return runLocalWorkflow("qa-review", workspaceRoot);
+  };
+
+  const runSecurity = async (): Promise<WorkflowRunResult> => {
+    const qaRun = await runQa();
+    setupRuns.push(toSetupRun("qa-review", qaRun));
+    writeYamlFile(join(requestsRoot, "security.yaml"), {
+      ...schemaFixtures.securityRequest,
+      targetRef: toBundleRef(qaRun),
+      evidenceSources: [toSummaryRef(qaRun)]
+    });
+    return runLocalWorkflow("security-review", workspaceRoot);
+  };
+
+  const runRelease = async (): Promise<WorkflowRunResult> => {
+    const securityRun = await runSecurity();
+    setupRuns.push(toSetupRun("security-review", securityRun));
+    const qaRun = setupRuns.find((run) => run.workflow === "qa-review");
+    if (!qaRun) {
+      throw new Error("QA setup run was not recorded before release eval execution.");
+    }
+    writeYamlFile(join(requestsRoot, "release.yaml"), {
+      ...schemaFixtures.releaseRequest,
+      qaReportRefs: [qaRun.bundlePath],
+      securityReportRefs: [toBundleRef(securityRun)],
+      evidenceSources: [toSummaryRef(securityRun)]
+    });
+    return runLocalWorkflow("release-readiness", workspaceRoot);
+  };
+
+  switch (spec.workflow) {
+    case "pr-review":
+      return { evaluatedRun: await runLocalWorkflow("pr-review", workspaceRoot), setupRuns };
+    case "planning-discovery":
+      writeYamlFile(join(requestsRoot, "planning.yaml"), spec.request);
+      return { evaluatedRun: await runLocalWorkflow("planning-discovery", workspaceRoot), setupRuns };
+    case "architecture-design-review": {
+      const planningRun = await runPlanning();
+      setupRuns.push(toSetupRun("planning-discovery", planningRun));
+      writeYamlFile(join(requestsRoot, "design.yaml"), {
+        ...spec.request,
+        planningBriefRef: toBundleRef(planningRun)
+      });
+      return { evaluatedRun: await runLocalWorkflow("architecture-design-review", workspaceRoot), setupRuns };
+    }
+    case "implementation-proposal": {
+      const designRun = await runDesign();
+      setupRuns.push(toSetupRun("architecture-design-review", designRun));
+      writeYamlFile(join(requestsRoot, "implementation.yaml"), {
+        ...spec.request,
+        designRecordRef: toBundleRef(designRun)
+      });
+      return { evaluatedRun: await runLocalWorkflow("implementation-proposal", workspaceRoot), setupRuns };
+    }
+    case "qa-review": {
+      const implementationRun = await runImplementation();
+      setupRuns.push(toSetupRun("implementation-proposal", implementationRun));
+      writeYamlFile(join(requestsRoot, "qa.yaml"), {
+        ...spec.request,
+        targetRef: toBundleRef(implementationRun),
+        evidenceSources: [toSummaryRef(implementationRun)]
+      });
+      return { evaluatedRun: await runLocalWorkflow("qa-review", workspaceRoot), setupRuns };
+    }
+    case "security-review": {
+      const qaRun = await runQa();
+      setupRuns.push(toSetupRun("qa-review", qaRun));
+      writeYamlFile(join(requestsRoot, "security.yaml"), {
+        ...spec.request,
+        targetRef: toBundleRef(qaRun),
+        evidenceSources: [toSummaryRef(qaRun)]
+      });
+      return { evaluatedRun: await runLocalWorkflow("security-review", workspaceRoot), setupRuns };
+    }
+    case "maintenance-triage": {
+      const releaseRun = await runRelease();
+      setupRuns.push(toSetupRun("release-readiness", releaseRun));
+      writeYamlFile(join(requestsRoot, "maintenance.yaml"), {
+        ...spec.request,
+        releaseReportRefs: [toBundleRef(releaseRun)]
+      });
+      return { evaluatedRun: await runLocalWorkflow("maintenance-triage", workspaceRoot), setupRuns };
+    }
+  }
+}
+
+export async function runLocalEval(specId: string, cwd = process.cwd()): Promise<EvalRunResult> {
+  const root = findWorkspaceRoot(cwd);
+  ensureInitFiles(root);
+  const spec = getEvalSpec(specId);
+  const controlPolicy = resolvePolicy(loadPolicyDocument(join(root, ".agentops", "policy.yaml")), process.env.CI ? "ci" : "local");
+  const controlState = createWorkflowState({
+    cwd: root,
+    workflow: `eval:${spec.id}`,
+    mode: controlPolicy.defaults.executionMode,
+    policy: controlPolicy
+  });
+
+  const workspaceRoot = spec.repoFixture === "agentforge-monorepo" ? root : createBlankEvalWorkspace(root, controlState.runId, spec.id);
+  let evaluatedRun: WorkflowRunResult | undefined;
+  let setupRuns: EvalSetupRun[] = [];
+  let executionError: string | undefined;
+
+  try {
+    const result = await executeEvalWorkflow(spec, workspaceRoot);
+    evaluatedRun = result.evaluatedRun;
+    setupRuns = result.setupRuns;
+  } catch (error) {
+    executionError = error instanceof Error ? error.message : String(error);
+  }
+
+  const evaluatedBundle =
+    evaluatedRun && existsSync(evaluatedRun.jsonPath)
+      ? auditBundleSchema.parse(JSON.parse(readFileSync(evaluatedRun.jsonPath, "utf8")) as unknown)
+      : undefined;
+  const { deterministicChecks, modelDependentChecks } = compareEvalSpec(spec, evaluatedBundle, executionError);
+  const { bundle, jsonPath, markdownPath, outputDir } = createEvalBundle(
+    root,
+    spec,
+    evaluatedRun,
+    workspaceRoot,
+    setupRuns,
+    deterministicChecks,
+    modelDependentChecks
+  );
+
+  return {
+    runId: bundle.runId,
+    specId: spec.id,
+    workflow: spec.workflow,
+    outputDir,
+    jsonPath,
+    markdownPath,
+    status: bundle.status,
+    evaluatedRunId: evaluatedRun?.runId,
+    evaluatedBundlePath: evaluatedRun ? toBundleRef(evaluatedRun) : undefined,
+    setupRunCount: setupRuns.length,
+    deterministicCheckCount: deterministicChecks.length,
+    deterministicFailures: deterministicChecks.filter((check) => check.status === "failed").length,
     artifactKinds: bundle.lifecycleArtifacts.map((artifact) => artifact.artifactKind)
   };
 }

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   auditBundleSchema,
   designArtifactSchema,
   designRequestSchema,
+  evalArtifactSchema,
   evalFixtureCorpusSchema,
   evalSpecSchema,
   githubActionsEvidenceNormalizationSchema,
@@ -63,6 +64,7 @@ describe("schema fixtures", () => {
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
     expect(() => incidentArtifactSchema.parse(schemaFixtures.incidentArtifact)).not.toThrow();
+    expect(() => evalArtifactSchema.parse(schemaFixtures.evalArtifact)).not.toThrow();
     expect(() => qaEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization)).not.toThrow();
     expect(() => securityEvidenceNormalizationSchema.parse(schemaFixtures.securityEvidenceNormalization)).not.toThrow();
     expect(() => releaseEvidenceNormalizationSchema.parse(schemaFixtures.releaseEvidenceNormalization)).not.toThrow();
@@ -110,6 +112,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.incidentArtifact).toBeDefined();
     expect(jsonSchemas.qaArtifact).toBeDefined();
     expect(jsonSchemas.securityArtifact).toBeDefined();
+    expect(jsonSchemas.evalArtifact).toBeDefined();
     expect(jsonSchemas.reviewArtifact).toBeDefined();
     expect(jsonSchemas.releaseArtifact).toBeDefined();
     expect(jsonSchemas.maintenanceArtifact).toBeDefined();
@@ -198,6 +201,7 @@ describe("schema fixtures", () => {
     expect(() => implementationArtifactSchema.parse(schemaFixtures.implementationArtifact)).not.toThrow();
     expect(() => qaArtifactSchema.parse(schemaFixtures.qaArtifact)).not.toThrow();
     expect(() => securityArtifactSchema.parse(schemaFixtures.securityArtifact)).not.toThrow();
+    expect(() => evalArtifactSchema.parse(schemaFixtures.evalArtifact)).not.toThrow();
     expect(() => reviewArtifactSchema.parse(schemaFixtures.reviewArtifact)).not.toThrow();
     expect(() => releaseArtifactSchema.parse(schemaFixtures.releaseArtifact)).not.toThrow();
     expect(() => maintenanceArtifactSchema.parse(schemaFixtures.maintenanceArtifact)).not.toThrow();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -20,11 +20,12 @@ export const lifecycleArtifactKindSchema = z.enum([
   "incident-brief",
   "qa-report",
   "security-report",
+  "eval-result",
   "review-report",
   "release-report",
   "maintenance-report"
 ]);
-export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "test", "security", "review", "release", "operate", "maintain"]);
+export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "test", "security", "evaluate", "review", "release", "operate", "maintain"]);
 export const lifecycleArtifactSourceTypeSchema = z.enum(["workflow-run", "manual-input", "imported"]);
 export const lifecycleArtifactStatusSchema = z.enum(["draft", "complete", "superseded", "cancelled"]);
 export const githubReferenceKindSchema = z.enum(["issue", "pull_request"]);
@@ -903,6 +904,44 @@ export const maintenanceArtifactPayloadSchema = z.object({
   followUpIssues: z.array(z.string().min(1)).default([])
 });
 
+export const evalCheckStatusSchema = z.enum(["passed", "failed", "not_applicable"]);
+
+export const evalDeterministicCheckSchema = z.object({
+  name: z.string().min(1),
+  status: evalCheckStatusSchema,
+  expected: z.string().min(1),
+  actual: z.string().min(1).optional(),
+  details: z.string().min(1).optional()
+});
+
+export const evalModelDependentCheckSchema = z.object({
+  name: z.string().min(1),
+  status: z.enum(["not_executed", "passed", "failed"]).default("not_executed"),
+  details: z.string().min(1).optional()
+});
+
+export const evalSetupRunSchema = z.object({
+  workflow: z.string().min(1),
+  runId: z.string().min(1),
+  bundlePath: z.string().min(1)
+});
+
+export const evalArtifactPayloadSchema = z.object({
+  specId: z.string().min(1),
+  specName: z.string().min(1),
+  workflow: evalWorkflowSchema,
+  repoFixture: evalRepoFixtureSchema,
+  workspacePath: z.string().min(1),
+  evaluatedRunId: z.string().min(1).optional(),
+  evaluatedBundlePath: z.string().min(1).optional(),
+  setupRuns: z.array(evalSetupRunSchema).default([]),
+  deterministicChecks: z.array(evalDeterministicCheckSchema).default([]),
+  modelDependentChecks: z.array(evalModelDependentCheckSchema).default([]),
+  passed: z.boolean(),
+  failureCount: z.number().int().nonnegative(),
+  warningCount: z.number().int().nonnegative().default(0)
+});
+
 export const planningArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   artifactKind: z.literal("planning-brief"),
   lifecycleDomain: z.literal("plan"),
@@ -939,6 +978,12 @@ export const securityArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   payload: securityArtifactPayloadSchema
 });
 
+export const evalArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("eval-result"),
+  lifecycleDomain: z.literal("evaluate"),
+  payload: evalArtifactPayloadSchema
+});
+
 export const reviewArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   artifactKind: z.literal("review-report"),
   lifecycleDomain: z.literal("review"),
@@ -964,6 +1009,7 @@ export const lifecycleArtifactSchema = z.discriminatedUnion("artifactKind", [
   incidentArtifactSchema,
   qaArtifactSchema,
   securityArtifactSchema,
+  evalArtifactSchema,
   reviewArtifactSchema,
   releaseArtifactSchema,
   maintenanceArtifactSchema
@@ -1023,6 +1069,10 @@ export const schemaRegistry = {
   incidentArtifactPayload: incidentArtifactPayloadSchema,
   qaArtifactPayload: qaArtifactPayloadSchema,
   securityArtifactPayload: securityArtifactPayloadSchema,
+  evalDeterministicCheck: evalDeterministicCheckSchema,
+  evalModelDependentCheck: evalModelDependentCheckSchema,
+  evalSetupRun: evalSetupRunSchema,
+  evalArtifactPayload: evalArtifactPayloadSchema,
   reviewArtifactPayload: reviewArtifactPayloadSchema,
   releaseVerificationCheck: releaseVerificationCheckSchema,
   releaseVersionTarget: releaseVersionTargetSchema,
@@ -1037,6 +1087,7 @@ export const schemaRegistry = {
   incidentArtifact: incidentArtifactSchema,
   qaArtifact: qaArtifactSchema,
   securityArtifact: securityArtifactSchema,
+  evalArtifact: evalArtifactSchema,
   reviewArtifact: reviewArtifactSchema,
   releaseArtifact: releaseArtifactSchema,
   maintenanceArtifact: maintenanceArtifactSchema,
@@ -1358,6 +1409,49 @@ const maintenanceArtifactFixture = {
   }
 } as const;
 
+const evalArtifactFixture = {
+  ...lifecycleArtifactFixtureBase,
+  artifactKind: "eval-result",
+  lifecycleDomain: "evaluate",
+  summary: "Eval result confirmed deterministic expectations for planning-discovery-local-brief.",
+  payload: {
+    specId: "planning-discovery-local-brief",
+    specName: "Planning discovery emits planning brief",
+    workflow: "planning-discovery",
+    repoFixture: "blank-local",
+    workspacePath: ".agentops/evals/planning-discovery-local-brief/workspace",
+    evaluatedRunId: "run-456",
+    evaluatedBundlePath: ".agentops/evals/planning-discovery-local-brief/workspace/.agentops/runs/run-456/bundle.json",
+    setupRuns: [],
+    deterministicChecks: [
+      {
+        name: "run-status",
+        status: "passed",
+        expected: "success",
+        actual: "success",
+        details: "The evaluated workflow completed successfully."
+      },
+      {
+        name: "artifact-kind:planning-brief",
+        status: "passed",
+        expected: "planning-brief",
+        actual: "planning-brief",
+        details: "The evaluated bundle emitted the expected lifecycle artifact."
+      }
+    ],
+    modelDependentChecks: [
+      {
+        name: "rubric-scoring",
+        status: "not_executed",
+        details: "Provider-dependent scoring is out of scope for the first local eval runner slice."
+      }
+    ],
+    passed: true,
+    failureCount: 0,
+    warningCount: 0
+  }
+} as const;
+
 const invalidLifecycleArtifactEnvelopeFixture = {
   ...planningArtifactFixture,
   artifactKind: "incident-report",
@@ -1659,7 +1753,7 @@ const evalFixtureCorpusFixture = {
       },
       redactionExpectations: {
         applied: true,
-        expectedCategories: ["secrets"]
+        expectedCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
       },
       artifactExpectations: []
     },
@@ -1688,7 +1782,7 @@ const evalFixtureCorpusFixture = {
       },
       redactionExpectations: {
         applied: true,
-        expectedCategories: ["secrets"]
+        expectedCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
       },
       artifactExpectations: [
         {
@@ -1724,7 +1818,7 @@ const evalFixtureCorpusFixture = {
       },
       redactionExpectations: {
         applied: true,
-        expectedCategories: ["secrets"]
+        expectedCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
       },
       artifactExpectations: [
         {
@@ -1753,7 +1847,7 @@ const evalFixtureCorpusFixture = {
       },
       redactionExpectations: {
         applied: true,
-        expectedCategories: ["secrets"]
+        expectedCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
       },
       artifactExpectations: [
         {
@@ -1782,7 +1876,7 @@ const evalFixtureCorpusFixture = {
       },
       redactionExpectations: {
         applied: true,
-        expectedCategories: ["secrets"]
+        expectedCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
       },
       artifactExpectations: [
         {
@@ -1811,7 +1905,7 @@ const evalFixtureCorpusFixture = {
       },
       redactionExpectations: {
         applied: true,
-        expectedCategories: ["secrets"]
+        expectedCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
       },
       artifactExpectations: [
         {
@@ -1840,7 +1934,7 @@ const evalFixtureCorpusFixture = {
       },
       redactionExpectations: {
         applied: true,
-        expectedCategories: ["secrets"]
+        expectedCategories: ["github-token", "api-key", "aws-key", "bearer-token", "password", "private-key"]
       },
       artifactExpectations: [
         {
@@ -2027,6 +2121,7 @@ export const schemaFixtures = {
   incidentArtifact: incidentArtifactFixture,
   qaArtifact: qaArtifactFixture,
   securityArtifact: securityArtifactFixture,
+  evalArtifact: evalArtifactFixture,
   reviewArtifact: reviewArtifactFixture,
   releaseArtifact: releaseArtifactFixture,
   maintenanceArtifact: maintenanceArtifactFixture,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -4,10 +4,15 @@ import type {
   DesignArtifact,
   DesignArtifactOption,
   DesignRequest,
+  EvalArtifact,
+  EvalArtifactPayload,
   EvalArtifactExpectation,
+  EvalDeterministicCheck,
   EvalFixtureCorpus,
+  EvalModelDependentCheck,
   EvalPolicyExpectation,
   EvalRedactionExpectation,
+  EvalSetupRun,
   EvalSpec,
   ImplementationArtifact,
   ImplementationInventory,
@@ -50,6 +55,8 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<QaArtifact["lifecycleDomain"]>().toEqualTypeOf<"test">();
     expectTypeOf<SecurityArtifact["artifactKind"]>().toEqualTypeOf<"security-report">();
     expectTypeOf<SecurityArtifact["lifecycleDomain"]>().toEqualTypeOf<"security">();
+    expectTypeOf<EvalArtifact["artifactKind"]>().toEqualTypeOf<"eval-result">();
+    expectTypeOf<EvalArtifact["lifecycleDomain"]>().toEqualTypeOf<"evaluate">();
     expectTypeOf<ReviewArtifact["artifactKind"]>().toEqualTypeOf<"review-report">();
     expectTypeOf<ReviewArtifact["lifecycleDomain"]>().toEqualTypeOf<"review">();
     expectTypeOf<ReleaseArtifact["artifactKind"]>().toEqualTypeOf<"release-report">();
@@ -75,6 +82,9 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<EvalArtifactExpectation["requiredPayloadFields"]>().toEqualTypeOf<string[]>();
     expectTypeOf<EvalPolicyExpectation["readOnly"]>().toEqualTypeOf<boolean>();
     expectTypeOf<EvalRedactionExpectation["expectedCategories"]>().toEqualTypeOf<string[]>();
+    expectTypeOf<EvalArtifactPayload["deterministicChecks"]>().toEqualTypeOf<EvalDeterministicCheck[]>();
+    expectTypeOf<EvalArtifactPayload["modelDependentChecks"]>().toEqualTypeOf<EvalModelDependentCheck[]>();
+    expectTypeOf<EvalArtifactPayload["setupRuns"]>().toEqualTypeOf<EvalSetupRun[]>();
     expectTypeOf<ImplementationRequest["designRecordRef"]>().toEqualTypeOf<string>();
     expectTypeOf<ImplementationRequest["approvalMode"]>().toEqualTypeOf<"proposal-only" | "apply-capable">();
     expectTypeOf<IncidentRequest["incidentSummary"]>().toEqualTypeOf<string>();

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -23,10 +23,15 @@ import {
   designArtifactPayloadSchema,
   designArtifactSchema,
   designRequestSchema,
+  evalArtifactPayloadSchema,
+  evalArtifactSchema,
+  evalDeterministicCheckSchema,
   evalArtifactExpectationSchema,
   evalFixtureCorpusSchema,
+  evalModelDependentCheckSchema,
   evalPolicyExpectationSchema,
   evalRedactionExpectationSchema,
+  evalSetupRunSchema,
   evalSpecSchema,
   effectivePolicySnapshotSchema,
   findingSchema,
@@ -114,6 +119,11 @@ export type DesignArtifactOption = Infer<typeof designArtifactOptionSchema>;
 export type DesignArtifactPayload = Infer<typeof designArtifactPayloadSchema>;
 export type DesignArtifact = Infer<typeof designArtifactSchema>;
 export type DesignRequest = Infer<typeof designRequestSchema>;
+export type EvalDeterministicCheck = Infer<typeof evalDeterministicCheckSchema>;
+export type EvalModelDependentCheck = Infer<typeof evalModelDependentCheckSchema>;
+export type EvalSetupRun = Infer<typeof evalSetupRunSchema>;
+export type EvalArtifactPayload = Infer<typeof evalArtifactPayloadSchema>;
+export type EvalArtifact = Infer<typeof evalArtifactSchema>;
 export type EvalArtifactExpectation = Infer<typeof evalArtifactExpectationSchema>;
 export type EvalPolicyExpectation = Infer<typeof evalPolicyExpectationSchema>;
 export type EvalRedactionExpectation = Infer<typeof evalRedactionExpectationSchema>;


### PR DESCRIPTION
## Summary
- add a bounded local `agentforge eval run <spec-id>` CLI surface
- emit `eval-result` artifacts from deterministic local eval specs
- document the eval framework as `eval-spec` plus local runner, with benchmark comparison still pending

Closes #165.

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`
- `node packages/cli/dist/bin.js eval run planning-discovery-local-brief --json`
- direct smoke validation for chained `maintenance-triage-local-report`

## Notes
- keeps the first eval runner local-first and deterministic only
- does not add benchmark comparison, hosted orchestration, or provider scoring
