### PR TITLE
docs: define published CLI parity rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,20 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 ## What You Can Do Today
 
 - try the current official workflow wedge with the published CLI, without cloning this monorepo
-- initialize a repository, scan it, run `pr-review`, `planning-discovery`, and `architecture-design-review`, then use the current repo build for `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage` until the next package release ships them
+- initialize a repository, scan it, and run `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage` with the latest published CLI
 - inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, `implementation-proposal`, `qa-report`, `security-report`, and `maintenance-report`
+- run `agentforge eval run` and `agentforge eval compare` locally against the deterministic workflow fixture corpus in the latest published CLI
 - evaluate the secure-by-default runtime model before broader SDLC workflow support lands
 
 ## Adoption Target
 
 AgentForge is ready now for technical early adopters who want local-first, read-only workflow tooling before PR creation. Plug-and-play external adoption for less technical users is an active product target, not a completed claim: the goal is to make the published CLI installable, understandable, and usable in other repositories without monorepo knowledge or hand-authoring request YAML for common paths.
+
+Published CLI wording rule:
+
+- `available in the published CLI` means the capability is present in the latest npm release
+- `source-build only` means the capability exists on `main` but has not reached the latest npm release yet
+- product-facing docs must use those terms consistently whenever repo `main` is ahead of npm
 
 ## Try It In 2 Minutes
 

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -166,6 +166,7 @@ Add:
 
 - `agentforge release check --json`
 - `agentforge release verify --json`
+- do not claim `available in the published CLI` in README, quickstart, or support docs until the latest npm release contains the capability and published verification has been re-run
 - if `pnpm test` is being run from a long-lived wrapper session, confirm the direct-shell exit code with `pnpm test; echo EXIT:$?` before treating a stalled session as a repo failure
 - [#120](https://github.com/H9-Foundry/AgentForge/issues/120) tracks the earlier validation ambiguity and its local-guidance resolution
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -11,6 +11,12 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 - **Planned**: not implemented yet
 - **Internal**: present in the repository but not yet supported as public surface
 
+## Published CLI Availability Terms
+
+- **Published now**: available in the latest npm release of `@h9-foundry/agentforge-cli`
+- **Source-build only**: implemented on `main`, but not yet in the latest npm release
+- Product-facing docs must say `available in the published CLI` only after published parity is verified
+
 ## Workflow Support
 
 | Workflow | Maturity | Notes |
@@ -102,6 +108,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 
 ## Compatibility Notes
 
+- Workflow maturity and published CLI availability are related but not identical. A workflow can be official on `main` and still need an explicit `source-build only` note until the latest npm release includes it.
 - Current support is strongest for local repository execution and GitHub-centric release workflows.
 - Public compatibility commitments are intentionally narrow until broader workflow and integration support exists.
 - Planned support in this matrix should be treated as roadmap direction, not shipped capability.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -2,9 +2,15 @@
 
 This quickstart walks through the current official AgentForge wedges: secure local repository review plus the planning-to-design-to-implementation-to-QA-to-security-to-maintenance lifecycle handoff, all with auditable outputs.
 
+Published CLI wording rule:
+
+- `available in the published CLI` means available in the latest npm release
+- `source-build only` means the capability exists on `main` but has not reached npm yet
+- this document should use those terms explicitly whenever repo `main` is ahead of the latest published package set
+
 ## Fastest Evaluator Path
 
-Use the published CLI if you want to try the current published wedges without cloning the monorepo.
+Use the published CLI if you want to try the current published wedges without cloning the monorepo. The latest published CLI now includes the full official local workflow surface plus `eval run` and `eval compare`.
 
 ```bash
 mkdir agentforge-demo
@@ -178,13 +184,13 @@ The security bundle should include one `security-report` lifecycle artifact with
 
 `maintenance-triage` is now available in the published CLI as part of the official local workflow surface.
 
-Create a maintenance request that points at the prior security or release bundle:
+Create a maintenance request that points at bounded maintenance follow-up context. The published maintenance request accepts `dependencyAlertRefs`, `docsTaskRefs`, `releaseReportRefs`, or `issueRefs`; it does not accept a security bundle in `releaseReportRefs`.
 
 ```bash
 cat > .agentops/requests/maintenance.yaml <<'EOF'
 maintenanceGoal: Review dependency and docs hygiene after the latest workflow chain
-releaseReportRefs:
-  - .agentops/runs/<security-or-release-run-id>/bundle.json
+issueRefs:
+  - '#224'
 constraints:
   - Keep the workflow read-only
 EOF
@@ -243,11 +249,11 @@ node packages/cli/dist/bin.js explain last-run
 
 ## Dogfood The Official Workflows With Local Evals
 
-Use the source-built CLI to execute the deterministic eval corpus against the official workflow surface:
+Use the published CLI to execute the deterministic eval corpus against the official workflow surface:
 
 ```bash
-node packages/cli/dist/bin.js eval run planning-discovery-local-brief --json
-node packages/cli/dist/bin.js eval run maintenance-triage-local-report --json
+npx @h9-foundry/agentforge-cli eval run planning-discovery-local-brief --json
+npx @h9-foundry/agentforge-cli eval run maintenance-triage-local-report --json
 ```
 
 Each eval writes a normal run bundle under `.agentops/runs/<eval-run-id>/` and emits one `eval-result` lifecycle artifact.
@@ -255,8 +261,8 @@ Each eval writes a normal run bundle under `.agentops/runs/<eval-run-id>/` and e
 To compare two eval runs deterministically and emit a benchmark artifact:
 
 ```bash
-node packages/cli/dist/bin.js eval compare <baseline-eval-run-id> <candidate-eval-run-id> --json
-node packages/cli/dist/bin.js explain last-run --json
+npx @h9-foundry/agentforge-cli eval compare <baseline-eval-run-id> <candidate-eval-run-id> --json
+npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 The benchmark compare path remains local-first and deterministic. It distinguishes:


### PR DESCRIPTION
## Summary

Make published-vs-source-build wording explicit and consistent across the product-facing docs.

Closes #224.

## What Changed

- updated `README.md` so the published CLI claims match the latest npm release and include the current official local workflow surface plus `eval run` / `eval compare`
- added explicit published CLI terminology to `docs/SUPPORT_MATRIX.md`
- updated `docs/quickstart.md` to use the parity wording consistently and fixed the maintenance example so it matches the published request contract
- added durable queue/process guidance in `docs/QUEUE_EXECUTION_FLOW.md` so docs cannot claim `available in the published CLI` before published verification is complete

## Published Verification

Verified against the latest published `0.8.0` CLI in a clean disposable repo:
- `pr-review`
- `planning-discovery`
- `architecture-design-review`
- `implementation-proposal`
- `qa-review`
- `security-review`
- `maintenance-triage`
- `eval run`
- `eval compare`

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- published CLI smoke path for the official workflow surface and eval commands

## Not Fully Verified

- `pnpm test` and `pnpm test; echo EXIT:$?` still showed the known long-lived desktop-wrapper ambiguity: Vitest started cleanly but did not emit a final exit in the wrapper session before stalling.