### PR TITLE
Version public AgentForge packages

### DIFF
--- a/.changeset/nontechnical-quick-path.md
+++ b/.changeset/nontechnical-quick-path.md
@@ -1,5 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
----
-
-Improve the planning preset quick path by making `init --preset planning-discovery` print explicit next-step guidance and by documenting the source-build-only canonical quick path until the next published release.

--- a/.changeset/registry-activation-decisions.md
+++ b/.changeset/registry-activation-decisions.md
@@ -1,5 +1,0 @@
----
-"@h9-foundry/agentforge-policy-engine": minor
----
-
-Add approval-gated registry activation decisions for verified catalog plugins and expose audit-ready activation outcomes through the internal registry client.

--- a/.changeset/registry-metadata-contract.md
+++ b/.changeset/registry-metadata-contract.md
@@ -1,6 +1,0 @@
----
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add a read-only registry metadata contract, including catalog entry and catalog schemas plus inferred shared types for plugin identity, compatibility, trust, and distribution support boundaries.

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @h9-foundry/agentforge-audit
 
+## 0.9.0
+
+### Patch Changes
+
+- Updated dependencies [203d736]
+  - @h9-foundry/agentforge-shared-types@0.9.0
+
 ## 0.8.0
 
 ### Patch Changes

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-audit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @h9-foundry/agentforge-cli
 
+## 0.9.0
+
+### Patch Changes
+
+- edd8435: Improve the planning preset quick path by making `init --preset planning-discovery` print explicit next-step guidance and by documenting the source-build-only canonical quick path until the next published release.
+- Updated dependencies [9c6c099]
+- Updated dependencies [203d736]
+  - @h9-foundry/agentforge-policy-engine@0.9.0
+  - @h9-foundry/agentforge-schemas@0.9.0
+  - @h9-foundry/agentforge-shared-types@0.9.0
+  - @h9-foundry/agentforge-runtime@0.9.0
+  - @h9-foundry/agentforge-context-engine@0.9.0
+  - @h9-foundry/agentforge-audit@0.9.0
+  - @h9-foundry/agentforge-sdk@0.9.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-cli",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/context-engine/CHANGELOG.md
+++ b/packages/context-engine/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @h9-foundry/agentforge-context-engine
 
+## 0.9.0
+
+### Patch Changes
+
+- Updated dependencies [203d736]
+  - @h9-foundry/agentforge-schemas@0.9.0
+  - @h9-foundry/agentforge-shared-types@0.9.0
+
 ## 0.8.0
 
 ### Patch Changes

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Repository and execution context collection for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/policy-engine/CHANGELOG.md
+++ b/packages/policy-engine/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @h9-foundry/agentforge-policy-engine
 
+## 0.9.0
+
+### Minor Changes
+
+- 9c6c099: Add approval-gated registry activation decisions for verified catalog plugins and expose audit-ready activation outcomes through the internal registry client.
+
+### Patch Changes
+
+- Updated dependencies [203d736]
+  - @h9-foundry/agentforge-schemas@0.9.0
+  - @h9-foundry/agentforge-shared-types@0.9.0
+
 ## 0.8.0
 
 ### Patch Changes

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @h9-foundry/agentforge-runtime
 
+## 0.9.0
+
+### Patch Changes
+
+- Updated dependencies [9c6c099]
+- Updated dependencies [203d736]
+  - @h9-foundry/agentforge-policy-engine@0.9.0
+  - @h9-foundry/agentforge-schemas@0.9.0
+  - @h9-foundry/agentforge-shared-types@0.9.0
+  - @h9-foundry/agentforge-audit@0.9.0
+  - @h9-foundry/agentforge-sdk@0.9.0
+
 ## 0.8.0
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @h9-foundry/agentforge-schemas
 
+## 0.9.0
+
+### Minor Changes
+
+- 203d736: Add a read-only registry metadata contract, including catalog entry and catalog schemas plus inferred shared types for plugin identity, compatibility, trust, and distribution support boundaries.
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @h9-foundry/agentforge-sdk
 
+## 0.9.0
+
+### Patch Changes
+
+- Updated dependencies [203d736]
+  - @h9-foundry/agentforge-shared-types@0.9.0
+
 ## 0.8.0
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @h9-foundry/agentforge-shared-types
 
+## 0.9.0
+
+### Minor Changes
+
+- 203d736: Add a read-only registry metadata contract, including catalog entry and catalog schemas plus inferred shared types for plugin identity, compatibility, trust, and distribution support boundaries.
+
+### Patch Changes
+
+- Updated dependencies [203d736]
+  - @h9-foundry/agentforge-schemas@0.9.0
+
 ## 0.8.0
 
 ### Minor Changes

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
   "license": "MIT",
   "author": "H9 Foundry",


### PR DESCRIPTION
## Summary
- version the public AgentForge packages after the external-adoption and registry/plugin chains landed on `main`
- consume the pending changesets and update the affected package changelogs
- replace stale Changesets PR `#231`, which no longer reflected the full merged registry work

## Validation
- `pnpm release:version`

## Residual Risk
- this PR is versioning/changelog generation only; publish verification still depends on the post-merge release workflow
- local repo still has an unrelated untracked scratch directory at `.agentops/evals/`