### PR TITLE
Add preset-based planning startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 
 - try the current official workflow wedge with the published CLI, without cloning this monorepo
 - initialize a repository, scan it, and run `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage` with the latest published CLI
+- start the first request-driven workflow path with `npx @h9-foundry/agentforge-cli init --preset planning-discovery`, which generates an explicit starter request under `.agentops/requests/planning.yaml`
 - inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, `implementation-proposal`, `qa-report`, `security-report`, and `maintenance-report`
 - run `agentforge eval run` and `agentforge eval compare` locally against the deterministic workflow fixture corpus in the latest published CLI
 - evaluate the secure-by-default runtime model before broader SDLC workflow support lands
@@ -39,6 +40,15 @@ npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 That path creates `.agentops/` locally and writes run artifacts under `.agentops/runs/<run-id>/`.
+
+If you want one request-driven starter path without hand-authoring YAML, run:
+
+```bash
+npx @h9-foundry/agentforge-cli init --preset planning-discovery
+npx @h9-foundry/agentforge-cli run planning-discovery --json
+```
+
+The preset writes an explicit starter request to `.agentops/requests/planning.yaml` and never auto-runs the workflow.
 
 If you want to develop AgentForge itself, use the contributor/source-build path in [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/quickstart.md](docs/quickstart.md).
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,6 +24,16 @@ npx @h9-foundry/agentforge-cli explain last-run --json
 
 That flow creates `.agentops/` locally and writes run artifacts under `.agentops/runs/<run-id>/`.
 
+## Start A Request-Driven Workflow From A Preset
+
+If you want the first request-driven success path without hand-writing YAML, the published CLI now supports one bounded startup preset:
+
+```bash
+npx @h9-foundry/agentforge-cli init --preset planning-discovery
+```
+
+That command keeps the normal local-first init behavior and also writes `.agentops/requests/planning.yaml` if it does not already exist. It never auto-runs a workflow and it will not overwrite an existing request file.
+
 ## What To Inspect After The First Run
 
 - `.agentops/runs/<run-id>/bundle.json`
@@ -40,7 +50,7 @@ For a small clean repository, a successful run should report:
 
 ## Run The Official Planning Workflow
 
-Create a bounded planning request:
+Create a bounded planning request. If you used `init --preset planning-discovery`, you can inspect and edit the generated `.agentops/requests/planning.yaml` instead of creating this file by hand:
 
 ```bash
 mkdir -p .agentops/requests

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -10,6 +10,7 @@ import {
   renderReleaseGuide,
   runLocalWorkflow,
   scanProject,
+  startupPresetNames,
   verifyReleaseArtifacts
 } from "./index.js";
 
@@ -23,10 +24,21 @@ program
 program
   .command("init")
   .description("Scaffold .agentops configuration in the current repository.")
-  .action(() => {
-    const result = initProject();
+  .option("--preset <name>", `Create one starter request preset. Supported presets: ${startupPresetNames.join(", ")}`)
+  .action((options: { preset?: string }) => {
+    if (options.preset && !startupPresetNames.includes(options.preset as (typeof startupPresetNames)[number])) {
+      throw new Error(`Unsupported startup preset: ${options.preset}. Supported presets: ${startupPresetNames.join(", ")}`);
+    }
+
+    const result = initProject(process.cwd(), {
+      preset: options.preset as (typeof startupPresetNames)[number] | undefined
+    });
     console.log(`Initialized AgentForge in ${result.root}`);
     console.log(result.created.length > 0 ? `Created ${result.created.length} file(s).` : "Configuration already present.");
+    if (result.preset) {
+      console.log(result.preset.created ? `Created starter request: ${result.preset.requestPath}` : `Starter request already present: ${result.preset.requestPath}`);
+      console.log(`Next: run \`agentforge run ${result.preset.workflow} --json\``);
+    }
   });
 
 program

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -207,6 +207,28 @@ describe("cli smoke flows", () => {
     expect(explanation.artifactKinds).toEqual([]);
   });
 
