### PR TITLE
Add GitLab SCM and CI normalization wedge

### DIFF
--- a/docs/GITHUB_INTEGRATION_MATURITY.md
+++ b/docs/GITHUB_INTEGRATION_MATURITY.md
@@ -97,7 +97,7 @@ Adapter expectations:
 
 GitHub is the first mature integration target because it already anchors planning and release.
 
-The host-agnostic SCM/CI contract layer now exists, so GitHub-specific references and Actions evidence should remain a host-specific baseline built on top of shared shapes rather than the shared model itself becoming GitHub-shaped.
+The host-agnostic SCM/CI contract layer now exists and the first non-GitHub host pair is validated through the bounded GitLab wedge, so GitHub-specific references and Actions evidence should remain a host-specific baseline built on top of shared shapes rather than the shared model itself becoming GitHub-shaped.
 
 It should remain:
 
@@ -112,4 +112,4 @@ This epic is now decomposed into:
 1. implemented: GitHub issue/PR reference and status normalization shared across lifecycle workflows
 2. implemented in part: bounded GitHub handoff rendering for planning, design, QA, and release artifacts
 3. implemented in part: deterministic GitHub Actions evidence ingestion for QA plus a shared normalization contract for later release workflows
-4. ongoing: support-matrix and policy guidance for GitHub-specific versus host-agnostic behavior
+4. ongoing: support-matrix and policy guidance for GitHub-specific versus host-agnostic behavior now that GitLab normalization also exists

