### PR TITLE
Refine the nontechnical planning quick path

### DIFF
--- a/.changeset/nontechnical-quick-path.md
+++ b/.changeset/nontechnical-quick-path.md
@@ -1,0 +1,5 @@
+---
+"@h9-foundry/agentforge-cli": patch
+---
+
+Improve the planning preset quick path by making `init --preset planning-discovery` print explicit next-step guidance and by documenting the source-build-only canonical quick path until the next published release.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 
 - try the current official workflow wedge with the published CLI, without cloning this monorepo
 - initialize a repository, scan it, and run `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage` with the latest published CLI
-- start the first request-driven workflow path with `npx @h9-foundry/agentforge-cli init --preset planning-discovery`, which generates an explicit starter request under `.agentops/requests/planning.yaml`
+- use the published CLI today for the current official workflow surface, and use the source build on `main` for newer startup UX that has not reached npm yet
 - inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, `implementation-proposal`, `qa-report`, `security-report`, and `maintenance-report`
 - run `agentforge eval run` and `agentforge eval compare` locally against the deterministic workflow fixture corpus in the latest published CLI
 - evaluate the secure-by-default runtime model before broader SDLC workflow support lands
@@ -25,30 +25,29 @@ Published CLI wording rule:
 - `source-build only` means the capability exists on `main` but has not reached the latest npm release yet
 - product-facing docs must use those terms consistently whenever repo `main` is ahead of npm
 
-## Try It In 2 Minutes
+## Quick Path
 
-The fastest evaluator path is the published CLI, not a source build.
-
-```bash
-mkdir agentforge-demo
-cd agentforge-demo
-git init
-npx @h9-foundry/agentforge-cli init
-npx @h9-foundry/agentforge-cli scan --json
-npx @h9-foundry/agentforge-cli run pr-review --json
-npx @h9-foundry/agentforge-cli explain last-run --json
-```
-
-That path creates `.agentops/` locally and writes run artifacts under `.agentops/runs/<run-id>/`.
-
-If you want one request-driven starter path without hand-authoring YAML, run:
+The current canonical quick path for the first request-driven workflow is source-build only until the next npm release includes `init --preset planning-discovery`.
 
 ```bash
-npx @h9-foundry/agentforge-cli init --preset planning-discovery
-npx @h9-foundry/agentforge-cli run planning-discovery --json
+git clone https://github.com/H9-Foundry/AgentForge.git
+cd AgentForge
+pnpm install
+pnpm build
+node packages/cli/dist/bin.js init --preset planning-discovery
+node packages/cli/dist/bin.js run planning-discovery --json
+node packages/cli/dist/bin.js explain last-run --json
 ```
 
-The preset writes an explicit starter request to `.agentops/requests/planning.yaml` and never auto-runs the workflow.
+That path is intentionally four steps only:
+1. clone, install, and build
+2. start the preset
+3. run the planning workflow
+4. inspect the latest run through `agentforge explain last-run`
+
+The preset writes an explicit starter request to `.agentops/requests/planning.yaml`, never auto-runs the workflow, and never overwrites an existing request file.
+
+If you want the fastest published CLI evaluator path today, keep using `init`, `scan`, and `run pr-review` until the next npm release includes the preset startup surface.
 
 If you want to develop AgentForge itself, use the contributor/source-build path in [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/quickstart.md](docs/quickstart.md).
 

--- a/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
+++ b/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
@@ -11,7 +11,7 @@ Can AgentForge be used in another repository today as a local-only pre-PR qualit
 
 Today, a technical evaluator can install the published CLI, run the official local workflow surface, and inspect bounded run artifacts without GitHub wiring. That is enough for pilot-style local usage in another repository.
 
-It is not yet plug-and-play for less technical adopters. The remaining gaps are preset-based startup, a simpler quick path, clearer external agent packaging, and explicit support guidance that does not assume familiarity with request-file authoring.
+It is not yet plug-and-play for less technical adopters. Preset-based startup and the canonical four-step quick path now exist on current `main`, but they are still source-build only until the next npm release. Clearer external agent packaging and published quick-path availability remain open gaps.
 
 ## Readiness Levels
 
@@ -38,8 +38,8 @@ The local-only adoption bar is met only when all of these are true:
 | Official workflow discoverability | Pass | README, support docs, and quickstart now describe the published CLI surface explicitly. |
 | Safe local-first defaults | Pass | Default posture remains local-first and read-only, with approval-gated side effects. |
 | Deterministic artifact inspection | Pass | Official workflows and evals emit inspectable run bundles with structured artifact output. |
-| Quick path without maintainer docs | Partial | A technical evaluator can follow the published quickstart, but less-technical users still face request-file friction. |
-| No-YAML startup for a common path | Fail | Preset-based startup is not implemented yet. |
+| Quick path without maintainer docs | Partial | Current `main` now provides one canonical four-step quick path, but it has not reached the latest published CLI yet. |
+| No-YAML startup for a common path | Partial | `init --preset planning-discovery` exists on current `main`, but it is source-build only until the next npm release. |
 | External starter-agent packaging clarity | Fail | Starter agents are still primarily repo-internal surfaces. |
 
 ## Decision Guidance
@@ -59,6 +59,7 @@ Do not describe AgentForge as plug-and-play for less technical adopters until:
 
 - preset-based startup exists
 - one non-technical quick path exists and is documented as supported