+  it("scaffolds a planning-discovery starter preset without overwriting an existing request", () => {
+    const root = createGitFixture("agentops-cli-preset-");
+
+    const firstInit = initProject(root, { preset: "planning-discovery" });
+    expect(firstInit.preset?.preset).toBe("planning-discovery");
+    expect(firstInit.preset?.workflow).toBe("planning-discovery");
+    expect(firstInit.preset?.created).toBe(true);
+
+    const requestPath = join(root, ".agentops", "requests", "planning.yaml");
+    const firstRequest = yaml.load(readFileSync(requestPath, "utf8")) as Record<string, unknown>;
+    expect(firstRequest.problemStatement).toMatch(/^Plan the next safe local-first improvement for agentops-cli-preset-/);
+    expect(firstRequest.constraints).toContain("Keep the default path local-first and read-only");
+    expect(firstRequest.pathHints).toContain("package.json");
+
+    writeFileSync(requestPath, yaml.dump({ problemStatement: "Keep my custom request" }));
+    const secondInit = initProject(root, { preset: "planning-discovery" });
+    expect(secondInit.preset?.created).toBe(false);
+
+    const secondRequest = yaml.load(readFileSync(requestPath, "utf8")) as Record<string, unknown>;
+    expect(secondRequest.problemStatement).toBe("Keep my custom request");
+  });
+
   it("loads an allowed local plugin and executes it through a workflow", async () => {
     const root = mkdtempSync(join(tmpdir(), "agentops-cli-plugin-"));
     execFileSync("git", ["init"], { cwd: root });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -68,6 +68,9 @@ export type { ReleaseCheckEntry, ReleaseCheckResult, ReleaseGuide } from "./inte
 export { verifyReleaseArtifacts } from "./internal/release-verification.js";
 export type { ReleaseVerifyEntry, ReleaseVerifyResult, ReleaseVerifyTarball } from "./internal/release-verification.js";
 
+export const startupPresetNames = ["planning-discovery"] as const;
+export type StartupPresetName = (typeof startupPresetNames)[number];
+
 const agentforgeConfigTemplate = `version: 1
 project:
   name: REPO_NAME
@@ -1927,10 +1930,60 @@ function validateWorkflowAgents(workflow: WorkflowDefinition, agents: Map<string
   }
 }
 
-export function initProject(cwd = process.cwd()): { root: string; created: string[] } {
+function createPlanningDiscoveryPresetRequest(root: string): PlanningRequest {
+  const repoName = root.split("/").at(-1) ?? "this repository";
+  const pathHints = ["README.md", "package.json", "src", "docs"].filter((pathHint) => existsSync(join(root, pathHint)));
+
+  return planningRequestSchema.parse({
+    problemStatement: `Plan the next safe local-first improvement for ${repoName}.`,
+    goals: ["Produce one planning brief artifact", "Identify a bounded next step before opening a pull request"],
+    constraints: ["Keep the default path local-first and read-only", "Prefer a small, reviewable next change"],
+    pathHints,
+    assumptions: ["This preset is a starter request that can be edited after initialization if the repository needs different focus."]
+  });
+}
+
+function applyStartupPreset(
+  root: string,
+  preset: StartupPresetName
+): { preset: StartupPresetName; workflow: string; requestPath: string; created: boolean } {
+  const requestsRoot = join(root, ".agentops", "requests");
+  ensureDirectory(requestsRoot);
+
+  switch (preset) {
+    case "planning-discovery": {
+      const requestPath = join(requestsRoot, "planning.yaml");
+      const created = !existsSync(requestPath);
+      if (created) {
+        writeYamlFile(requestPath, createPlanningDiscoveryPresetRequest(root));
+      }
+
+      return {
+        preset,
+        workflow: "planning-discovery",
+        requestPath,
+        created
+      };
+    }
+  }
+}
+
+export function initProject(
+  cwd = process.cwd(),
+  options?: { preset?: StartupPresetName }
+): {
+  root: string;
+  created: string[];
+  preset?: { preset: StartupPresetName; workflow: string; requestPath: string; created: boolean };
+} {
   const root = findWorkspaceRoot(cwd);
   const created = ensureInitFiles(root);
-  return { root, created };
+  const preset = options?.preset ? applyStartupPreset(root, options.preset) : undefined;
+  return {
+    root,
+    created,
+    ...(preset ? { preset } : {})
+  };
 }
 
 export function scanProject(cwd = process.cwd()): {


### PR DESCRIPTION
## Summary
- add one bounded startup preset via `agentforge init --preset planning-discovery`
- generate an explicit starter request at `.agentops/requests/planning.yaml` without auto-running workflows or overwriting existing request files
- document the preset path in the README and quickstart

## Validation
- `pnpm exec vitest run packages/cli/src/index.test.ts -t "planning-discovery starter preset"`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- built CLI smoke run in a disposable repo for `init --preset planning-discovery` followed by `run planning-discovery --json`

## Residual Risk
- local repo still has an untracked scratch directory at `.agentops/evals/`, which is unrelated and not included in this PR