### PR TITLE
Add the registry metadata catalog contract

### DIFF
--- a/.changeset/registry-metadata-contract.md
+++ b/.changeset/registry-metadata-contract.md
@@ -1,0 +1,6 @@
+---
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add a read-only registry metadata contract, including catalog entry and catalog schemas plus inferred shared types for plugin identity, compatibility, trust, and distribution support boundaries.

--- a/docs/PLUGIN_REGISTRY_ROADMAP.md
+++ b/docs/PLUGIN_REGISTRY_ROADMAP.md
@@ -33,11 +33,11 @@ Available now:
 - trust-tier, trust-source, and reviewed-state enforcement
 - blocked-plugin reporting in audit output
 - internal `packages/registry-client` placeholder package
+- registry metadata contract for read-only catalog records
 
 Not yet available:
 
 - remote plugin discovery
-- registry metadata schema
 - signed third-party plugin distribution
 - adapter/provider plugin loading
 - install or update flows

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -30,6 +30,8 @@ import {
   qaRequestSchema,
   releaseEvidenceNormalizationSchema,
   releaseRequestSchema,
+  registryPluginCatalogEntrySchema,
+  registryPluginCatalogSchema,
   securityArtifactSchema,
   securityEvidenceNormalizationSchema,
   securityRequestSchema,
@@ -64,6 +66,8 @@ describe("schema fixtures", () => {
     expect(() => githubWorkflowStatusMappingSchema.parse(schemaFixtures.githubWorkflowStatusMapping)).not.toThrow();
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
+    expect(() => registryPluginCatalogEntrySchema.parse(schemaFixtures.registryPluginCatalogEntry)).not.toThrow();
+    expect(() => registryPluginCatalogSchema.parse(schemaFixtures.registryPluginCatalog)).not.toThrow();
     expect(() => incidentArtifactSchema.parse(schemaFixtures.incidentArtifact)).not.toThrow();
     expect(() => evalArtifactSchema.parse(schemaFixtures.evalArtifact)).not.toThrow();
     expect(() => benchmarkArtifactSchema.parse(schemaFixtures.benchmarkArtifact)).not.toThrow();
@@ -103,6 +107,8 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.githubWorkflowStatusMapping).toBeDefined();
     expect(jsonSchemas.normalizedValidationCommand).toBeDefined();
     expect(jsonSchemas.implementationInventory).toBeDefined();
+    expect(jsonSchemas.registryPluginCatalogEntry).toBeDefined();
+    expect(jsonSchemas.registryPluginCatalog).toBeDefined();
     expect(jsonSchemas.qaEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.securityEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.maintenanceEvidenceNormalization).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v3";
+import { z, type ZodTypeAny } from "zod/v3";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
 export const schemaVersion = "1.0.0";
@@ -13,6 +13,10 @@ export const toolResultStatusSchema = z.enum(["success", "blocked", "failed"]);
 export const runStatusSchema = z.enum(["success", "partial", "failed"]);
 export const trustTierSchema = z.enum(["core", "verified", "community", "untrusted"]);
 export const trustSourceSchema = z.enum(["official", "local", "third-party"]);
+export const registryPluginTypeSchema = z.enum(["agent", "adapter", "workflow"]);
+export const registryDistributionChannelSchema = z.enum(["manual", "npm"]);
+export const registryInstallSupportSchema = z.enum(["manual-only", "not-supported"]);
+export const registryActivationSupportSchema = z.enum(["not-supported", "approval-required"]);
 export const lifecycleArtifactKindSchema = z.enum([
   "planning-brief",
   "design-record",
@@ -85,6 +89,38 @@ export const trustMetadataSchema = z.object({
   tier: trustTierSchema.default("core"),
   source: trustSourceSchema.default("official"),
   reviewed: z.boolean().default(true)
+});
+
+export const registryPluginCompatibilitySchema = z.object({
+  agentforgeVersionRange: z.string().min(1),
+  manifestVersion: z.number().int().positive().default(1),
+  supportedWorkflowDomains: z.array(catalogDomainSchema).default([])
+});
+
+export const registryPluginDistributionSchema = z.object({
+  channel: registryDistributionChannelSchema,
+  packageName: z.string().min(1),
+  version: z.string().min(1),
+  reference: z.string().min(1),
+  installSupport: registryInstallSupportSchema.default("manual-only"),
+  activationSupport: registryActivationSupportSchema.default("not-supported")
+});
+
+export const registryPluginCatalogEntrySchema = z.object({
+  id: z.string().min(1),
+  displayName: z.string().min(1),
+  pluginType: registryPluginTypeSchema,
+  description: z.string().min(1).optional(),
+  catalog: catalogMetadataSchema,
+  trust: trustMetadataSchema,
+  compatibility: registryPluginCompatibilitySchema,
+  distribution: registryPluginDistributionSchema
+});
+
+export const registryPluginCatalogSchema = z.object({
+  version: z.number().int().positive(),
+  generatedAt: z.string().datetime().optional(),
+  entries: z.array(registryPluginCatalogEntrySchema).default([])
 });
 
 export const agentPluginRegistrationSchema = z.object({
@@ -1083,7 +1119,7 @@ export const auditBundleSchema = z.object({
   components: z.array(auditComponentSchema).default([])
 });
 
-export const schemaRegistry = {
+export const schemaRegistry: Record<string, ZodTypeAny> = {
   finding: findingSchema,
   blockedPlugin: blockedPluginSchema,
   proposedAction: proposedActionSchema,
@@ -1108,6 +1144,10 @@ export const schemaRegistry = {
   lifecycleArtifactAuditLink: lifecycleArtifactAuditLinkSchema,
   lifecycleArtifactEnvelope: lifecycleArtifactEnvelopeSchema,
   catalogMetadata: catalogMetadataSchema,
+  registryPluginCompatibility: registryPluginCompatibilitySchema,
+  registryPluginDistribution: registryPluginDistributionSchema,
+  registryPluginCatalogEntry: registryPluginCatalogEntrySchema,
+  registryPluginCatalog: registryPluginCatalogSchema,
   planningArtifactPayload: planningArtifactPayloadSchema,
   designArtifactOption: designArtifactOptionSchema,
   designArtifactPayload: designArtifactPayloadSchema,
@@ -2124,6 +2164,72 @@ export const schemaFixtures = {
       source: "official",
       reviewed: true
     }
+  },
+  registryPluginCatalogEntry: {
+    id: "local-review",
+    displayName: "Local Review Plugin",
+    pluginType: "agent",
+    description: "Catalog entry for a locally registered review plugin.",
+    catalog: {
+      domain: "review",
+      supportLevel: "planned",
+      maturity: "prototype",
+      trustScope: "official-and-reviewed-local"
+    },
+    trust: {
+      tier: "verified",
+      source: "local",
+      reviewed: true
+    },
+    compatibility: {
+      agentforgeVersionRange: ">=0.8.0",
+      manifestVersion: 1,
+      supportedWorkflowDomains: ["review", "test"]
+    },
+    distribution: {
+      channel: "manual",
+      packageName: "@example/local-review",
+      version: "0.1.0",
+      reference: "packages/local-review",
+      installSupport: "manual-only",
+      activationSupport: "approval-required"
+    }
+  },
+  registryPluginCatalog: {
+    version: 1,
+    generatedAt: "2026-03-19T11:30:00.000Z",
+    entries: [
+      {
+        id: "local-review",
+        displayName: "Local Review Plugin",
+        pluginType: "agent",
+        description: "Catalog entry for a locally registered review plugin.",
+        catalog: {
+          domain: "review",
+          supportLevel: "planned",
+          maturity: "prototype",
+          trustScope: "official-and-reviewed-local"
+        },
+        trust: {
+          tier: "verified",
+          source: "local",
+          reviewed: true
+        },
+        compatibility: {
+          agentforgeVersionRange: ">=0.8.0",
+          manifestVersion: 1,
+          supportedWorkflowDomains: ["review", "test"]
+        },
+        distribution: {
+          channel: "manual",
+          packageName: "@example/local-review",
+          version: "0.1.0",
+          reference: "packages/local-review",
+          installSupport: "manual-only",
+          activationSupport: "approval-required"
+        }
+      }
+    ]
   },
   policyDocument: {
     version: 1,

--- a/packages/shared-types/src/index.test.ts
+++ b/packages/shared-types/src/index.test.ts
@@ -35,6 +35,10 @@ import type {
   ReleaseApprovalRecommendation,
   ReleaseRequest,
   ReleaseEvidenceNormalization,
+  RegistryPluginCatalog,
+  RegistryPluginCatalogEntry,
+  RegistryPluginCompatibility,
+  RegistryPluginDistribution,
   SecurityArtifact,
   SecurityEvidenceNormalization,
   SecurityRequest,
@@ -117,5 +121,14 @@ describe("shared lifecycle artifact types", () => {
     expectTypeOf<NormalizedValidationCommand["classification"]>().toEqualTypeOf<
       "allow" | "approval_required" | "deny"
     >();
+    expectTypeOf<RegistryPluginCompatibility["agentforgeVersionRange"]>().toEqualTypeOf<string>();
+    expectTypeOf<RegistryPluginCompatibility["supportedWorkflowDomains"]>().toEqualTypeOf<
+      Array<"foundation" | "plan" | "design" | "build" | "review" | "test" | "security" | "release" | "operate" | "maintain">
+    >();
+    expectTypeOf<RegistryPluginDistribution["activationSupport"]>().toEqualTypeOf<
+      "not-supported" | "approval-required"
+    >();
+    expectTypeOf<RegistryPluginCatalogEntry["pluginType"]>().toEqualTypeOf<"agent" | "adapter" | "workflow">();
+    expectTypeOf<RegistryPluginCatalog["entries"]>().toEqualTypeOf<RegistryPluginCatalogEntry[]>();
   });
 });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -81,6 +81,10 @@ import {
   releaseVerificationCheckSchema,
   releaseVersionResolutionSchema,
   releaseVersionTargetSchema,
+  registryPluginCatalogEntrySchema,
+  registryPluginCatalogSchema,
+  registryPluginCompatibilitySchema,
+  registryPluginDistributionSchema,
   reviewArtifactPayloadSchema,
   reviewArtifactSchema,
   trustMetadataSchema,
@@ -160,6 +164,10 @@ export type ReleaseVerificationCheck = Infer<typeof releaseVerificationCheckSche
 export type ReleaseVersionTarget = Infer<typeof releaseVersionTargetSchema>;
 export type ReleaseVersionResolution = Infer<typeof releaseVersionResolutionSchema>;
 export type ReleaseApprovalRecommendation = Infer<typeof releaseApprovalRecommendationSchema>;
+export type RegistryPluginCompatibility = Infer<typeof registryPluginCompatibilitySchema>;
+export type RegistryPluginDistribution = Infer<typeof registryPluginDistributionSchema>;
+export type RegistryPluginCatalogEntry = Infer<typeof registryPluginCatalogEntrySchema>;
+export type RegistryPluginCatalog = Infer<typeof registryPluginCatalogSchema>;
 export type ReleaseRequest = Infer<typeof releaseRequestSchema>;
 export type ReleaseEvidenceNormalization = Infer<typeof releaseEvidenceNormalizationSchema>;
 export type ReleaseArtifactPayload = Infer<typeof releaseArtifactPayloadSchema>;


### PR DESCRIPTION
## Summary
- add registry catalog schemas for compatibility, distribution, catalog entries, and catalogs
- export inferred shared types for the new read-only registry metadata surface
- update the plugin/registry roadmap to reflect that the metadata-contract wedge now exists

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`

## Residual Risk
- this slice is contract-only; `packages/registry-client` behavior is unchanged and read-only discovery remains for `#162`
- local repo still has an unrelated untracked scratch directory at `.agentops/evals/`