--- a/docs/SCM_CI_INTEGRATIONS_ROADMAP.md
+++ b/docs/SCM_CI_INTEGRATIONS_ROADMAP.md
@@ -4,7 +4,7 @@ This document defines the design target for issue [#64](https://github.com/H9-Fo
 
 It describes how AgentForge should expand beyond the current GitHub-centric baseline without promising broad integration support prematurely.
 
-It does **not** claim that additional SCM or CI integrations are implemented today.
+It does **not** claim that broad cross-platform SCM or CI support is implemented today.
 
 ## Why This Exists
 
@@ -29,17 +29,19 @@ Available now:
 - narrow GitHub integration for planning/release/process work
 - GitHub-hosted validation and release automation
 
-Not yet available:
-
-- additional SCM host adapters
-- additional CI evidence adapters
-- host-agnostic workflow surfaces across multiple providers
-
 Implemented now:
 
 - host-agnostic SCM reference contracts
 - host-agnostic CI evidence contracts
 - adapter capability metadata for bounded host behavior
+- bounded GitLab issue and merge-request normalization into the shared SCM contract
+- bounded local GitLab CI evidence normalization into the shared CI contract
+
+Not yet available:
+
+- additional generic CI evidence adapters beyond the GitHub and GitLab wedges
+- broad host-agnostic workflow surfaces across multiple providers
+- live remote SCM or CI reads on the default local path
 
 ## Recommended Priority Order
 
@@ -57,7 +59,9 @@ This keeps future adapters from inventing incompatible contracts.
 
 ### Priority 2: One Additional SCM/CI Pair
 
-The first additional target should validate the host-agnostic model with one concrete ecosystem, likely:
+Status: implemented as the first concrete non-GitHub host pair.
+
+The first additional target validates the host-agnostic model with one concrete ecosystem:
 
 - GitLab SCM plus GitLab CI
 
@@ -109,5 +113,5 @@ Additional SCM/CI work should:
 This epic should be decomposed into at least:
 
 1. host-agnostic SCM and CI reference contracts plus adapter capability metadata
-2. GitLab issue/MR and CI evidence integration wedge as the first additional concrete host
-3. generic CI evidence adapter surface for bounded pipeline status and artifact ingestion
+2. implemented: GitLab issue/MR and CI evidence integration wedge as the first additional concrete host pair
+3. next: generic CI evidence adapter surface for bounded pipeline status and artifact ingestion

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -9,7 +9,7 @@ import { schemaFixtures } from "@h9-foundry/agentforge-schemas";
 
 import { compareLocalEvalRuns, explainLastRun, initProject, mapWorkflowRunStatusToGitHubStatus, runLocalEval, runLocalWorkflow, scanProject } from "./index.js";
 
-function createGitFixture(prefix: string): string {
+function createGitFixture(prefix: string, repositoryUrl = "https://github.com/H9-Foundry/fixture.git"): string {
   const root = mkdtempSync(join(tmpdir(), prefix));
   execFileSync("git", ["init"], { cwd: root });
   execFileSync("git", ["config", "user.email", "test@example.com"], { cwd: root });
@@ -21,7 +21,7 @@ function createGitFixture(prefix: string): string {
         name: "fixture",
         repository: {
           type: "git",
-          url: "https://github.com/H9-Foundry/fixture.git"
+          url: repositoryUrl
         },
         scripts: {
           test: "echo test",
@@ -39,6 +39,14 @@ function createGitFixture(prefix: string): string {
   execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "-m", "init"], { cwd: root });
   writeFileSync(join(root, "src.ts"), "export const value = 2;\n");
   return root;
+}
+
+function createGitLabFixture(prefix: string): string {
+  return createGitFixture(prefix, "https://gitlab.com/h9-foundry/platform/fixture.git");
+}
+
+function createGenericHostFixture(prefix: string): string {
+  return createGitFixture(prefix, "https://example.com/acme/fixture.git");
 }
 
 function createGitFixtureWithoutLockfile(prefix: string): string {
@@ -1119,6 +1127,77 @@ describe("cli smoke flows", () => {
     );
   });
 
+  it("ingests bounded local GitLab CI evidence exports during qa-review", async () => {
+    const root = createGitLabFixture("agentops-qa-gitlab-ci-");
+
+    initProject(root);
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "evidence", "gitlab-ci.json"),
+      JSON.stringify(
+        {
+          host: "gitlab.com",
+          projectPath: "h9-foundry/platform/fixture",
+          pipelineId: 98765,
+          pipelineName: "GitLab CI",
+          runAttempt: 1,
+          event: "merge_request_event",
+          branch: "main",
+          commitSha: "abc123",
+          status: "failed",
+          webUrl: "https://gitlab.com/h9-foundry/platform/fixture/-/pipelines/98765",
+          jobs: [
+            {
+              name: "test",
+              status: "success",
+              webUrl: "https://gitlab.com/h9-foundry/platform/fixture/-/jobs/1"
+            },
+            {
+              name: "lint",
+              status: "failed",
+              webUrl: "https://gitlab.com/h9-foundry/platform/fixture/-/jobs/2"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+
+    writeFileSync(
+      join(root, ".agentops", "requests", "qa.yaml"),
+      [
+        "targetRef: package.json",
+        "evidenceSources:",
+        "  - .agentops/evidence/gitlab-ci.json",
+        "executedChecks:",
+        "  - pnpm test",
+        "focusAreas:",
+        "  - release-readiness",
+        "releaseContext: candidate"
+      ].join("\n")
+    );
+
+    const qaRun = await runLocalWorkflow("qa-review", root);
+    const bundle = readJson<{
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: { coverageGaps?: string[]; recommendedNextChecks?: string[]; releaseImpact?: string };
+      }>;
+    }>(qaRun.jsonPath);
+
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("qa-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.coverageGaps).toContain(
+      "Imported CI evidence still reports a failing check that needs manual review: GitLab CI / lint"
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.recommendedNextChecks).toContain(
+      "Review the imported CI evidence for pipeline `GitLab CI` before promotion."
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.releaseImpact).toContain(
+      "Imported CI evidence still shows failing checks: GitLab CI / lint."
+    );
+  });
+
   it("allows bounded QA executed checks in a generic repo when the package manager is unknown", async () => {
     const root = createGitFixtureWithoutLockfile("agentops-qa-generic-");
     initProject(root);
@@ -2151,5 +2230,120 @@ describe("cli smoke flows", () => {
     for (const bundle of [planningBundle, designBundle, implementationBundle, qaBundle, securityBundle]) {
       expect(bundle.lifecycleArtifacts[0]?.source.githubRefs?.map((entry) => entry.canonical)).toContain("H9-Foundry/fixture#142");
     }
+  });
+
+  it("propagates normalized GitLab SCM references through downstream lifecycle artifacts without creating GitHub refs", async () => {
+    const root = createGitLabFixture("agentops-gitlab-refs-");
+    initProject(root);
+    mkdirSync(join(root, ".agentops", "requests"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Plan the GitLab normalization slice",
+        "goals:",
+        "  - Produce one planning brief",
+        "issueRefs:",
+        "  - '#123'",
+        "  - '!45'",
+        "  - 'https://gitlab.com/h9-foundry/platform/fixture/-/issues/77'",
+        "  - 'https://gitlab.com/h9-foundry/platform/fixture/-/merge_requests/88'",
+        "pathHints:",
+        "  - packages/cli",
+        "  - packages/schemas"
+      ].join("\n")
+    );
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "design.yaml"),
+      [
+        `planningBriefRef: .agentops/runs/${planningRun.runId}/bundle.json`,
+        "decisionTarget: Design GitLab reference normalization",
+        "pathHints:",
+        "  - packages/cli"
+      ].join("\n")
+    );
+    const designRun = await runLocalWorkflow("architecture-design-review", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "implementation.yaml"),
+      [
+        `designRecordRef: .agentops/runs/${designRun.runId}/bundle.json`,
+        "implementationGoal: Implement GitLab reference normalization",
+        "approvalMode: proposal-only",
+        "targetPaths:",
+        "  - packages/cli",
+        "constraints:",
+        "  - Keep the default path read-only"
+      ].join("\n")
+    );
+    const implementationRun = await runLocalWorkflow("implementation-proposal", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "qa.yaml"),
+      [
+        `targetRef: .agentops/runs/${implementationRun.runId}/bundle.json`,
+        "evidenceSources:",
+        `  - .agentops/runs/${implementationRun.runId}/summary.md`,
+        "focusAreas:",
+        "  - regression-risk"
+      ].join("\n")
+    );
+    const qaRun = await runLocalWorkflow("qa-review", root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "security.yaml"),
+      [
+        `targetRef: .agentops/runs/${qaRun.runId}/bundle.json`,
+        "evidenceSources:",
+        `  - .agentops/runs/${qaRun.runId}/summary.md`,
+        "focusAreas:",
+        "  - dependency-risk",
+        "releaseContext: candidate"
+      ].join("\n")
+    );
+    const securityRun = await runLocalWorkflow("security-review", root);
+
+    const expectedCanonicals = [
+      "gitlab.com/h9-foundry/platform/fixture#123",
+      "gitlab.com/h9-foundry/platform/fixture!45",
+      "gitlab.com/h9-foundry/platform/fixture#77",
+      "gitlab.com/h9-foundry/platform/fixture!88"
+    ];
+    const bundles = [
+      readJson<{ lifecycleArtifacts: Array<{ source: { scmRefs?: Array<{ canonical: string }>; githubRefs?: Array<{ canonical: string }> } }> }>(planningRun.jsonPath),
+      readJson<{ lifecycleArtifacts: Array<{ source: { scmRefs?: Array<{ canonical: string }>; githubRefs?: Array<{ canonical: string }> } }> }>(designRun.jsonPath),
+      readJson<{ lifecycleArtifacts: Array<{ source: { scmRefs?: Array<{ canonical: string }>; githubRefs?: Array<{ canonical: string }> } }> }>(implementationRun.jsonPath),
+      readJson<{ lifecycleArtifacts: Array<{ source: { scmRefs?: Array<{ canonical: string }>; githubRefs?: Array<{ canonical: string }> } }> }>(qaRun.jsonPath),
+      readJson<{ lifecycleArtifacts: Array<{ source: { scmRefs?: Array<{ canonical: string }>; githubRefs?: Array<{ canonical: string }> } }> }>(securityRun.jsonPath)
+    ];
+
+    for (const bundle of bundles) {
+      expect(bundle.lifecycleArtifacts[0]?.source.scmRefs?.map((entry) => entry.canonical)).toEqual(
+        expect.arrayContaining(expectedCanonicals)
+      );
+      expect(bundle.lifecycleArtifacts[0]?.source.githubRefs ?? []).toEqual([]);
+    }
+  });
+
+  it("does not infer GitLab merge request shorthand outside a GitLab repo context", async () => {
+    const root = createGenericHostFixture("agentops-generic-refs-");
+    initProject(root);
+    writeFileSync(
+      join(root, ".agentops", "requests", "planning.yaml"),
+      [
+        "problemStatement: Confirm host-specific shorthand remains bounded",
+        "goals:",
+        "  - Produce one planning brief",
+        "issueRefs:",
+        "  - '!45'",
+        "pathHints:",
+        "  - packages/cli"
+      ].join("\n")
+    );
+
+    const planningRun = await runLocalWorkflow("planning-discovery", root);
+    const planningBundle = readJson<{
+      lifecycleArtifacts: Array<{ source: { scmRefs?: Array<{ canonical: string }>; githubRefs?: Array<{ canonical: string }> } }>;
+    }>(planningRun.jsonPath);
+
+    expect(planningBundle.lifecycleArtifacts[0]?.source.scmRefs ?? []).toEqual([]);
+    expect(planningBundle.lifecycleArtifacts[0]?.source.githubRefs ?? []).toEqual([]);
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -49,6 +49,7 @@ import type {
   PlanningRequest,
   QaRequest,
   ReleaseRequest,
+  ScmReference,
   SecurityRequest,
   WorkflowDefinition
 } from "@h9-foundry/agentforge-shared-types";
@@ -398,6 +399,17 @@ interface GitHubRepoContext {
   repo: string;
 }
 
+interface GitLabRepoContext {
+  host: string;
+  namespace: string;
+  repo: string;
+}
+
+type ScmRepoContext =
+  | ({ platform: "github" } & GitHubRepoContext)
+  | ({ platform: "gitlab" } & GitLabRepoContext)
+  | { platform: "generic"; host: string; namespace: string; repo: string };
+
 function runGit(root: string, args: string[]): string {
   try {
     return execFileSync("git", args, { cwd: root, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
@@ -406,26 +418,103 @@ function runGit(root: string, args: string[]): string {
   }
 }
 
-function parseGitHubRepositoryUrl(value: string): GitHubRepoContext | undefined {
+function inferScmPlatform(host: string): "github" | "gitlab" | "generic" {
+  const normalizedHost = host.toLowerCase();
+  if (normalizedHost.includes("github")) {
+    return "github";
+  }
+
+  if (normalizedHost.includes("gitlab")) {
+    return "gitlab";
+  }
+
+  return "generic";
+}
+
+function parseScmRepositoryUrl(value: string): ScmRepoContext | undefined {
   const trimmed = value.trim();
-  const sshMatch = trimmed.match(/^git@([^:]+):([^/]+)\/([^/]+?)(?:\.git)?$/i);
+  const sshMatch = trimmed.match(/^git@([^:]+):(.+?)(?:\.git)?$/i);
   if (sshMatch) {
+    const host = sshMatch[1].toLowerCase();
+    const pathSegments = sshMatch[2].split("/").filter(Boolean);
+    if (pathSegments.length < 2) {
+      return undefined;
+    }
+
+    const repo = pathSegments[pathSegments.length - 1] ?? "";
+    const namespace = pathSegments.slice(0, -1).join("/");
+    const platform = inferScmPlatform(host);
+    if (platform === "github") {
+      return {
+        platform,
+        host,
+        owner: namespace,
+        repo
+      };
+    }
+
     return {
-      host: sshMatch[1].toLowerCase(),
-      owner: sshMatch[2],
-      repo: sshMatch[3]
+      platform,
+      host,
+      namespace,
+      repo
     };
   }
 
-  const httpsMatch = trimmed.match(/^https?:\/\/([^/]+)\/([^/]+)\/([^/]+?)(?:\.git)?(?:\/)?$/i);
+  const httpsMatch = trimmed.match(/^https?:\/\/([^/]+)\/(.+?)(?:\.git)?(?:\/)?$/i);
   if (!httpsMatch) {
     return undefined;
   }
 
+  const host = httpsMatch[1].toLowerCase();
+  const pathSegments = httpsMatch[2].split("/").filter(Boolean);
+  if (pathSegments.length < 2) {
+    return undefined;
+  }
+
+  const repo = pathSegments[pathSegments.length - 1] ?? "";
+  const namespace = pathSegments.slice(0, -1).join("/");
+  const platform = inferScmPlatform(host);
+  if (platform === "github") {
+    return {
+      platform,
+      host,
+      owner: namespace,
+      repo
+    };
+  }
+
   return {
-    host: httpsMatch[1].toLowerCase(),
-    owner: httpsMatch[2],
-    repo: httpsMatch[3]
+    platform,
+    host,
+    namespace,
+    repo
+  };
+}
+
+function parseGitHubRepositoryUrl(value: string): GitHubRepoContext | undefined {
+  const parsed = parseScmRepositoryUrl(value);
+  if (!parsed || parsed.platform !== "github") {
+    return undefined;
+  }
+
+  return {
+    host: parsed.host,
+    owner: parsed.owner,
+    repo: parsed.repo
+  };
+}
+
+function parseGitLabRepositoryUrl(value: string): GitLabRepoContext | undefined {
+  const parsed = parseScmRepositoryUrl(value);
+  if (!parsed || parsed.platform !== "gitlab") {
+    return undefined;
+  }
+
+  return {
+    host: parsed.host,
+    namespace: parsed.namespace,
+    repo: parsed.repo
   };
 }
 
@@ -453,6 +542,68 @@ function inferGitHubRepoContext(root: string): GitHubRepoContext | undefined {
 
   const remoteUrl = runGit(root, ["config", "--get", "remote.origin.url"]);
   return remoteUrl ? parseGitHubRepositoryUrl(remoteUrl) : undefined;
+}
+
+function inferGitLabRepoContext(root: string): GitLabRepoContext | undefined {
+  const packageJsonPath = join(root, "package.json");
+  if (existsSync(packageJsonPath)) {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
+    if (isRecord(parsed)) {
+      const repository = parsed.repository;
+      if (typeof repository === "string") {
+        const context = parseGitLabRepositoryUrl(repository);
+        if (context) {
+          return context;
+        }
+      }
+
+      if (isRecord(repository) && typeof repository.url === "string") {
+        const context = parseGitLabRepositoryUrl(repository.url);
+        if (context) {
+          return context;
+        }
+      }
+    }
+  }
+
+  const remoteUrl = runGit(root, ["config", "--get", "remote.origin.url"]);
+  return remoteUrl ? parseGitLabRepositoryUrl(remoteUrl) : undefined;
+}
+
+function inferScmRepoContext(root: string): ScmRepoContext | undefined {
+  const gitHubContext = inferGitHubRepoContext(root);
+  if (gitHubContext) {
+    return { platform: "github", ...gitHubContext };
+  }
+
+  const gitLabContext = inferGitLabRepoContext(root);
+  if (gitLabContext) {
+    return { platform: "gitlab", ...gitLabContext };
+  }
+
+  const packageJsonPath = join(root, "package.json");
+  if (existsSync(packageJsonPath)) {
+    const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as unknown;
+    if (isRecord(parsed)) {
+      const repository = parsed.repository;
+      if (typeof repository === "string") {
+        const context = parseScmRepositoryUrl(repository);
+        if (context) {
+          return context;
+        }
+      }
+
+      if (isRecord(repository) && typeof repository.url === "string") {
+        const context = parseScmRepositoryUrl(repository.url);
+        if (context) {
+          return context;
+        }
+      }
+    }
+  }
+
+  const remoteUrl = runGit(root, ["config", "--get", "remote.origin.url"]);
+  return remoteUrl ? parseScmRepositoryUrl(remoteUrl) : undefined;
 }
 
 function normalizeGitHubReference(rawValue: string, repoContext?: GitHubRepoContext): GithubReference | undefined {
@@ -529,6 +680,110 @@ function normalizeGitHubReferences(rawValues: readonly string[], repoContext?: G
 
     seen.add(githubRef.canonical);
     normalized.push(githubRef);
+  }
+
+  return normalized;
+}
+
+function normalizeGitLabReference(rawValue: string, repoContext?: GitLabRepoContext): ScmReference | undefined {
+  const raw = rawValue.trim();
+  if (!raw) {
+    return undefined;
+  }
+
+  const fromParts = (context: GitLabRepoContext, kind: "issue" | "merge_request", number: number): ScmReference => ({
+    platform: "gitlab",
+    host: context.host,
+    namespace: context.namespace,
+    repo: context.repo,
+    kind,
+    identifier: `${number}`,
+    number,
+    canonical: kind === "issue"
+      ? `${context.host}/${context.namespace}/${context.repo}#${number}`
+      : `${context.host}/${context.namespace}/${context.repo}!${number}`,
+    url: kind === "issue"
+      ? `https://${context.host}/${context.namespace}/${context.repo}/-/issues/${number}`
+      : `https://${context.host}/${context.namespace}/${context.repo}/-/merge_requests/${number}`,
+    source: raw
+  });
+
+  const urlMatch = raw.match(/^https?:\/\/([^/]+)\/(.+?)\/-\/(issues|merge_requests)\/(\d+)(?:\/)?$/i);
+  if (urlMatch) {
+    const pathSegments = urlMatch[2].split("/").filter(Boolean);
+    if (pathSegments.length < 2) {
+      return undefined;
+    }
+
+    const repo = pathSegments[pathSegments.length - 1] ?? "";
+    const namespace = pathSegments.slice(0, -1).join("/");
+    return fromParts(
+      { host: urlMatch[1].toLowerCase(), namespace, repo },
+      urlMatch[3].toLowerCase() === "merge_requests" ? "merge_request" : "issue",
+      Number.parseInt(urlMatch[4], 10)
+    );
+  }
+
+  const shortIssueMatch = raw.match(/^#(\d+)$/);
+  if (shortIssueMatch && repoContext) {
+    return fromParts(repoContext, "issue", Number.parseInt(shortIssueMatch[1], 10));
+  }
+
+  const shortMergeRequestMatch = raw.match(/^!(\d+)$/);
+  if (shortMergeRequestMatch && repoContext) {
+    return fromParts(repoContext, "merge_request", Number.parseInt(shortMergeRequestMatch[1], 10));
+  }
+
+  return undefined;
+}
+
+function normalizeScmReference(rawValue: string, repoContext?: ScmRepoContext): ScmReference | undefined {
+  const raw = rawValue.trim();
+  if (!raw) {
+    return undefined;
+  }
+
+  const gitHubRef = normalizeGitHubReference(
+    raw,
+    repoContext?.platform === "github"
+      ? { host: repoContext.host, owner: repoContext.owner, repo: repoContext.repo }
+      : undefined
+  );
+  if (gitHubRef) {
+    return {
+      platform: "github",
+      host: gitHubRef.host,
+      namespace: gitHubRef.owner,
+      repo: gitHubRef.repo,
+      kind: gitHubRef.kind,
+      identifier: `${gitHubRef.number}`,
+      number: gitHubRef.number,
+      canonical: `${gitHubRef.host}/${gitHubRef.owner}/${gitHubRef.repo}${gitHubRef.kind === "issue" ? `#${gitHubRef.number}` : `/pull/${gitHubRef.number}`}`,
+      url: gitHubRef.url,
+      source: gitHubRef.source
+    };
+  }
+
+  return normalizeGitLabReference(
+    raw,
+    repoContext?.platform === "gitlab"
+      ? { host: repoContext.host, namespace: repoContext.namespace, repo: repoContext.repo }
+      : undefined
+  );
+}
+
+function normalizeScmReferences(rawValues: readonly string[], repoContext?: ScmRepoContext): ScmReference[] {
+  const seen = new Set<string>();
+  const normalized: ScmReference[] = [];
+
+  for (const rawValue of rawValues) {
+    const scmRef = normalizeScmReference(rawValue, repoContext);
+    if (!scmRef || seen.has(scmRef.canonical)) {
+      continue;
+    }
+
+    seen.add(scmRef.canonical);
+    normalized.push(scmRef);
   }
 
   return normalized;
@@ -718,15 +973,17 @@ function loadLifecycleArtifactKinds(root: string, bundleRef: string): string[] {
 function loadLifecycleArtifactSourceReferences(
   root: string,
   bundleRef: string
-): { issueRefs: string[]; githubRefs: GithubReference[] } {
+): { issueRefs: string[]; scmRefs: ScmReference[]; githubRefs: GithubReference[] } {
   const bundlePath = join(root, bundleRef);
   if (!existsSync(bundlePath)) {
     throw new Error(`Referenced bundle not found: ${bundleRef}`);
   }
 
   const bundle = auditBundleSchema.parse(JSON.parse(readFileSync(bundlePath, "utf8")) as unknown);
-  const repoContext = inferGitHubRepoContext(root);
+  const scmRepoContext = inferScmRepoContext(root);
+  const gitHubRepoContext = inferGitHubRepoContext(root);
   const issueRefs = new Set<string>();
+  const scmRefs = new Map<string, ScmReference>();
   const githubRefs = new Map<string, GithubReference>();
 
   for (const artifact of bundle.lifecycleArtifacts) {
@@ -734,17 +991,26 @@ function loadLifecycleArtifactSourceReferences(
       issueRefs.add(issueRef);
     }
 
+    for (const scmRef of artifact.source.scmRefs ?? []) {
+      scmRefs.set(scmRef.canonical, scmRef);
+    }
+
     for (const githubRef of artifact.source.githubRefs ?? []) {
       githubRefs.set(githubRef.canonical, githubRef);
     }
 
-    for (const githubRef of normalizeGitHubReferences(artifact.source.issueRefs, repoContext)) {
+    for (const scmRef of normalizeScmReferences(artifact.source.issueRefs, scmRepoContext)) {
+      scmRefs.set(scmRef.canonical, scmRef);
+    }
+
+    for (const githubRef of normalizeGitHubReferences(artifact.source.issueRefs, gitHubRepoContext)) {
       githubRefs.set(githubRef.canonical, githubRef);
     }
   }
 
   return {
     issueRefs: [...issueRefs],
+    scmRefs: [...scmRefs.values()],
     githubRefs: [...githubRefs.values()]
   };
 }
@@ -763,10 +1029,12 @@ function prepareWorkflowInputs(
     const planningRequest = validatePlanningRequestCompleteness(
       readYamlFile(join(root, requestPath), planningRequestSchema, "planning request")
     );
+    const planningScmRefs = normalizeScmReferences(planningRequest.issueRefs, inferScmRepoContext(root));
     const planningGithubRefs = normalizeGitHubReferences(planningRequest.issueRefs, inferGitHubRepoContext(root));
 
     return {
       planningRequest,
+      planningScmRefs,
       planningGithubRefs,
       requestFile: requestPath
     };
@@ -814,11 +1082,12 @@ function prepareWorkflowInputs(
 
     const referencedSourceRefs = qaRequest.targetRef.endsWith("bundle.json")
       ? loadLifecycleArtifactSourceReferences(root, qaRequest.targetRef)
-      : { issueRefs: [], githubRefs: [] };
+      : { issueRefs: [], scmRefs: [], githubRefs: [] };
 
     return {
       qaRequest: qaRequest satisfies QaRequest,
       qaIssueRefs: referencedSourceRefs.issueRefs,
+      qaScmRefs: referencedSourceRefs.scmRefs,
       qaGithubRefs: referencedSourceRefs.githubRefs,
       requestFile: requestPath
     };
@@ -848,12 +1117,13 @@ function prepareWorkflowInputs(
 
     const referencedSourceRefs = securityRequest.targetRef.endsWith("bundle.json")
       ? loadLifecycleArtifactSourceReferences(root, securityRequest.targetRef)
-      : { issueRefs: [], githubRefs: [] };
+      : { issueRefs: [], scmRefs: [], githubRefs: [] };
 
     return {
       securityRequest: securityRequest satisfies SecurityRequest,
       securityTargetArtifactKinds: referencedArtifactKinds,
       securityIssueRefs: referencedSourceRefs.issueRefs,
+      securityScmRefs: referencedSourceRefs.scmRefs,
       securityGithubRefs: referencedSourceRefs.githubRefs,
       requestFile: requestPath
     };
@@ -867,6 +1137,7 @@ function prepareWorkflowInputs(
     );
 
     const releaseIssueRefs = new Set<string>();
+    const releaseScmRefMap = new Map<string, ScmReference>();
     const releaseGithubRefMap = new Map<string, GithubReference>();
     for (const qaReportRef of releaseRequest.qaReportRefs) {
       ensureReadablePath(policyEngine, qaReportRef, "QA report reference");
@@ -874,6 +1145,9 @@ function prepareWorkflowInputs(
       const refs = loadLifecycleArtifactSourceReferences(root, qaReportRef);
       for (const issueRef of refs.issueRefs) {
         releaseIssueRefs.add(issueRef);
+      }
+      for (const scmRef of refs.scmRefs) {
+        releaseScmRefMap.set(scmRef.canonical, scmRef);
       }
       for (const githubRef of refs.githubRefs) {
         releaseGithubRefMap.set(githubRef.canonical, githubRef);
@@ -886,6 +1160,9 @@ function prepareWorkflowInputs(
       const refs = loadLifecycleArtifactSourceReferences(root, securityReportRef);
       for (const issueRef of refs.issueRefs) {
         releaseIssueRefs.add(issueRef);
+      }
+      for (const scmRef of refs.scmRefs) {
+        releaseScmRefMap.set(scmRef.canonical, scmRef);
       }
       for (const githubRef of refs.githubRefs) {
         releaseGithubRefMap.set(githubRef.canonical, githubRef);
@@ -902,6 +1179,7 @@ function prepareWorkflowInputs(
     return {
       releaseRequest: releaseRequest satisfies ReleaseRequest,
       releaseIssueRefs: [...releaseIssueRefs],
+      releaseScmRefs: [...releaseScmRefMap.values()],
       releaseGithubRefs: [...releaseGithubRefMap.values()],
       requestFile: requestPath
     };
@@ -914,10 +1192,15 @@ function prepareWorkflowInputs(
       readYamlFile(join(root, requestPath), incidentRequestSchema, "incident request")
     );
 
-    const repoContext = inferGitHubRepoContext(root);
+    const scmRepoContext = inferScmRepoContext(root);
+    const gitHubRepoContext = inferGitHubRepoContext(root);
     const incidentIssueRefs = new Set<string>(incidentRequest.issueRefs);
+    const incidentScmRefMap = new Map<string, ScmReference>();
     const incidentGithubRefMap = new Map<string, GithubReference>();
-    for (const githubRef of normalizeGitHubReferences(incidentRequest.issueRefs, repoContext)) {
+    for (const scmRef of normalizeScmReferences(incidentRequest.issueRefs, scmRepoContext)) {
+      incidentScmRefMap.set(scmRef.canonical, scmRef);
+    }
+    for (const githubRef of normalizeGitHubReferences(incidentRequest.issueRefs, gitHubRepoContext)) {
       incidentGithubRefMap.set(githubRef.canonical, githubRef);
     }
 
@@ -927,6 +1210,9 @@ function prepareWorkflowInputs(
       const refs = loadLifecycleArtifactSourceReferences(root, releaseReportRef);
       for (const issueRef of refs.issueRefs) {
         incidentIssueRefs.add(issueRef);
+      }
+      for (const scmRef of refs.scmRefs) {
+        incidentScmRefMap.set(scmRef.canonical, scmRef);
       }
       for (const githubRef of refs.githubRefs) {
         incidentGithubRefMap.set(githubRef.canonical, githubRef);
@@ -943,6 +1229,7 @@ function prepareWorkflowInputs(
     return {
       incidentRequest: incidentRequest satisfies IncidentRequest,
       incidentIssueRefs: [...incidentIssueRefs],
+      incidentScmRefs: [...incidentScmRefMap.values()],
       incidentGithubRefs: [...incidentGithubRefMap.values()],
       requestFile: requestPath
     };
@@ -955,10 +1242,15 @@ function prepareWorkflowInputs(
       readYamlFile(join(root, requestPath), maintenanceRequestSchema, "maintenance request")
     );
 
-    const repoContext = inferGitHubRepoContext(root);
+    const scmRepoContext = inferScmRepoContext(root);
+    const gitHubRepoContext = inferGitHubRepoContext(root);
     const maintenanceIssueRefs = new Set<string>(maintenanceRequest.issueRefs);
+    const maintenanceScmRefMap = new Map<string, ScmReference>();
     const maintenanceGithubRefMap = new Map<string, GithubReference>();
-    for (const githubRef of normalizeGitHubReferences(maintenanceRequest.issueRefs, repoContext)) {
+    for (const scmRef of normalizeScmReferences(maintenanceRequest.issueRefs, scmRepoContext)) {
+      maintenanceScmRefMap.set(scmRef.canonical, scmRef);
+    }
+    for (const githubRef of normalizeGitHubReferences(maintenanceRequest.issueRefs, gitHubRepoContext)) {
       maintenanceGithubRefMap.set(githubRef.canonical, githubRef);
     }
 
@@ -968,6 +1260,9 @@ function prepareWorkflowInputs(
       const refs = loadLifecycleArtifactSourceReferences(root, releaseReportRef);
       for (const issueRef of refs.issueRefs) {
         maintenanceIssueRefs.add(issueRef);
+      }
+      for (const scmRef of refs.scmRefs) {
+        maintenanceScmRefMap.set(scmRef.canonical, scmRef);
       }
       for (const githubRef of refs.githubRefs) {
         maintenanceGithubRefMap.set(githubRef.canonical, githubRef);
@@ -991,6 +1286,7 @@ function prepareWorkflowInputs(
     return {
       maintenanceRequest: maintenanceRequest satisfies MaintenanceRequest,
       maintenanceIssueRefs: [...maintenanceIssueRefs],
+      maintenanceScmRefs: [...maintenanceScmRefMap.values()],
       maintenanceGithubRefs: [...maintenanceGithubRefMap.values()],
       requestFile: requestPath
     };

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -4,8 +4,10 @@ import { join } from "node:path";
 import {
   agentManifestSchema,
   agentOutputSchema,
+  ciEvidenceSchema,
   designArtifactSchema,
   githubActionsEvidenceSchema,
+  gitlabCiEvidenceExportSchema,
   implementationArtifactSchema,
   implementationInventorySchema,
   incidentArtifactSchema,
@@ -28,11 +30,13 @@ import {
 } from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 import type {
+  CiEvidence,
   DesignArtifact,
   DesignRequest,
   GithubActionsEvidence,
   GithubActionsEvidenceNormalization,
   GithubReference,
+  GitlabCiEvidenceExport,
   ImplementationArtifact,
   ImplementationInventory,
   ImplementationRequest,
@@ -51,6 +55,7 @@ import type {
   ReleaseArtifact,
   ReleaseEvidenceNormalization,
   ReleaseRequest,
+  ScmReference,
   SecurityArtifact,
   SecurityEvidenceNormalization,
   SecurityRequest,
@@ -384,6 +389,96 @@ function normalizeGitHubActionsEvidence(
   };
 }
 
+function loadGitLabCiEvidenceExport(bundlePath: string): GitlabCiEvidenceExport | undefined {
+  if (!existsSync(bundlePath) || !bundlePath.endsWith(".json")) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(readFileSync(bundlePath, "utf8")) as unknown;
+  const candidate = isRecord(parsed) ? { ...parsed, sourcePath: parsed.sourcePath ?? bundlePath } : parsed;
+  const result = gitlabCiEvidenceExportSchema.safeParse(candidate);
+  return result.success ? result.data : undefined;
+}
+
+function mapGitLabCiStatus(status: GitlabCiEvidenceExport["status"]): Pick<CiEvidence, "status" | "conclusion"> {
+  switch (status) {
+    case "pending":
+      return { status: "queued" };
+    case "running":
+      return { status: "in_progress" };
+    case "success":
+      return { status: "completed", conclusion: "success" };
+    case "failed":
+      return { status: "completed", conclusion: "failure" };
+    case "canceled":
+      return { status: "completed", conclusion: "cancelled" };
+    case "skipped":
+      return { status: "completed", conclusion: "skipped" };
+  }
+}
+
+function normalizeGitLabCiEvidence(
+  repoRoot: string | undefined,
+  evidenceSources: readonly string[]
+): CiEvidence[] {
+  return evidenceSources.flatMap((pathValue) => {
+    if (!repoRoot) {
+      return [];
+    }
+
+    const normalized = loadGitLabCiEvidenceExport(join(repoRoot, pathValue));
+    if (!normalized) {
+      return [];
+    }
+
+    const pipelineStatus = mapGitLabCiStatus(normalized.status);
+    const jobs = normalized.jobs.map((job) => {
+      const jobStatus = mapGitLabCiStatus(job.status);
+      return {
+        name: job.name,
+        status: jobStatus.status,
+        conclusion: jobStatus.conclusion,
+        htmlUrl: job.webUrl,
+        startedAt: job.startedAt,
+        completedAt: job.completedAt
+      };
+    });
+
+    const evidence = ciEvidenceSchema.parse({
+      platform: "gitlab-ci",
+      host: normalized.host,
+      repository: normalized.projectPath,
+      pipelineName: normalized.pipelineName,
+      pipelineRunId: `${normalized.pipelineId}`,
+      runAttempt: normalized.runAttempt,
+      event: normalized.event,
+      branch: normalized.branch,
+      commitSha: normalized.commitSha,
+      status: pipelineStatus.status,
+      conclusion: pipelineStatus.conclusion,
+      htmlUrl: normalized.webUrl,
+      jobs,
+      provenanceSource: "local-export"
+    });
+
+    return [evidence];
+  });
+}
+
+function summarizeCiEvidenceFailures(evidence: CiEvidence): string[] {
+  const failedJobs = evidence.jobs
+    .filter((job) => job.status === "completed" && isFailingGitHubActionsConclusion(job.conclusion))
+    .map((job) => `${evidence.pipelineName} / ${job.name}`);
+  const runLevelFailure =
+    failedJobs.length === 0 &&
+      evidence.status === "completed" &&
+      isFailingGitHubActionsConclusion(evidence.conclusion)
+      ? [`${evidence.pipelineName} / pipeline-run`]
+      : [];
+
+  return [...failedJobs, ...runLevelFailure];
+}
+
 function derivePackageScope(pathValue: string): string | undefined {
   const segments = pathValue.split("/").filter(Boolean);
   if (segments.length < 2) {
@@ -417,6 +512,7 @@ function buildLifecycleArtifactEnvelopeBase(
   summary: string,
   inputRefs: readonly string[],
   issueRefs: readonly string[] = [],
+  scmRefs: readonly ScmReference[] = [],
   githubRefs: readonly GithubReference[] = []
 ) {
   return {
@@ -430,6 +526,7 @@ function buildLifecycleArtifactEnvelopeBase(
       runId: state.runId,
       inputRefs: [...inputRefs],
       issueRefs: [...issueRefs],
+      scmRefs: [...scmRefs],
       githubRefs: [...githubRefs]
     },
     status: "complete" as const,
@@ -464,6 +561,7 @@ function buildArtifactEnvelopeBase(
   summary: string,
   inputRefs: readonly string[],
   issueRefs: readonly string[],
+  scmRefs: readonly ScmReference[] = [],
   githubRefs: readonly GithubReference[] = []
 ) {
   return {
@@ -476,6 +574,7 @@ function buildArtifactEnvelopeBase(
       runId: state.runId,
       inputRefs: [...inputRefs],
       issueRefs: [...issueRefs],
+      scmRefs: [...scmRefs],
       githubRefs: [...githubRefs]
     },
     status: "complete" as const,
@@ -605,6 +704,7 @@ const planningAnalystAgent: RuntimeAgent = {
   outputSchema: agentOutputSchema,
   async execute({ state, stateSlice }) {
     const planningRequest = getWorkflowInput<PlanningRequest>(stateSlice, "planningRequest");
+    const planningScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "planningScmRefs") ?? [];
     const planningGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "planningGithubRefs") ?? [];
     const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
     if (!planningRequest) {
@@ -636,6 +736,7 @@ const planningAnalystAgent: RuntimeAgent = {
         summary,
         [requestFile ?? ".agentops/requests/planning.yaml"],
         planningRequest.issueRefs,
+        planningScmRefs,
         planningGithubRefs
       ),
       artifactKind: "planning-brief",
@@ -1278,6 +1379,7 @@ const maintenanceIntakeAgent: RuntimeAgent = {
     const maintenanceRequest = getWorkflowInput<MaintenanceRequest>(stateSlice, "maintenanceRequest");
     const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
     const maintenanceIssueRefs = getWorkflowInput<string[]>(stateSlice, "maintenanceIssueRefs") ?? [];
+    const maintenanceScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "maintenanceScmRefs") ?? [];
     const maintenanceGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "maintenanceGithubRefs") ?? [];
     if (!maintenanceRequest) {
       throw new Error("maintenance-triage requires a validated maintenance request before runtime execution.");
@@ -1299,6 +1401,7 @@ const maintenanceIntakeAgent: RuntimeAgent = {
           issueRefs: [...new Set(maintenanceRequest.issueRefs)]
         }),
         maintenanceIssueRefs,
+        maintenanceScmRefs,
         maintenanceGithubRefs,
         evidenceSourceCount:
           maintenanceRequest.dependencyAlertRefs.length +
@@ -1484,6 +1587,7 @@ const maintenanceAnalystAgent: RuntimeAgent = {
   async execute({ state, stateSlice }) {
     const maintenanceRequest = getWorkflowInput<MaintenanceRequest>(stateSlice, "maintenanceRequest");
     const maintenanceIssueRefs = getWorkflowInput<string[]>(stateSlice, "maintenanceIssueRefs") ?? [];
+    const maintenanceScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "maintenanceScmRefs") ?? [];
     const maintenanceGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "maintenanceGithubRefs") ?? [];
     const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
     if (!maintenanceRequest) {
@@ -1560,6 +1664,7 @@ const maintenanceAnalystAgent: RuntimeAgent = {
         summary,
         [requestFile ?? ".agentops/requests/maintenance.yaml", ...evidenceSources],
         maintenanceIssueRefs,
+        maintenanceScmRefs,
         maintenanceGithubRefs
       ),
       artifactKind: "maintenance-report",
@@ -1660,6 +1765,7 @@ const incidentAnalystAgent: RuntimeAgent = {
     const incidentRequest = getWorkflowInput<IncidentRequest>(stateSlice, "incidentRequest");
     const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
     const incidentIssueRefs = getWorkflowInput<string[]>(stateSlice, "incidentIssueRefs") ?? [];
+    const incidentScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "incidentScmRefs") ?? [];
     const incidentGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "incidentGithubRefs") ?? [];
     if (!incidentRequest) {
       throw new Error("incident-handoff requires validated incident inputs before incident analysis.");
@@ -1709,6 +1815,7 @@ const incidentAnalystAgent: RuntimeAgent = {
         summary,
         [requestFile ?? ".agentops/requests/incident.yaml", ...evidenceSources],
         incidentIssueRefs,
+        incidentScmRefs,
         incidentGithubRefs
       ),
       artifactKind: "incident-brief",
@@ -1807,6 +1914,7 @@ const releaseIntakeAgent: RuntimeAgent = {
   async execute({ stateSlice }) {
     const releaseRequest = getWorkflowInput<ReleaseRequest>(stateSlice, "releaseRequest");
     const releaseIssueRefs = getWorkflowInput<string[]>(stateSlice, "releaseIssueRefs") ?? [];
+    const releaseScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "releaseScmRefs") ?? [];
     const releaseGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "releaseGithubRefs") ?? [];
     const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
     if (!releaseRequest) {
@@ -1823,6 +1931,7 @@ const releaseIntakeAgent: RuntimeAgent = {
       metadata: {
         ...releaseRequestSchema.parse(releaseRequest),
         releaseIssueRefs,
+        releaseScmRefs,
         releaseGithubRefs,
         evidenceSourceCount:
           releaseRequest.qaReportRefs.length + releaseRequest.securityReportRefs.length + releaseRequest.evidenceSources.length
@@ -2047,6 +2156,7 @@ const releaseAnalystAgent: RuntimeAgent = {
   async execute({ state, stateSlice }) {
     const releaseRequest = getWorkflowInput<ReleaseRequest>(stateSlice, "releaseRequest");
     const releaseIssueRefs = getWorkflowInput<string[]>(stateSlice, "releaseIssueRefs") ?? [];
+    const releaseScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "releaseScmRefs") ?? [];
     const releaseGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "releaseGithubRefs") ?? [];
     const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
     if (!releaseRequest) {
@@ -2140,6 +2250,7 @@ const releaseAnalystAgent: RuntimeAgent = {
         summary,
         [requestFile ?? ".agentops/requests/release.yaml", ...allEvidenceRefs],
         releaseIssueRefs,
+        releaseScmRefs,
         releaseGithubRefs
       ),
       artifactKind: "release-report",
@@ -2329,6 +2440,7 @@ const securityAnalystAgent: RuntimeAgent = {
   async execute({ state, stateSlice }) {
     const securityRequest = getWorkflowInput<SecurityRequest>(stateSlice, "securityRequest");
     const securityIssueRefs = getWorkflowInput<string[]>(stateSlice, "securityIssueRefs") ?? [];
+    const securityScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "securityScmRefs") ?? [];
     const securityGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "securityGithubRefs") ?? [];
     const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
     if (!securityRequest) {
@@ -2399,6 +2511,7 @@ const securityAnalystAgent: RuntimeAgent = {
           ...(normalizedEvidence?.provenanceRefs ?? [securityRequest.targetRef, ...securityRequest.evidenceSources])
         ],
         securityIssueRefs,
+        securityScmRefs,
         securityGithubRefs
       ),
       artifactKind: "security-report",
@@ -2539,6 +2652,7 @@ const qaEvidenceNormalizationAgent: RuntimeAgent = {
     const allowlistedCommands = new Set(allowedValidationCommands.map((entry) => entry.command));
     const normalizedExecutedChecks = qaRequest.executedChecks.map(normalizeRequestedCommand);
     const unrecognizedExecutedChecks = normalizedExecutedChecks.filter((command) => !allowlistedCommands.has(command));
+    const ciEvidence = normalizeGitLabCiEvidence(repoRoot, normalizedEvidenceSources);
     const githubActions = normalizeGitHubActionsEvidence(repoRoot, normalizedEvidenceSources);
     const normalization = qaEvidenceNormalizationSchema.parse({
       targetRef: qaRequest.targetRef,
@@ -2550,11 +2664,12 @@ const qaEvidenceNormalizationAgent: RuntimeAgent = {
       unrecognizedExecutedChecks,
       affectedPackages,
       allowedValidationCommands,
+      ciEvidence,
       githubActions
     });
 
     return agentOutputSchema.parse({
-      summary: `Normalized QA evidence across ${normalization.normalizedEvidenceSources.length} source(s), ${normalization.allowedValidationCommands.length} allowlisted validation command(s), and ${normalization.githubActions.evidence.length} GitHub Actions evidence export(s).`,
+      summary: `Normalized QA evidence across ${normalization.normalizedEvidenceSources.length} source(s), ${normalization.allowedValidationCommands.length} allowlisted validation command(s), ${normalization.githubActions.evidence.length} GitHub Actions export(s), and ${normalization.ciEvidence.length} generic CI evidence export(s).`,
       findings: [],
       proposedActions: [],
       lifecycleArtifacts: [],
@@ -2604,6 +2719,7 @@ const qaAnalystAgent: RuntimeAgent = {
   async execute({ state, stateSlice }) {
     const qaRequest = getWorkflowInput<QaRequest>(stateSlice, "qaRequest");
     const qaIssueRefs = getWorkflowInput<string[]>(stateSlice, "qaIssueRefs") ?? [];
+    const qaScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "qaScmRefs") ?? [];
     const qaGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "qaGithubRefs") ?? [];
     const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
     if (!qaRequest) {
@@ -2627,6 +2743,9 @@ const qaAnalystAgent: RuntimeAgent = {
           failingChecks: [],
           provenanceRefs: []
         };
+    const normalizedCiEvidence = normalizedEvidence?.ciEvidence ?? [];
+    const normalizedCiWorkflowNames = [...new Set(normalizedCiEvidence.map((entry) => entry.pipelineName))];
+    const normalizedCiFailingChecks = [...new Set(normalizedCiEvidence.flatMap((entry) => summarizeCiEvidenceFailures(entry)))];
     const targetType =
       normalizedEvidence?.targetType
         ? normalizedEvidence.targetType
@@ -2671,6 +2790,9 @@ const qaAnalystAgent: RuntimeAgent = {
       ...unrecognizedExecutedChecks.map((command) => `Executed check is outside the bounded allowlist and still needs manual interpretation: ${command}`),
       ...normalizedGithubActions.failingChecks.map(
         (checkName) => `GitHub Actions evidence still reports a failing check that needs manual review: ${checkName}`
+      ),
+      ...normalizedCiFailingChecks.map(
+        (checkName) => `Imported CI evidence still reports a failing check that needs manual review: ${checkName}`
       )
     ];
     const recommendedNextChecks = [
@@ -2678,6 +2800,9 @@ const qaAnalystAgent: RuntimeAgent = {
       ...focusAreas.map((focusArea) => `Confirm whether ${focusArea} needs additional deterministic QA evidence.`),
       ...normalizedGithubActions.workflowNames.map(
         (workflowName) => `Review the exported GitHub Actions evidence for workflow \`${workflowName}\` before promotion.`
+      ),
+      ...normalizedCiWorkflowNames.map(
+        (workflowName) => `Review the imported CI evidence for pipeline \`${workflowName}\` before promotion.`
       ),
       ...(normalizedConstraints.length > 0 ? [`Keep QA follow-up bounded by: ${normalizedConstraints.join("; ")}.`] : [])
     ];
@@ -2694,6 +2819,7 @@ const qaAnalystAgent: RuntimeAgent = {
         summary,
         [requestFile ?? ".agentops/requests/qa.yaml", qaRequest.targetRef, ...qaRequest.evidenceSources],
         qaIssueRefs,
+        qaScmRefs,
         qaGithubRefs
       ),
       artifactKind: "qa-report",
@@ -2713,8 +2839,15 @@ const qaAnalystAgent: RuntimeAgent = {
             ? recommendedNextChecks
             : ["Capture additional bounded QA evidence before promotion."],
         releaseImpact:
-          normalizedGithubActions.failingChecks.length > 0
-            ? `${releaseImpactBase} GitHub Actions evidence still shows failing checks: ${normalizedGithubActions.failingChecks.join(", ")}.`
+          normalizedGithubActions.failingChecks.length > 0 || normalizedCiFailingChecks.length > 0
+            ? `${releaseImpactBase} ${[
+                normalizedGithubActions.failingChecks.length > 0
+                  ? `GitHub Actions evidence still shows failing checks: ${normalizedGithubActions.failingChecks.join(", ")}.`
+                  : undefined,
+                normalizedCiFailingChecks.length > 0
+                  ? `Imported CI evidence still shows failing checks: ${normalizedCiFailingChecks.join(", ")}.`
+                  : undefined
+              ].filter((value): value is string => Boolean(value)).join(" ")}`
             : releaseImpactBase
       }
     });
@@ -2735,6 +2868,7 @@ const qaAnalystAgent: RuntimeAgent = {
           executedChecks,
           focusAreas,
           constraints: normalizedConstraints,
+          ciEvidence: normalizedCiEvidence,
           githubActions: normalizedGithubActions
         },
         synthesizedAssessment: {
@@ -2977,6 +3111,7 @@ const implementationPlannerAgent: RuntimeAgent = {
         summary,
         [requestFile ?? ".agentops/requests/implementation.yaml", implementationRequest.designRecordRef],
         designRecord.source.issueRefs,
+        designRecord.source.scmRefs,
         designRecord.source.githubRefs
       ),
       artifactKind: "implementation-proposal",
@@ -3100,6 +3235,7 @@ const designAnalystAgent: RuntimeAgent = {
         summary,
         [requestFile ?? ".agentops/requests/design.yaml", designRequest.planningBriefRef],
         planningBrief.source.issueRefs,
+        planningBrief.source.scmRefs,
         planningBrief.source.githubRefs
       ),
       artifactKind: "design-record",

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   auditBundleSchema,
   benchmarkArtifactSchema,
   ciEvidenceSchema,
+  gitlabCiEvidenceExportSchema,
   designArtifactSchema,
   designRequestSchema,
   evalArtifactSchema,
@@ -62,8 +63,13 @@ describe("schema fixtures", () => {
     expect(() => releaseRequestSchema.parse(schemaFixtures.releaseRequest)).not.toThrow();
     expect(() => githubReferenceSchema.parse(schemaFixtures.githubReference)).not.toThrow();
     expect(() => scmReferenceSchema.parse(schemaFixtures.scmReference)).not.toThrow();
+    expect(() => scmReferenceSchema.parse(schemaFixtures.gitlabIssueScmReference)).not.toThrow();
+    expect(() => scmReferenceSchema.parse(schemaFixtures.gitlabMergeRequestScmReference)).not.toThrow();
     expect(() => ciEvidenceSchema.parse(schemaFixtures.ciEvidence)).not.toThrow();
+    expect(() => ciEvidenceSchema.parse(schemaFixtures.gitlabCiEvidence)).not.toThrow();
+    expect(() => gitlabCiEvidenceExportSchema.parse(schemaFixtures.gitlabCiEvidenceExport)).not.toThrow();
     expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.adapterCapabilityMetadata)).not.toThrow();
+    expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.gitlabAdapterCapabilityMetadata)).not.toThrow();
     expect(() => githubActionsEvidenceSchema.parse(schemaFixtures.githubActionsEvidence)).not.toThrow();
     expect(() =>
       githubActionsEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization.githubActions)
@@ -109,6 +115,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.githubReference).toBeDefined();
     expect(jsonSchemas.scmReference).toBeDefined();
     expect(jsonSchemas.ciEvidence).toBeDefined();
+    expect(jsonSchemas.gitlabCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.adapterCapabilityMetadata).toBeDefined();
     expect(jsonSchemas.githubActionsEvidence).toBeDefined();
     expect(jsonSchemas.githubActionsEvidenceNormalization).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -494,6 +494,31 @@ export const ciEvidenceSchema = z.object({
   provenanceSource: z.enum(["local-export", "adapter-read"]).default("local-export")
 });
 
+export const gitlabCiJobExportStatusSchema = z.enum(["pending", "running", "success", "failed", "canceled", "skipped"]);
+
+export const gitlabCiJobEvidenceExportSchema = z.object({
+  name: z.string().min(1),
+  status: gitlabCiJobExportStatusSchema,
+  webUrl: z.string().url().optional(),
+  startedAt: z.string().datetime().optional(),
+  completedAt: z.string().datetime().optional()
+});
+
+export const gitlabCiEvidenceExportSchema = z.object({
+  sourcePath: z.string().min(1).optional(),
+  host: z.string().min(1).default("gitlab.com"),
+  projectPath: z.string().min(1),
+  pipelineId: z.number().int().positive(),
+  pipelineName: z.string().min(1).default("GitLab CI"),
+  runAttempt: z.number().int().positive().default(1),
+  event: z.string().min(1).optional(),
+  branch: z.string().min(1).optional(),
+  commitSha: z.string().min(1).optional(),
+  status: gitlabCiJobExportStatusSchema,
+  webUrl: z.string().url().optional(),
+  jobs: z.array(gitlabCiJobEvidenceExportSchema).default([])
+});
+
 export const adapterCapabilityKindSchema = z.enum([
   "issue-reference-normalization",
   "pull-request-reference-normalization",
@@ -524,6 +549,7 @@ export const qaEvidenceNormalizationSchema = z.object({
   unrecognizedExecutedChecks: z.array(z.string().min(1)).default([]),
   affectedPackages: z.array(z.string().min(1)).default([]),
   allowedValidationCommands: z.array(normalizedValidationCommandSchema).default([]),
+  ciEvidence: z.array(ciEvidenceSchema).default([]),
   githubActions: githubActionsEvidenceNormalizationSchema.default({
     evidence: [],
     workflowNames: [],
@@ -700,6 +726,7 @@ export const lifecycleArtifactSourceReferenceSchema = z.object({
   runId: z.string().min(1).optional(),
   inputRefs: z.array(z.string()).default([]),
   issueRefs: z.array(z.string()).default([]),
+  scmRefs: z.array(scmReferenceSchema).default([]),
   githubRefs: z.array(githubReferenceSchema).default([])
 });
 
@@ -1196,6 +1223,8 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   scmReference: scmReferenceSchema,
   ciJobEvidence: ciJobEvidenceSchema,
   ciEvidence: ciEvidenceSchema,
+  gitlabCiJobEvidenceExport: gitlabCiJobEvidenceExportSchema,
+  gitlabCiEvidenceExport: gitlabCiEvidenceExportSchema,
   adapterCapabilityMetadata: adapterCapabilityMetadataSchema,
   githubReference: githubReferenceSchema,
   githubActionsJobEvidence: githubActionsJobEvidenceSchema,
@@ -1754,6 +1783,32 @@ const scmReferenceFixture = {
   source: "#142"
 } as const;
 
+const gitlabIssueScmReferenceFixture = {
+  platform: "gitlab",
+  host: "gitlab.com",
+  namespace: "h9-foundry/platform",
+  repo: "agentforge",
+  kind: "issue",
+  identifier: "123",
+  number: 123,
+  canonical: "gitlab.com/h9-foundry/platform/agentforge#123",
+  url: "https://gitlab.com/h9-foundry/platform/agentforge/-/issues/123",
+  source: "#123"
+} as const;
+
+const gitlabMergeRequestScmReferenceFixture = {
+  platform: "gitlab",
+  host: "gitlab.com",
+  namespace: "h9-foundry/platform",
+  repo: "agentforge",
+  kind: "merge_request",
+  identifier: "45",
+  number: 45,
+  canonical: "gitlab.com/h9-foundry/platform/agentforge!45",
+  url: "https://gitlab.com/h9-foundry/platform/agentforge/-/merge_requests/45",
+  source: "!45"
+} as const;
+
 const githubWorkflowStatusMappingFixture = {
   workflow: "planning-discovery",
   localRunStatus: "success",
@@ -1827,6 +1882,62 @@ const ciEvidenceFixture = {
   provenanceSource: "local-export"
 } as const;
 
+const gitlabCiEvidenceExportFixture = {
+  sourcePath: ".agentops/evidence/gitlab-ci.json",
+  host: "gitlab.com",
+  projectPath: "h9-foundry/platform/agentforge",
+  pipelineId: 987654321,
+  pipelineName: "GitLab CI",
+  runAttempt: 1,
+  event: "merge_request_event",
+  branch: "main",
+  commitSha: "caf36447a49fc6e9fc308c34b98424958237aa1e",
+  status: "failed",
+  webUrl: "https://gitlab.com/h9-foundry/platform/agentforge/-/pipelines/987654321",
+  jobs: [
+    {
+      name: "test",
+      status: "success",
+      webUrl: "https://gitlab.com/h9-foundry/platform/agentforge/-/jobs/1"
+    },
+    {
+      name: "lint",
+      status: "failed",
+      webUrl: "https://gitlab.com/h9-foundry/platform/agentforge/-/jobs/2"
+    }
+  ]
+} as const;
+
+const gitlabCiEvidenceFixture = {
+  platform: "gitlab-ci",
+  host: "gitlab.com",
+  repository: "h9-foundry/platform/agentforge",
+  pipelineName: "GitLab CI",
+  pipelineRunId: "987654321",
+  runAttempt: 1,
+  event: "merge_request_event",
+  branch: "main",
+  commitSha: "caf36447a49fc6e9fc308c34b98424958237aa1e",
+  status: "completed",
+  conclusion: "failure",
+  htmlUrl: "https://gitlab.com/h9-foundry/platform/agentforge/-/pipelines/987654321",
+  jobs: [
+    {
+      name: "test",
+      status: "completed",
+      conclusion: "success",
+      htmlUrl: "https://gitlab.com/h9-foundry/platform/agentforge/-/jobs/1"
+    },
+    {
+      name: "lint",
+      status: "completed",
+      conclusion: "failure",
+      htmlUrl: "https://gitlab.com/h9-foundry/platform/agentforge/-/jobs/2"
+    }
+  ],
+  provenanceSource: "local-export"
+} as const;
+
 const adapterCapabilityMetadataFixture = {
   platform: "github",
   host: "github.com",
@@ -1835,6 +1946,19 @@ const adapterCapabilityMetadataFixture = {
   capabilities: [
     "issue-reference-normalization",
     "pull-request-reference-normalization",
+    "local-ci-evidence-ingestion"
+  ],
+  trustBoundary: "local-only"
+} as const;
+
+const gitlabAdapterCapabilityMetadataFixture = {
+  platform: "gitlab",
+  host: "gitlab.com",
+  supportedScmReferenceKinds: ["issue", "merge_request"],
+  supportedCiPlatforms: ["gitlab-ci"],
+  capabilities: [
+    "issue-reference-normalization",
+    "merge-request-reference-normalization",
     "local-ci-evidence-ingestion"
   ],
   trustBoundary: "local-only"
@@ -1899,6 +2023,7 @@ const qaEvidenceNormalizationFixture = {
       reason: "Discovered from a bounded repository script; execution would still require approval."
     }
   ],
+  ciEvidence: [gitlabCiEvidenceFixture],
   githubActions: {
     evidence: [githubActionsEvidenceFixture],
     workflowNames: ["CI"],
@@ -2426,8 +2551,13 @@ export const schemaFixtures = {
   evalFixtureCorpus: evalFixtureCorpusFixture,
   githubReference: githubReferenceFixture,
   scmReference: scmReferenceFixture,
+  gitlabIssueScmReference: gitlabIssueScmReferenceFixture,
+  gitlabMergeRequestScmReference: gitlabMergeRequestScmReferenceFixture,
   ciEvidence: ciEvidenceFixture,
+  gitlabCiEvidenceExport: gitlabCiEvidenceExportFixture,
+  gitlabCiEvidence: gitlabCiEvidenceFixture,
   adapterCapabilityMetadata: adapterCapabilityMetadataFixture,
+  gitlabAdapterCapabilityMetadata: gitlabAdapterCapabilityMetadataFixture,
   githubActionsEvidence: githubActionsEvidenceFixture,
   githubHandoffSummary: githubHandoffSummaryFixture,
   githubWorkflowStatusMapping: githubWorkflowStatusMappingFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -39,6 +39,8 @@ import {
   benchmarkDeterministicDeltaSchema,
   ciEvidenceSchema,
   ciJobEvidenceSchema,
+  gitlabCiEvidenceExportSchema,
+  gitlabCiJobEvidenceExportSchema,
   effectivePolicySnapshotSchema,
   findingSchema,
   adapterCapabilityMetadataSchema,
@@ -112,6 +114,8 @@ export type AuditProvenance = Infer<typeof auditProvenanceSchema>;
 export type AuditRedaction = Infer<typeof auditRedactionSchema>;
 export type CiJobEvidence = Infer<typeof ciJobEvidenceSchema>;
 export type CiEvidence = Infer<typeof ciEvidenceSchema>;
+export type GitlabCiJobEvidenceExport = Infer<typeof gitlabCiJobEvidenceExportSchema>;
+export type GitlabCiEvidenceExport = Infer<typeof gitlabCiEvidenceExportSchema>;
 export type AdapterCapabilityMetadata = Infer<typeof adapterCapabilityMetadataSchema>;
 export type GithubActionsJobEvidence = Infer<typeof githubActionsJobEvidenceSchema>;
 export type GithubActionsCheckRunEvidence = Infer<typeof githubActionsCheckRunEvidenceSchema>;


### PR DESCRIPTION
## Summary
- add a bounded GitLab SCM normalization path on top of the shared SCM contracts
- add bounded local GitLab CI export normalization into shared CI evidence
- propagate additive `scmRefs` through lifecycle artifact sources without changing existing GitHub behavior

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`

Closes #168