### PR TITLE
docs: make external adoption target explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 - inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, `implementation-proposal`, `qa-report`, `security-report`, and `maintenance-report`
 - evaluate the secure-by-default runtime model before broader SDLC workflow support lands
 
+## Adoption Target
+
+AgentForge is ready now for technical early adopters who want local-first, read-only workflow tooling before PR creation. Plug-and-play external adoption for less technical users is an active product target, not a completed claim: the goal is to make the published CLI installable, understandable, and usable in other repositories without monorepo knowledge or hand-authoring request YAML for common paths.
+
 ## Try It In 2 Minutes
 
 The fastest evaluator path is the published CLI, not a source build.
@@ -126,6 +130,7 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 - plugin ecosystem and registry-facing surfaces
 - evals, benchmarks, and compatibility guarantees
 - enterprise governance, tenancy, and scale-oriented controls
+- plug-and-play external adoption and less-technical user readiness
 
 ## SDLC Lifecycle Coverage
 

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -2,7 +2,7 @@
 
 This document defines how maintainers should work through the AgentForge backlog.
 
-It is a **maintainer operating flow**, not a shipped product workflow. The only official runtime workflow remains `.agentops/workflows/pr-review.yaml`, plus the existing release/readiness tooling.
+It is a **maintainer operating flow**, not a shipped product workflow. Official runtime workflow support is tracked in [docs/SUPPORT_MATRIX.md](SUPPORT_MATRIX.md); this document exists to sequence backlog work and maintain truthful queue state.
 
 The live execution tracker for this process is [#83](https://github.com/H9-Foundry/AgentForge/issues/83).
 
@@ -28,6 +28,13 @@ See [docs/SELF_HOSTING.md](SELF_HOSTING.md).
 
 The backlog is managed in four lanes plus one parallel safe lane for newcomer usability work.
 
+Cross-cutting productization target:
+
+- plug-and-play external adoption and less-technical user readiness
+  - this is a tracked umbrella epic that cuts across onboarding, workflow packaging, evals, registry work, published CLI parity, and external local-only adoption readiness
+  - it should influence sequencing and acceptance for user-facing slices
+  - it is not complete and must not be treated as shipped product status
+
 ### Active Lane
 
 Work that is currently being executed now.
@@ -40,7 +47,7 @@ Rules:
 
 Current active lane:
 
-1. [#62](https://github.com/H9-Foundry/AgentForge/issues/62) plugin and registry roadmap
+1. [#63](https://github.com/H9-Foundry/AgentForge/issues/63) evals and benchmarks framework
 
 ### Ready Lane
 
@@ -48,12 +55,10 @@ Work that is explicitly designed or queued next, but should not start until the 
 
 Current ready lane:
 
-2. [#63](https://github.com/H9-Foundry/AgentForge/issues/63) evals and benchmarks framework
+2. [#62](https://github.com/H9-Foundry/AgentForge/issues/62) plugin and registry roadmap
 3. [#64](https://github.com/H9-Foundry/AgentForge/issues/64) additional SCM and CI integrations roadmap
 4. [#65](https://github.com/H9-Foundry/AgentForge/issues/65) supply-chain and release trust hardening
-5. planning/discovery implementation follow-ons under [#127](https://github.com/H9-Foundry/AgentForge/issues/127), [#128](https://github.com/H9-Foundry/AgentForge/issues/128), [#129](https://github.com/H9-Foundry/AgentForge/issues/129), and [#130](https://github.com/H9-Foundry/AgentForge/issues/130)
-6. architecture/design implementation follow-ons under [#132](https://github.com/H9-Foundry/AgentForge/issues/132), [#133](https://github.com/H9-Foundry/AgentForge/issues/133), [#134](https://github.com/H9-Foundry/AgentForge/issues/134), [#136](https://github.com/H9-Foundry/AgentForge/issues/136), and [#135](https://github.com/H9-Foundry/AgentForge/issues/135)
-7. Phase 2 workflow implementation follow-ons under [#139](https://github.com/H9-Foundry/AgentForge/issues/139) through [#159](https://github.com/H9-Foundry/AgentForge/issues/159)
+5. the plug-and-play external adoption and less-technical user readiness umbrella plus its child issues for preset startup, external agent packaging, quick-path onboarding, local-only readiness criteria, and published CLI parity
 
 ### Parallel Safe Lane
 
@@ -85,7 +90,9 @@ Work that is part of the roadmap and ordered relative to dependencies, but not y
 
 Current mapped lane:
 
-- no additional mapped items beyond the current active and ready lanes yet
+- Phase 2 workflow implementation follow-ons under [#139](https://github.com/H9-Foundry/AgentForge/issues/139) through [#159](https://github.com/H9-Foundry/AgentForge/issues/159) (substantially implemented)
+- eval runner / benchmark completion under [#165](https://github.com/H9-Foundry/AgentForge/issues/165) and [#166](https://github.com/H9-Foundry/AgentForge/issues/166)
+- the external adoption/readiness umbrella tracks cross-cutting productization work that depends on these slices but is not satisfied by workflow breadth alone
 
 ### Deferred Lane
 

--- a/docs/SDLC_COVERAGE.md
+++ b/docs/SDLC_COVERAGE.md
@@ -6,6 +6,8 @@ This document describes lifecycle coverage across AgentForge using three honest 
 - **In progress**: explicitly targeted in the near-term backlog
 - **Planned**: not implemented yet, but intentionally on the roadmap
 
+Workflow coverage is not the same thing as plug-and-play external usability. A lifecycle domain can be implemented and still require technical early-adopter setup; less-technical external adoption is tracked separately as a productization/readiness target.
+
 ## Coverage Map
 
 | Lifecycle Domain | Status | Current Reality | Next Target |

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -81,6 +81,14 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | general CI runtime support | Partial | Some workflow behavior exists in CI, but general CI workflow support is not complete. |
 | hosted multi-tenant service | Planned | Not implemented. |
 
+## Adoption Readiness
+
+| Adoption Surface | Maturity | Notes |
+| --- | --- | --- |
+| technical local-first adoption | Partial | Strongest current external fit: technical evaluators can install the CLI, run official local workflows, and inspect audit artifacts without GitHub wiring. |
+| less-technical plug-and-play adoption | Planned | This is now an explicit product target, but it is not complete yet; common workflow startup still expects too much familiarity with request files and repo structure. |
+| agent-stack integration readiness | Planned | Internal starter agents exist, but external packaging, preset distribution, and low-friction agent consumption are not yet supported as a public surface. |
+
 ## Self-Hosting Scope
 
 | Self-hosted use | Maturity | Notes |


### PR DESCRIPTION
## Summary

Make plug-and-play external adoption and less-technical user readiness an explicit product target instead of an implicit byproduct of workflow breadth.

Closes #219.

## What Changed

- added an explicit adoption-target statement to `README.md`
- added an `Adoption Readiness` section to `docs/SUPPORT_MATRIX.md`
- clarified in `docs/SDLC_COVERAGE.md` that workflow coverage is not the same thing as plug-and-play external usability
- updated `docs/QUEUE_EXECUTION_FLOW.md` so the queue framing acknowledges the new cross-cutting productization target
- opened linked child issues:
  - #220 preset-based workflow startup for external repos
  - #221 external agent packaging and starter preset distribution
  - #222 non-technical adopter quick path
  - #223 readiness criteria for external local-only adoption
  - #224 published CLI parity with documented official workflows

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

## Not Fully Verified

- `pnpm test` still showed the same long-lived desktop wrapper ambiguity seen in earlier slices: Vitest started cleanly but did not emit a final exit in this wrapper session before stalling. I did not treat that as a repo failure for this doc-only slice.