### PR TITLE
Fix generic repo validation command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 
 - try the current official workflow wedge with the published CLI, without cloning this monorepo
 - initialize a repository, scan it, and run `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage` with the latest published CLI
-- use the published CLI today for the current official workflow surface, and use the source build on `main` for newer startup UX that has not reached npm yet
+- use the published CLI today for the current official workflow surface, the bounded planning preset startup path, and the local eval runner and compare flow
 - inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, `implementation-proposal`, `qa-report`, `security-report`, and `maintenance-report`
 - run `agentforge eval run` and `agentforge eval compare` locally against the deterministic workflow fixture corpus in the latest published CLI
 - evaluate the secure-by-default runtime model before broader SDLC workflow support lands
@@ -27,27 +27,24 @@ Published CLI wording rule:
 
 ## Quick Path
 
-The current canonical quick path for the first request-driven workflow is source-build only until the next npm release includes `init --preset planning-discovery`.
+The current canonical quick path for the first request-driven workflow is available in the published CLI.
 
 ```bash
-git clone https://github.com/H9-Foundry/AgentForge.git
-cd AgentForge
-pnpm install
-pnpm build
-node packages/cli/dist/bin.js init --preset planning-discovery
-node packages/cli/dist/bin.js run planning-discovery --json
-node packages/cli/dist/bin.js explain last-run --json
+mkdir agentforge-demo
+cd agentforge-demo
+git init
+npx @h9-foundry/agentforge-cli init --preset planning-discovery
+npx @h9-foundry/agentforge-cli run planning-discovery --json
+npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 That path is intentionally four steps only:
-1. clone, install, and build
+1. create a local repo
 2. start the preset
 3. run the planning workflow
 4. inspect the latest run through `agentforge explain last-run`
 
 The preset writes an explicit starter request to `.agentops/requests/planning.yaml`, never auto-runs the workflow, and never overwrites an existing request file.
-
-If you want the fastest published CLI evaluator path today, keep using `init`, `scan`, and `run pr-review` until the next npm release includes the preset startup surface.
 
 If you want to develop AgentForge itself, use the contributor/source-build path in [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/quickstart.md](docs/quickstart.md).
 

--- a/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
+++ b/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
@@ -7,11 +7,11 @@ Can AgentForge be used in another repository today as a local-only pre-PR qualit
 ## Current Answer
 
 - technical early-adopter local-only adoption: `Partial`
-- less-technical plug-and-play local-only adoption: `Planned`
+- less-technical plug-and-play local-only adoption: `Partial`
 
 Today, a technical evaluator can install the published CLI, run the official local workflow surface, and inspect bounded run artifacts without GitHub wiring. That is enough for pilot-style local usage in another repository.
 
-It is not yet plug-and-play for less technical adopters. Preset-based startup and the canonical four-step quick path now exist on current `main`, but they are still source-build only until the next npm release. The external support boundary is now explicit: the CLI plus official workflows and presets are the supported external surface, while `agents/*` and `packages/registry-client` remain repo-internal. Published quick-path availability remains the main open gap.
+It is not yet fully plug-and-play for less technical adopters. The published CLI now includes preset-based startup and the canonical four-step quick path, and the external support boundary is explicit: the CLI plus official workflows and presets are the supported external surface, while `agents/*` and `packages/registry-client` remain repo-internal. The remaining gap is broader ease-of-use beyond the first bounded local-first path.
 
 ## Readiness Levels
 
@@ -34,12 +34,12 @@ The local-only adoption bar is met only when all of these are true:
 
 | Criterion | Status | Current Reality |
 | --- | --- | --- |
-| Published CLI parity | Pass | The latest published `0.8.0` CLI includes the official local workflow surface plus `eval run` and `eval compare`. |
+| Published CLI parity | Pass | The latest published `0.9.0` CLI includes the official local workflow surface plus the bounded planning preset startup path, `eval run`, and `eval compare`. |
 | Official workflow discoverability | Pass | README, support docs, and quickstart now describe the published CLI surface explicitly. |
 | Safe local-first defaults | Pass | Default posture remains local-first and read-only, with approval-gated side effects. |
 | Deterministic artifact inspection | Pass | Official workflows and evals emit inspectable run bundles with structured artifact output. |
-| Quick path without maintainer docs | Partial | Current `main` now provides one canonical four-step quick path, but it has not reached the latest published CLI yet. |
-| No-YAML startup for a common path | Partial | `init --preset planning-discovery` exists on current `main`, but it is source-build only until the next npm release. |
+| Quick path without maintainer docs | Pass | The published CLI now provides one canonical four-step quick path for the first request-driven workflow. |
+| No-YAML startup for a common path | Pass | `init --preset planning-discovery` is now available in the published CLI. |
 | External starter-agent packaging clarity | Pass | The support boundary is now explicit: external users consume workflows and presets through the CLI, while `agents/*` and `packages/registry-client` remain repo-internal. |
 
 ## Decision Guidance
@@ -59,7 +59,6 @@ Do not describe AgentForge as plug-and-play for less technical adopters until:
 
 - preset-based startup exists
 - one non-technical quick path exists and is documented as supported
-- the quick path is available in the published CLI, not only on current `main`
 - external agent packaging/support boundaries are explicit
 - product-facing docs no longer assume request-file authoring for the first successful path
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -96,7 +96,7 @@ See [docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md](EXTERNAL_LOCAL_ADOPTION_READINES
 | Adoption Surface | Maturity | Notes |
 | --- | --- | --- |
 | technical local-first adoption | Partial | Strongest current external fit: technical evaluators can install the CLI, run official local workflows, and inspect audit artifacts without GitHub wiring. |
-| less-technical plug-and-play adoption | Planned | This is now an explicit product target, but it is not complete yet; the quick path and no-YAML startup are still source-build only until the next published release. |
+| less-technical plug-and-play adoption | Partial | The published CLI now includes one bounded quick path plus no-YAML preset startup, but broader adoption still expects low-to-mid technical comfort. |
 | agent-stack integration readiness | Planned | The supported external surface is still the CLI plus official workflows and presets; starter agents and `packages/registry-client` remain repo-internal. |
 
 ## Self-Hosting Scope
@@ -112,7 +112,7 @@ See [docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md](EXTERNAL_LOCAL_ADOPTION_READINES
 
 ## Compatibility Notes
 
-- Workflow maturity and published CLI availability are related but not identical. A workflow can be official on `main` and still need an explicit `source-build only` note until the latest npm release includes it.
+- Workflow maturity and published CLI availability are related but not identical. A workflow can be official on `main` and still need an explicit `source-build only` note until the latest npm release includes it, but the current quick path and preset startup are already available in the published CLI.
 - Current support is strongest for local repository execution and GitHub-centric release workflows.
 - Public compatibility commitments are intentionally narrow until broader workflow and integration support exists.
 - Planned support in this matrix should be treated as roadmap direction, not shipped capability.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,32 +26,29 @@ That flow creates `.agentops/` locally and writes run artifacts under `.agentops
 
 ## Canonical Quick Path
 
-The canonical quick path for the first request-driven workflow is source-build only until the next npm release includes `init --preset planning-discovery`.
-
-From a fresh checkout of this repository:
+The canonical quick path for the first request-driven workflow is now available in the published CLI.
 
 ```bash
-git clone https://github.com/H9-Foundry/AgentForge.git
-cd AgentForge
-pnpm install
-pnpm build
-node packages/cli/dist/bin.js init --preset planning-discovery
-node packages/cli/dist/bin.js run planning-discovery --json
-node packages/cli/dist/bin.js explain last-run --json
+mkdir agentforge-demo
+cd agentforge-demo
+git init
+npx @h9-foundry/agentforge-cli init --preset planning-discovery
+npx @h9-foundry/agentforge-cli run planning-discovery --json
+npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 That path is intentionally four steps only:
-1. clone, install, and build
+1. create a local repo
 2. start the preset
 3. run the planning workflow
 4. inspect the latest run through `agentforge explain last-run`
 
 ## Start A Request-Driven Workflow From A Preset
 
-If you want the first request-driven success path without hand-writing YAML, current `main` now supports one bounded startup preset. This is source-build only until the next npm release.
+If you want the first request-driven success path without hand-writing YAML, the published CLI now supports one bounded startup preset.
 
 ```bash
-node packages/cli/dist/bin.js init --preset planning-discovery
+npx @h9-foundry/agentforge-cli init --preset planning-discovery
 ```
 
 That command keeps the normal local-first init behavior and also writes `.agentops/requests/planning.yaml` if it does not already exist. It never auto-runs a workflow and it will not overwrite an existing request file.
@@ -154,7 +151,7 @@ npx @h9-foundry/agentforge-cli explain last-run --json
 
 The implementation bundle should include one `implementation-proposal` lifecycle artifact with deterministic affected-path inventory plus approval-required validation guidance. The default path remains read-only and proposal-only.
 
-If the published CLI reports `packageManager: "unknown"` in a generic repo, omit `validationCommands` from the request and let the workflow emit proposal-only validation guidance from the referenced design record and target paths. Add explicit commands only after package-manager detection is available for that repo.
+If `scan --json` still reports `packageManager: "unknown"` in a generic repo, `implementation-proposal` will still accept bounded root-package validation commands such as `pnpm test`, `npm test`, or `yarn test` when they match discovered allowlisted scripts in `package.json`.
 
 ## Run The Official QA Workflow
 
@@ -182,7 +179,7 @@ npx @h9-foundry/agentforge-cli explain last-run --json
 
 The QA bundle should include one `qa-report` lifecycle artifact with normalized evidence sources, normalized executed checks, coverage gaps, findings, and recommended next checks. The default path remains read-only and bounded to local evidence.
 
-If package-manager detection is unavailable in the published generic-repo path, omit `executedChecks` and rely on bounded evidence references such as the implementation bundle and summary. Add explicit executed checks only when the repo’s package manager is known and the commands are allowlisted for that repo.
+If `scan --json` still reports `packageManager: "unknown"` in a generic repo, `qa-review` will still accept bounded root-package executed checks such as `pnpm test`, `npm test`, or `yarn test` when they match discovered allowlisted scripts in `package.json`.
 
 ## Run The Official Security Workflow
 

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -41,6 +41,37 @@ function createGitFixture(prefix: string): string {
   return root;
 }
 
+function createGitFixtureWithoutLockfile(prefix: string): string {
+  const root = mkdtempSync(join(tmpdir(), prefix));
+  execFileSync("git", ["init"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "AgentForge Test"], { cwd: root });
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify(
+      {
+        name: "fixture",
+        repository: {
+          type: "git",
+          url: "https://github.com/H9-Foundry/fixture.git"
+        },
+        scripts: {
+          test: "echo test",
+          lint: "echo lint",
+          typecheck: "echo typecheck"
+        }
+      },
+      null,
+      2
+    )
+  );
+  writeFileSync(join(root, "src.ts"), "export const value = 1;\n");
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "init"], { cwd: root });
+  writeFileSync(join(root, "src.ts"), "export const value = 2;\n");
+  return root;
+}
+
 function createFixtureRepo(): string {
   return createGitFixture("agentops-cli-");
 }
@@ -853,6 +884,51 @@ describe("cli smoke flows", () => {
     expect(explanation.artifactKinds).toContain("implementation-proposal");
   });
 
+  it("allows bounded implementation validation commands in a generic repo when the package manager is unknown", async () => {
+    const root = createGitFixtureWithoutLockfile("agentops-cli-implementation-generic-");
+    initProject(root);
+    expect(scanProject(root).packageManager).toBe("unknown");
+    mkdirSync(join(root, ".agentops", "requests"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Plan the first workflow wedge",
+        "goals:",
+        "  - Produce a planning brief",
+        "constraints:",
+        "  - Keep the workflow local-first"
+      ].join("\n")
+    );
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "design.yaml"),
+      [
+        `planningBriefRef: .agentops/runs/${planningRun.runId}/bundle.json`,
+        "decisionTarget: Choose the first design workflow implementation shape",
+        "pathHints:",
+        "  - package.json",
+        "  - .agentops/policy.yaml",
+        "alternatives:",
+        "  - single-workflow-pass"
+      ].join("\n")
+    );
+    const designRun = await runLocalWorkflow("architecture-design-review", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        `designRecordRef: .agentops/runs/${designRun.runId}/bundle.json`,
+        "implementationGoal: Prepare the next bounded implementation proposal",
+        "approvalMode: proposal-only",
+        "validationCommands:",
+        "  - pnpm test"
+      ].join("\n")
+    );
+
+    const implementationRun = await runLocalWorkflow("implementation-proposal", root);
+    expect(implementationRun.status).toBe("success");
+    expect(implementationRun.artifactKinds).toContain("implementation-proposal");
+  });
+
   it("runs qa-review after a valid implementation-proposal handoff", async () => {
     const root = createGitFixture("agentops-qa-");
 
@@ -1041,6 +1117,67 @@ describe("cli smoke flows", () => {
     expect(bundle.lifecycleArtifacts[0]?.payload?.releaseImpact).toContain(
       "GitHub Actions evidence still shows failing checks: CI / lint."
     );
+  });
+
+  it("allows bounded QA executed checks in a generic repo when the package manager is unknown", async () => {
+    const root = createGitFixtureWithoutLockfile("agentops-qa-generic-");
+    initProject(root);
+    expect(scanProject(root).packageManager).toBe("unknown");
+
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Plan a bounded QA workflow handoff",
+        "goals:",
+        "  - Produce a planning brief for the QA workflow",
+        "constraints:",
+        "  - Keep the workflow local-first",
+        "  - Keep the workflow read-only by default"
+      ].join("\n")
+    );
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "design.yaml"),
+      [
+        `planningBriefRef: .agentops/runs/${planningRun.runId}/bundle.json`,
+        "decisionTarget: Choose the first QA workflow implementation shape",
+        "pathHints:",
+        "  - package.json",
+        "  - .agentops/policy.yaml",
+        "alternatives:",
+        "  - single-pass-qa"
+      ].join("\n")
+    );
+    const designRun = await runLocalWorkflow("architecture-design-review", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        `designRecordRef: .agentops/runs/${designRun.runId}/bundle.json`,
+        "implementationGoal: Prepare the next bounded implementation proposal",
+        "approvalMode: proposal-only",
+        "validationCommands:",
+        "  - pnpm test"
+      ].join("\n")
+    );
+    const implementationRun = await runLocalWorkflow("implementation-proposal", root);
+
+    writeFileSync(
+      join(root, ".agentops", "requests", "qa.yaml"),
+      [
+        `targetRef: .agentops/runs/${implementationRun.runId}/bundle.json`,
+        "evidenceSources:",
+        `  - .agentops/runs/${implementationRun.runId}/summary.md`,
+        "executedChecks:",
+        "  - pnpm test",
+        "focusAreas:",
+        "  - coverage",
+        "releaseContext: candidate"
+      ].join("\n")
+    );
+
+    const qaRun = await runLocalWorkflow("qa-review", root);
+    expect(qaRun.status).toBe("success");
+    expect(qaRun.artifactKinds).toContain("qa-report");
   });
 
   it("rejects underspecified qa-review requests before reasoning", async () => {

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -176,6 +176,7 @@ function resolveWorkspacePackage(root: string | undefined, packageName: string):
 }
 
 const allowedValidationScriptNames = new Set(["test", "lint", "typecheck", "build", "build:packages", "release:verify"]);
+const fallbackValidationPackageManagers = ["pnpm", "npm", "yarn"] as const;
 
 function normalizeRequestedCommand(command: string): string {
   return command.trim().replace(/\s+/g, " ");
@@ -193,6 +194,18 @@ function buildValidationCommand(
   return `${packageManager} ${scriptName}`;
 }
 
+function resolveValidationCommandManagers(
+  packageManager: string,
+  packageName?: string
+): readonly string[] {
+  if (packageManager !== "unknown") {
+    return [packageManager];
+  }
+
+  // Generic repos without lockfiles still need deterministic command matching for bounded root scripts.
+  return packageName ? ["pnpm"] : fallbackValidationPackageManagers;
+}
+
 function collectValidationCommands(
   repoRoot: string | undefined,
   packageManager: string,
@@ -202,15 +215,17 @@ function collectValidationCommands(
   const registerScripts = (packageJsonPath: string, source: "package-script" | "workspace-script", packageName?: string) => {
     const scripts = parsePackageScripts(packageJsonPath);
     for (const scriptName of Object.keys(scripts)) {
-      const command = buildValidationCommand(packageManager, scriptName, packageName);
-      discoveredValidationCommands.push({
-        command,
-        source,
-        classification: allowedValidationScriptNames.has(scriptName) ? "approval_required" : "deny",
-        reason: allowedValidationScriptNames.has(scriptName)
-          ? "Discovered from a bounded repository script; execution would still require approval."
-          : "Command is not in the bounded allowlist for workflow validation."
-      });
+      for (const commandPackageManager of resolveValidationCommandManagers(packageManager, packageName)) {
+        const command = buildValidationCommand(commandPackageManager, scriptName, packageName);
+        discoveredValidationCommands.push({
+          command,
+          source,
+          classification: allowedValidationScriptNames.has(scriptName) ? "approval_required" : "deny",
+          reason: allowedValidationScriptNames.has(scriptName)
+            ? "Discovered from a bounded repository script; execution would still require approval."
+            : "Command is not in the bounded allowlist for workflow validation."
+        });
+      }
     }
   };
 

--- a/packages/context-engine/src/index.test.ts
+++ b/packages/context-engine/src/index.test.ts
@@ -39,6 +39,12 @@ describe("context engine", () => {
     expect(detectPackageManager(root)).toBe("pnpm");
   });
 
+  it("detects the package manager from package.json metadata when lockfiles are absent", () => {
+    const root = mkdtempSync(join(tmpdir(), "agentops-context-package-manager-"));
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "fixture", packageManager: "pnpm@9.1.0" }));
+    expect(detectPackageManager(root)).toBe("pnpm");
+  });
+
   it("creates workflow state from a git repo", () => {
     const root = mkdtempSync(join(tmpdir(), "agentops-state-"));
     execFileSync("git", ["init"], { cwd: root });

--- a/packages/context-engine/src/index.ts
+++ b/packages/context-engine/src/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { basename } from "node:path";
 import { execFileSync } from "node:child_process";
 
@@ -36,6 +36,19 @@ export function detectPackageManager(root: string): string {
   if (existsSync(`${root}/pnpm-lock.yaml`)) return "pnpm";
   if (existsSync(`${root}/package-lock.json`)) return "npm";
   if (existsSync(`${root}/yarn.lock`)) return "yarn";
+  if (existsSync(`${root}/package.json`)) {
+    try {
+      const parsed = JSON.parse(readFileSync(`${root}/package.json`, "utf8")) as { packageManager?: unknown };
+      if (typeof parsed.packageManager === "string") {
+        const normalized = parsed.packageManager.split("@")[0]?.trim();
+        if (normalized === "pnpm" || normalized === "npm" || normalized === "yarn") {
+          return normalized;
+        }
+      }
+    } catch {
+      // Fall through to the bounded unknown fallback when package.json is absent or malformed.
+    }
+  }
   return "unknown";
 }
 


### PR DESCRIPTION
## Summary
- align published `0.9.0` docs with the now-published preset startup and quick path
- accept bounded root-package validation commands in generic repos even when `scan --json` still reports `packageManager: "unknown"`
- add focused tests for package-manager metadata detection plus generic implementation and QA validation flows

## Validation
- `pnpm exec vitest run packages/context-engine/src/index.test.ts packages/cli/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`
- local clean generic-repo smoke run through `planning-discovery`, `implementation-proposal`, and `qa-review`

Closes #197