### PR TITLE
Define external starter agent packaging boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
   - `.agentops/workflows/qa-review.yaml`
   - `.agentops/workflows/security-review.yaml`
   - `.agentops/workflows/maintenance-triage.yaml`
-- official starter agents for context collection, planning analysis, design analysis, implementation planning, QA analysis, security analysis, maintenance analysis, security audit, code review, and test generation
+- official in-repo starter agents for context collection, planning analysis, design analysis, implementation planning, QA analysis, security analysis, maintenance analysis, security audit, code review, and test generation; these are bundled workflow assets, not separately supported external packages
 - internal starter adapters for filesystem, git, shell, and GitHub-aware mediation
 - public npm packages for the runtime core, CLI, contracts, and audit surfaces
 - GitHub Actions release automation, trusted publishing, and package verification tooling
@@ -210,6 +210,8 @@ See [docs/architecture.md](docs/architecture.md), [docs/runtime-model.md](docs/r
 - `examples/*`: starter repositories and extension examples
 
 Internal packages remain private until their APIs stabilize and their support expectations are documented.
+
+See [docs/EXTERNAL_STARTER_AGENT_PACKAGING.md](docs/EXTERNAL_STARTER_AGENT_PACKAGING.md) for the current external support boundary for starter agents, presets, and registry-facing surfaces.
 
 ## Quickstart
 

--- a/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
+++ b/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
@@ -11,7 +11,7 @@ Can AgentForge be used in another repository today as a local-only pre-PR qualit
 
 Today, a technical evaluator can install the published CLI, run the official local workflow surface, and inspect bounded run artifacts without GitHub wiring. That is enough for pilot-style local usage in another repository.
 
-It is not yet plug-and-play for less technical adopters. Preset-based startup and the canonical four-step quick path now exist on current `main`, but they are still source-build only until the next npm release. Clearer external agent packaging and published quick-path availability remain open gaps.
+It is not yet plug-and-play for less technical adopters. Preset-based startup and the canonical four-step quick path now exist on current `main`, but they are still source-build only until the next npm release. The external support boundary is now explicit: the CLI plus official workflows and presets are the supported external surface, while `agents/*` and `packages/registry-client` remain repo-internal. Published quick-path availability remains the main open gap.
 
 ## Readiness Levels
 
@@ -40,7 +40,7 @@ The local-only adoption bar is met only when all of these are true:
 | Deterministic artifact inspection | Pass | Official workflows and evals emit inspectable run bundles with structured artifact output. |
 | Quick path without maintainer docs | Partial | Current `main` now provides one canonical four-step quick path, but it has not reached the latest published CLI yet. |
 | No-YAML startup for a common path | Partial | `init --preset planning-discovery` exists on current `main`, but it is source-build only until the next npm release. |
-| External starter-agent packaging clarity | Fail | Starter agents are still primarily repo-internal surfaces. |
+| External starter-agent packaging clarity | Pass | The support boundary is now explicit: external users consume workflows and presets through the CLI, while `agents/*` and `packages/registry-client` remain repo-internal. |
 
 ## Decision Guidance
 
@@ -69,3 +69,5 @@ Do not describe AgentForge as plug-and-play for less technical adopters until:
 - [#220](https://github.com/H9-Foundry/AgentForge/issues/220) preset-based workflow startup for external repos
 - [#222](https://github.com/H9-Foundry/AgentForge/issues/222) non-technical adopter quick path
 - [#221](https://github.com/H9-Foundry/AgentForge/issues/221) external agent packaging and starter preset distribution
+
+See [docs/EXTERNAL_STARTER_AGENT_PACKAGING.md](EXTERNAL_STARTER_AGENT_PACKAGING.md) for the current starter-agent and preset packaging boundary.

--- a/docs/EXTERNAL_STARTER_AGENT_PACKAGING.md
+++ b/docs/EXTERNAL_STARTER_AGENT_PACKAGING.md
@@ -1,0 +1,61 @@
+# External Starter Agent Packaging
+
+This document answers one narrow question:
+
+How should external users think about starter agents and presets today?
+
+## Supported External Consumption Today
+
+The supported external surface is:
+
+- the published CLI
+- the official workflows shipped with the CLI
+- the presets exposed through the CLI
+
+That means external users should consume AgentForge through workflow commands such as:
+
+- `agentforge run pr-review`
+- `agentforge run planning-discovery`
+- `agentforge init --preset planning-discovery`
+
+The CLI is the supported packaging boundary. The individual starter agents that power those workflows are not separately supported external packages today.
+
+## What Stays Repo-Internal
+
+These remain repo-internal implementation assets:
+
+- `agents/*`
+- `adapters/*`
+- `packages/registry-client`
+
+They are real and used by the runtime, but they are not yet a supported external installation surface.
+
+## External Boundary
+
+Use these rules when describing the current product:
+
+- official workflows are externally consumable through the CLI
+- official starter agents are bundled implementation assets behind those workflows
+- presets are supported entry points for common external workflow startup
+- local/manual plugins are supported only through explicit local registration
+- remote registry discovery, install, and activation remain future-facing
+
+## Trust Boundary
+
+Current trust posture stays unchanged:
+
+- built-in workflow assets and bundled starter agents are core official assets
+- local/manual plugins must still pass existing trust-policy checks
+- third-party registry-backed discovery or activation is not supported yet
+- `packages/registry-client` remains internal until the registry roadmap lands
+
+## Future Packaging Direction
+
+The intended direction is:
+
+1. keep the CLI and official workflows as the supported external surface
+2. make presets more discoverable and easier to start
+3. define registry metadata and read-only discovery
+4. only then define any bounded third-party activation path
+
+This document does not imply that starter agents will become individually supported npm packages.

--- a/docs/PLUGIN_REGISTRY_ROADMAP.md
+++ b/docs/PLUGIN_REGISTRY_ROADMAP.md
@@ -110,6 +110,7 @@ Current truthful state:
 - local/manual plugin trust is real
 - registry integrations are planned
 - `packages/registry-client` remains internal
+- the supported external adoption path is still the CLI plus official workflows and presets, not standalone starter-agent packages
 
 The roadmap should keep those statements true until later implementation lands.
 
@@ -120,4 +121,3 @@ This epic should be decomposed into at least:
 1. registry metadata schema and plugin-catalog contract
 2. read-only registry-client discovery and compatibility verification surface
 3. verified third-party plugin activation flow with explicit approval and trust checks
-

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -35,15 +35,17 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 
 ## Agent Support
 
+`Official` in this table means supported as bundled workflow assets behind the CLI and official workflows, not as standalone external packages unless stated otherwise.
+
 | Agent | Maturity | Notes |
 | --- | --- | --- |
 | `context-collector` | Official | Current starter agent. |
 | `planning-analyst` | Official | Starter planning agent for `planning-discovery`. |
 | `design-analyst` | Official | Starter design agent for `architecture-design-review`. |
 | `implementation-planner` | Official | Starter implementation agent for `implementation-proposal`. |
-| `qa-analyst` | Official | Starter QA agent for `qa-review`. |
-| `security-analyst` | Official | Starter security agent for `security-review`. |
-| `maintenance-analyst` | Official | Starter maintenance agent for `maintenance-triage`. |
+| `qa-analyst` | Official | Starter QA agent for `qa-review`; supported as an in-repo workflow asset, not as a standalone external package. |
+| `security-analyst` | Official | Starter security agent for `security-review`; supported as an in-repo workflow asset, not as a standalone external package. |
+| `maintenance-analyst` | Official | Starter maintenance agent for `maintenance-triage`; supported as an in-repo workflow asset, not as a standalone external package. |
 | `security-audit` | Official | Current starter agent. |
 | `code-review` | Official | Current starter agent. |
 | `test-generation` | Official | Current starter agent. |
@@ -75,7 +77,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `@h9-foundry/agentforge-runtime` | Official | Public runtime package. |
 | `@h9-foundry/agentforge-audit` | Official | Public audit/reporting package. |
 | `packages/registry-client` | Internal | Future-facing registry surface. |
-| `agents/*` | Internal | Official in-repo agents, not yet public packages. |
+| `agents/*` | Internal | Official in-repo agents used by the workflow surface, not individually supported public packages. |
 | `adapters/*` | Internal | Internal starter adapters, not yet public packages. |
 
 ## Environment Support
@@ -94,8 +96,8 @@ See [docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md](EXTERNAL_LOCAL_ADOPTION_READINES
 | Adoption Surface | Maturity | Notes |
 | --- | --- | --- |
 | technical local-first adoption | Partial | Strongest current external fit: technical evaluators can install the CLI, run official local workflows, and inspect audit artifacts without GitHub wiring. |
-| less-technical plug-and-play adoption | Planned | This is now an explicit product target, but it is not complete yet; common workflow startup still expects too much familiarity with request files and repo structure. |
-| agent-stack integration readiness | Planned | Internal starter agents exist, but external packaging, preset distribution, and low-friction agent consumption are not yet supported as a public surface. |
+| less-technical plug-and-play adoption | Planned | This is now an explicit product target, but it is not complete yet; the quick path and no-YAML startup are still source-build only until the next published release. |
+| agent-stack integration readiness | Planned | The supported external surface is still the CLI plus official workflows and presets; starter agents and `packages/registry-client` remain repo-internal. |
 
 ## Self-Hosting Scope
 


### PR DESCRIPTION
## Summary
- add an explicit external starter-agent packaging/support-boundary doc
- clarify that the supported external surface is the CLI plus official workflows and presets
- keep `agents/*` and `packages/registry-client` explicitly repo-internal until later registry work lands

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

## Residual Risk
- local repo still has an unrelated untracked scratch directory at `.agentops/evals/`
- this slice defines support boundaries only; it does not change plugin installation, activation, or registry behavior