### PR TITLE
Version public AgentForge packages for 0.8.0

### DIFF
--- a/.changeset/benchmark-summary-reporting.md
+++ b/.changeset/benchmark-summary-reporting.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add local benchmark comparison via `agentforge eval compare ...` and emit `benchmark-summary` artifacts for deterministic eval-result deltas.

--- a/.changeset/eval-spec-fixture-corpus.md
+++ b/.changeset/eval-spec-fixture-corpus.md
@@ -1,6 +1,0 @@
----
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Add provider-agnostic `eval-spec` contracts and a deterministic local fixture corpus for the current official workflow surface.

--- a/.changeset/local-eval-runner.md
+++ b/.changeset/local-eval-runner.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add a bounded local eval runner with `agentforge eval run <spec-id>` and emit `eval-result` artifacts for deterministic workflow fixture checks.

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @h9-foundry/agentforge-audit
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies [9ce38fa]
+- Updated dependencies [005e3ba]
+- Updated dependencies [ebf3f39]
+  - @h9-foundry/agentforge-shared-types@0.8.0
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-audit",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,25 @@
 # @h9-foundry/agentforge-cli
 
+## 0.8.0
+
+### Minor Changes
+
+- 9ce38fa: Add local benchmark comparison via `agentforge eval compare ...` and emit `benchmark-summary` artifacts for deterministic eval-result deltas.
+- ebf3f39: Add a bounded local eval runner with `agentforge eval run <spec-id>` and emit `eval-result` artifacts for deterministic workflow fixture checks.
+
+### Patch Changes
+
+- Updated dependencies [9ce38fa]
+- Updated dependencies [005e3ba]
+- Updated dependencies [ebf3f39]
+  - @h9-foundry/agentforge-schemas@0.8.0
+  - @h9-foundry/agentforge-shared-types@0.8.0
+  - @h9-foundry/agentforge-context-engine@0.8.0
+  - @h9-foundry/agentforge-policy-engine@0.8.0
+  - @h9-foundry/agentforge-runtime@0.8.0
+  - @h9-foundry/agentforge-audit@0.8.0
+  - @h9-foundry/agentforge-sdk@0.8.0
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/context-engine/CHANGELOG.md
+++ b/packages/context-engine/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @h9-foundry/agentforge-context-engine
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies [9ce38fa]
+- Updated dependencies [005e3ba]
+- Updated dependencies [ebf3f39]
+  - @h9-foundry/agentforge-schemas@0.8.0
+  - @h9-foundry/agentforge-shared-types@0.8.0
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Repository and execution context collection for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/policy-engine/CHANGELOG.md
+++ b/packages/policy-engine/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @h9-foundry/agentforge-policy-engine
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies [9ce38fa]
+- Updated dependencies [005e3ba]
+- Updated dependencies [ebf3f39]
+  - @h9-foundry/agentforge-schemas@0.8.0
+  - @h9-foundry/agentforge-shared-types@0.8.0
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @h9-foundry/agentforge-runtime
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies [9ce38fa]
+- Updated dependencies [005e3ba]
+- Updated dependencies [ebf3f39]
+  - @h9-foundry/agentforge-schemas@0.8.0
+  - @h9-foundry/agentforge-shared-types@0.8.0
+  - @h9-foundry/agentforge-policy-engine@0.8.0
+  - @h9-foundry/agentforge-audit@0.8.0
+  - @h9-foundry/agentforge-sdk@0.8.0
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @h9-foundry/agentforge-schemas
 
+## 0.8.0
+
+### Minor Changes
+
+- 9ce38fa: Add local benchmark comparison via `agentforge eval compare ...` and emit `benchmark-summary` artifacts for deterministic eval-result deltas.
+- ebf3f39: Add a bounded local eval runner with `agentforge eval run <spec-id>` and emit `eval-result` artifacts for deterministic workflow fixture checks.
+
+### Patch Changes
+
+- 005e3ba: Add provider-agnostic `eval-spec` contracts and a deterministic local fixture corpus for the current official workflow surface.
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @h9-foundry/agentforge-sdk
 
+## 0.8.0
+
+### Patch Changes
+
+- Updated dependencies [9ce38fa]
+- Updated dependencies [005e3ba]
+- Updated dependencies [ebf3f39]
+  - @h9-foundry/agentforge-shared-types@0.8.0
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @h9-foundry/agentforge-shared-types
 
+## 0.8.0
+
+### Minor Changes
+
+- 9ce38fa: Add local benchmark comparison via `agentforge eval compare ...` and emit `benchmark-summary` artifacts for deterministic eval-result deltas.
+- ebf3f39: Add a bounded local eval runner with `agentforge eval run <spec-id>` and emit `eval-result` artifacts for deterministic workflow fixture checks.
+
+### Patch Changes
+
+- 005e3ba: Add provider-agnostic `eval-spec` contracts and a deterministic local fixture corpus for the current official workflow surface.
+- Updated dependencies [9ce38fa]
+- Updated dependencies [005e3ba]
+- Updated dependencies [ebf3f39]
+  - @h9-foundry/agentforge-schemas@0.8.0
+
 ## 0.7.1
 
 ### Patch Changes

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
   "license": "MIT",
   "author": "H9 Foundry",


### PR DESCRIPTION
## Summary

Human-owned replacement for the stale Changesets bot release PR.

This `0.8.0` release includes:
- `eval-spec` fixture corpus
- `agentforge eval run`
- `agentforge eval compare`

Closes the release gap after #217 and #218.

## Validation

- generated with `pnpm release:version`

## Notes

- replacing stale bot PR #216 so the release can merge from current `main`
- publish verification will be run after merge