+- the quick path is available in the published CLI, not only on current `main`
 - external agent packaging/support boundaries are explicit
 - product-facing docs no longer assume request-file authoring for the first successful path
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -24,12 +24,34 @@ npx @h9-foundry/agentforge-cli explain last-run --json
 
 That flow creates `.agentops/` locally and writes run artifacts under `.agentops/runs/<run-id>/`.
 
-## Start A Request-Driven Workflow From A Preset
+## Canonical Quick Path
 
-If you want the first request-driven success path without hand-writing YAML, the published CLI now supports one bounded startup preset:
+The canonical quick path for the first request-driven workflow is source-build only until the next npm release includes `init --preset planning-discovery`.
+
+From a fresh checkout of this repository:
 
 ```bash
-npx @h9-foundry/agentforge-cli init --preset planning-discovery
+git clone https://github.com/H9-Foundry/AgentForge.git
+cd AgentForge
+pnpm install
+pnpm build
+node packages/cli/dist/bin.js init --preset planning-discovery
+node packages/cli/dist/bin.js run planning-discovery --json
+node packages/cli/dist/bin.js explain last-run --json
+```
+
+That path is intentionally four steps only:
+1. clone, install, and build
+2. start the preset
+3. run the planning workflow
+4. inspect the latest run through `agentforge explain last-run`
+
+## Start A Request-Driven Workflow From A Preset
+
+If you want the first request-driven success path without hand-writing YAML, current `main` now supports one bounded startup preset. This is source-build only until the next npm release.
+
+```bash
+node packages/cli/dist/bin.js init --preset planning-discovery
 ```
 
 That command keeps the normal local-first init behavior and also writes `.agentops/requests/planning.yaml` if it does not already exist. It never auto-runs a workflow and it will not overwrite an existing request file.

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -23,8 +23,8 @@ program
 
 program
   .command("init")
-  .description("Scaffold .agentops configuration in the current repository.")
-  .option("--preset <name>", `Create one starter request preset. Supported presets: ${startupPresetNames.join(", ")}`)
+  .description("Scaffold .agentops configuration and optional starter requests in the current repository.")
+  .option("--preset <name>", `Create one starter request preset for a common local-first path. Supported presets: ${startupPresetNames.join(", ")}`)
   .action((options: { preset?: string }) => {
     if (options.preset && !startupPresetNames.includes(options.preset as (typeof startupPresetNames)[number])) {
       throw new Error(`Unsupported startup preset: ${options.preset}. Supported presets: ${startupPresetNames.join(", ")}`);
@@ -37,7 +37,9 @@ program
     console.log(result.created.length > 0 ? `Created ${result.created.length} file(s).` : "Configuration already present.");
     if (result.preset) {
       console.log(result.preset.created ? `Created starter request: ${result.preset.requestPath}` : `Starter request already present: ${result.preset.requestPath}`);
-      console.log(`Next: run \`agentforge run ${result.preset.workflow} --json\``);
+      console.log(`Next: inspect or edit ${result.preset.requestPath}`);
+      console.log(`Then run: \`agentforge run ${result.preset.workflow} --json\``);
+      console.log("After the run, inspect `.agentops/runs/<run-id>/bundle.json` or run `agentforge explain last-run --json`.");
     }
   });
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -536,6 +536,24 @@ describe("cli smoke flows", () => {
     expect(run.stdout).toContain("agentforge explain last-run");
   }, 90_000);
 
+  it("prints a four-step quick path for the planning preset in plain-text mode", () => {
+    const root = createGitFixture("agentops-cli-quick-path-");
+    ensureBuiltCli();
+
+    const cliEntry = join(process.cwd(), "packages", "cli", "dist", "bin.js");
+    const run = spawnSync("node", [cliEntry, "init", "--preset", "planning-discovery"], {
+      cwd: root,
+      encoding: "utf8"
+    });
+
+    expect(run.status).toBe(0);
+    expect(run.stdout).toContain("Created starter request:");
+    expect(run.stdout).toContain("inspect or edit");
+    expect(run.stdout).toContain("Then run: `agentforge run planning-discovery --json`");
+    expect(run.stdout).toContain(".agentops/runs/<run-id>/bundle.json");
+    expect(run.stdout).toContain("agentforge explain last-run --json");
+  }, 90_000);
+
   it("fails planning-discovery before reasoning when the request is missing", async () => {
     const root = createGitFixture("agentops-cli-planning-missing-");
     initProject(root);


### PR DESCRIPTION
## Summary
- strengthen `agentforge init --preset planning-discovery` with explicit next-step and artifact-inspection guidance
- make the preset path more discoverable in `init --help`
- rewrite the top-level quick path in the README and quickstart while keeping published-vs-source-build wording honest

## Validation
- `pnpm exec vitest run packages/cli/src/index.test.ts -t "quick path|planning-discovery starter preset"`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build:packages`
- disposable source-build smoke run for:
  - `node packages/cli/dist/bin.js init --preset planning-discovery`
  - `node packages/cli/dist/bin.js run planning-discovery --json`
  - `node packages/cli/dist/bin.js explain last-run --json`
  - `node packages/cli/dist/bin.js init --help`

## Residual Risk
- local repo still has an unrelated untracked scratch directory at `.agentops/evals/`
- the quick path is still source-build only until the next published release includes the preset surface