### PR TITLE
Add generic CI evidence adapter surface

### DIFF
--- a/docs/GITHUB_INTEGRATION_MATURITY.md
+++ b/docs/GITHUB_INTEGRATION_MATURITY.md
@@ -99,6 +99,8 @@ GitHub is the first mature integration target because it already anchors plannin
 
 The host-agnostic SCM/CI contract layer now exists and the first non-GitHub host pair is validated through the bounded GitLab wedge, so GitHub-specific references and Actions evidence should remain a host-specific baseline built on top of shared shapes rather than the shared model itself becoming GitHub-shaped.
 
+That host-agnostic layer now also includes a bounded generic local CI evidence adapter, so GitHub Actions should remain the best-supported concrete CI baseline rather than the only supported way to normalize external pipeline evidence.
+
 It should remain:
 
 - the best-supported near-term host integration
@@ -112,4 +114,4 @@ This epic is now decomposed into:
 1. implemented: GitHub issue/PR reference and status normalization shared across lifecycle workflows
 2. implemented in part: bounded GitHub handoff rendering for planning, design, QA, and release artifacts
 3. implemented in part: deterministic GitHub Actions evidence ingestion for QA plus a shared normalization contract for later release workflows
-4. ongoing: support-matrix and policy guidance for GitHub-specific versus host-agnostic behavior now that GitLab normalization also exists
+4. ongoing: support-matrix and policy guidance for GitHub-specific versus host-agnostic behavior now that GitLab normalization and generic local CI evidence ingestion also exist

--- a/docs/SCM_CI_INTEGRATIONS_ROADMAP.md
+++ b/docs/SCM_CI_INTEGRATIONS_ROADMAP.md
@@ -36,10 +36,11 @@ Implemented now:
 - adapter capability metadata for bounded host behavior
 - bounded GitLab issue and merge-request normalization into the shared SCM contract
 - bounded local GitLab CI evidence normalization into the shared CI contract
+- bounded generic CI evidence ingestion for local pipeline status and artifact exports
 
 Not yet available:
 
-- additional generic CI evidence adapters beyond the GitHub and GitLab wedges
+- additional generic CI evidence adapters beyond the initial generic local export surface
 - broad host-agnostic workflow surfaces across multiple providers
 - live remote SCM or CI reads on the default local path
 
@@ -68,6 +69,8 @@ The first additional target validates the host-agnostic model with one concrete 
 This provides a meaningful contrast to GitHub without exploding scope.
 
 ### Priority 3: Additional Generic CI Evidence
+
+Status: implemented as the first generic local CI evidence wedge.
 
 After the first new host pair:
 
@@ -114,4 +117,5 @@ This epic should be decomposed into at least:
 
 1. host-agnostic SCM and CI reference contracts plus adapter capability metadata
 2. implemented: GitLab issue/MR and CI evidence integration wedge as the first additional concrete host pair
-3. next: generic CI evidence adapter surface for bounded pipeline status and artifact ingestion
+3. implemented: generic CI evidence adapter surface for bounded local pipeline status and artifact ingestion
+4. next: additional provider-specific CI adapters and richer host-agnostic workflow consumption built on the shared contracts

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1198,6 +1198,88 @@ describe("cli smoke flows", () => {
     );
   });
 
+  it("ingests bounded generic CI evidence exports during qa-review", async () => {
+    const root = createFixtureRepo();
+
+    initProject(root);
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    writeFileSync(
+      join(root, ".agentops", "evidence", "generic-ci.json"),
+      JSON.stringify(
+        {
+          providerName: "Buildkite",
+          host: "buildkite.local",
+          repository: "H9-Foundry/fixture",
+          pipelineName: "Buildkite CI",
+          pipelineRunId: "bk-123",
+          runAttempt: 1,
+          event: "pull_request",
+          branch: "main",
+          commitSha: "abc123",
+          status: "completed",
+          conclusion: "failure",
+          htmlUrl: "https://buildkite.example.com/builds/123",
+          jobs: [
+            {
+              name: "test",
+              status: "completed",
+              conclusion: "success",
+              htmlUrl: "https://buildkite.example.com/builds/123/jobs/1"
+            },
+            {
+              name: "lint",
+              status: "completed",
+              conclusion: "failure",
+              htmlUrl: "https://buildkite.example.com/builds/123/jobs/2"
+            }
+          ],
+          artifacts: [
+            {
+              name: "junit-report",
+              type: "junit-xml",
+              path: "artifacts/junit.xml"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+
+    writeFileSync(
+      join(root, ".agentops", "requests", "qa.yaml"),
+      [
+        "targetRef: package.json",
+        "evidenceSources:",
+        "  - .agentops/evidence/generic-ci.json",
+        "executedChecks:",
+        "  - pnpm test",
+        "focusAreas:",
+        "  - release-readiness",
+        "releaseContext: candidate"
+      ].join("\n")
+    );
+
+    const qaRun = await runLocalWorkflow("qa-review", root);
+    const bundle = readJson<{
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: { coverageGaps?: string[]; recommendedNextChecks?: string[]; releaseImpact?: string };
+      }>;
+    }>(qaRun.jsonPath);
+
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("qa-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.coverageGaps).toContain(
+      "Imported CI evidence still reports a failing check that needs manual review: Buildkite CI / lint"
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.recommendedNextChecks).toContain(
+      "Review the imported CI evidence for pipeline `Buildkite CI` before promotion."
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.releaseImpact).toContain(
+      "Imported CI evidence still shows failing checks: Buildkite CI / lint."
+    );
+  });
+
   it("allows bounded QA executed checks in a generic repo when the package manager is unknown", async () => {
     const root = createGitFixtureWithoutLockfile("agentops-qa-generic-");
     initProject(root);
@@ -1692,6 +1774,154 @@ describe("cli smoke flows", () => {
     );
     expect(bundle.lifecycleArtifacts[0]?.payload?.verificationChecks?.map((check) => check.name)).toEqual(
       expect.arrayContaining(["qa-report-refs", "security-report-refs", "local-release-evidence", "workspace-version-targets"])
+    );
+  });
+
+  it("consumes generic imported CI evidence during release-readiness", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+    mkdirSync(join(root, "packages", "cli"), { recursive: true });
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    writeFileSync(
+      join(root, "packages", "cli", "package.json"),
+      JSON.stringify(
+        {
+          name: "@h9-foundry/agentforge-cli",
+          version: "0.6.0",
+          type: "module"
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(
+      join(root, ".agentops", "evidence", "generic-ci.json"),
+      JSON.stringify(
+        {
+          providerName: "Buildkite",
+          host: "buildkite.local",
+          repository: "H9-Foundry/fixture",
+          pipelineName: "Buildkite CI",
+          pipelineRunId: "bk-123",
+          runAttempt: 1,
+          event: "pull_request",
+          branch: "main",
+          commitSha: "abc123",
+          status: "completed",
+          conclusion: "failure",
+          htmlUrl: "https://buildkite.example.com/builds/123",
+          jobs: [
+            {
+              name: "test",
+              status: "completed",
+              conclusion: "success",
+              htmlUrl: "https://buildkite.example.com/builds/123/jobs/1"
+            }
+          ],
+          artifacts: [
+            {
+              name: "junit-report",
+              type: "junit-xml",
+              path: "artifacts/junit.xml"
+            }
+          ]
+        },
+        null,
+        2
+      )
+    );
+
+    const qaBundleDir = join(root, ".agentops", "runs", "run-qa");
+    mkdirSync(qaBundleDir, { recursive: true });
+    writeFileSync(join(qaBundleDir, "bundle.json"), JSON.stringify({
+      version: "1.0.0",
+      runId: "run-qa",
+      workflow: "qa-review",
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+      status: "success",
+      policy: {
+        version: 1,
+        environment: "local",
+        resolvedAt: new Date().toISOString(),
+        defaults: schemaFixtures.policyDocument.defaults,
+        paths: schemaFixtures.policyDocument.paths,
+        plugins: schemaFixtures.policyDocument.plugins,
+        tools: schemaFixtures.policyDocument.tools
+      },
+      entries: [],
+      findings: [],
+      proposedActions: [],
+      blockedPlugins: [],
+      lifecycleArtifacts: [schemaFixtures.qaArtifact],
+      artifactPaths: { json: ".agentops/runs/run-qa/bundle.json", markdown: ".agentops/runs/run-qa/summary.md" },
+      provenance: { generatedBy: "agentforge-runtime", schemaVersion: "1.0.0", executionEnvironment: "local", repoRoot: root },
+      redaction: { applied: true, strategyVersion: "1.0.0", categories: ["github-token"] },
+      components: []
+    }, null, 2));
+    writeFileSync(join(qaBundleDir, "summary.md"), "# qa summary\n");
+
+    const securityBundleDir = join(root, ".agentops", "runs", "run-security");
+    mkdirSync(securityBundleDir, { recursive: true });
+    writeFileSync(join(securityBundleDir, "bundle.json"), JSON.stringify({
+      version: "1.0.0",
+      runId: "run-security",
+      workflow: "security-review",
+      startedAt: new Date().toISOString(),
+      finishedAt: new Date().toISOString(),
+      status: "success",
+      policy: {
+        version: 1,
+        environment: "local",
+        resolvedAt: new Date().toISOString(),
+        defaults: schemaFixtures.policyDocument.defaults,
+        paths: schemaFixtures.policyDocument.paths,
+        plugins: schemaFixtures.policyDocument.plugins,
+        tools: schemaFixtures.policyDocument.tools
+      },
+      entries: [],
+      findings: [],
+      proposedActions: [],
+      blockedPlugins: [],
+      lifecycleArtifacts: [schemaFixtures.securityArtifact],
+      artifactPaths: { json: ".agentops/runs/run-security/bundle.json", markdown: ".agentops/runs/run-security/summary.md" },
+      provenance: { generatedBy: "agentforge-runtime", schemaVersion: "1.0.0", executionEnvironment: "local", repoRoot: root },
+      redaction: { applied: true, strategyVersion: "1.0.0", categories: ["github-token"] },
+      components: []
+    }, null, 2));
+    writeFileSync(join(securityBundleDir, "summary.md"), "# security summary\n");
+
+    writeYamlFile(join(root, ".agentops", "requests", "release.yaml"), {
+      releaseScope: "Prepare the 0.7.0 candidate for maintainer review",
+      versionTargets: [{ name: "@h9-foundry/agentforge-cli", version: "0.7.0" }],
+      qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+      securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+      evidenceSources: [".agentops/evidence/generic-ci.json"],
+      constraints: ["Keep release readiness read-only by default"]
+    });
+
+    const releaseRun = await runLocalWorkflow("release-readiness", root);
+    const bundle = readJson<{
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: {
+          verificationChecks?: Array<{ name: string; status: string }>;
+          publishingPlan?: string[];
+          externalDependencies?: string[];
+        };
+      }>;
+    }>(releaseRun.jsonPath);
+
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("release-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.verificationChecks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "imported-ci-evidence", status: "passed" })])
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.publishingPlan).toEqual(
+      expect.arrayContaining(["Review the imported CI evidence from `Buildkite` before any publish or promotion step."])
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.externalDependencies).toEqual(
+      expect.arrayContaining(["Imported CI evidence from Buildkite remains available for reviewer inspection."])
     );
   });
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -5,6 +5,7 @@ import {
   agentManifestSchema,
   agentOutputSchema,
   ciEvidenceSchema,
+  genericCiEvidenceExportSchema,
   designArtifactSchema,
   githubActionsEvidenceSchema,
   gitlabCiEvidenceExportSchema,
@@ -33,6 +34,7 @@ import type {
   CiEvidence,
   DesignArtifact,
   DesignRequest,
+  GenericCiEvidenceExport,
   GithubActionsEvidence,
   GithubActionsEvidenceNormalization,
   GithubReference,
@@ -400,6 +402,17 @@ function loadGitLabCiEvidenceExport(bundlePath: string): GitlabCiEvidenceExport 
   return result.success ? result.data : undefined;
 }
 
+function loadGenericCiEvidenceExport(bundlePath: string): GenericCiEvidenceExport | undefined {
+  if (!existsSync(bundlePath) || !bundlePath.endsWith(".json")) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(readFileSync(bundlePath, "utf8")) as unknown;
+  const candidate = isRecord(parsed) ? { ...parsed, sourcePath: parsed.sourcePath ?? bundlePath } : parsed;
+  const result = genericCiEvidenceExportSchema.safeParse(candidate);
+  return result.success ? result.data : undefined;
+}
+
 function mapGitLabCiStatus(status: GitlabCiEvidenceExport["status"]): Pick<CiEvidence, "status" | "conclusion"> {
   switch (status) {
     case "pending":
@@ -458,11 +471,70 @@ function normalizeGitLabCiEvidence(
       conclusion: pipelineStatus.conclusion,
       htmlUrl: normalized.webUrl,
       jobs,
+      artifacts: [],
       provenanceSource: "local-export"
     });
 
     return [evidence];
   });
+}
+
+function normalizeGenericCiEvidence(
+  repoRoot: string | undefined,
+  evidenceSources: readonly string[]
+): CiEvidence[] {
+  return evidenceSources.flatMap((pathValue) => {
+    if (!repoRoot) {
+      return [];
+    }
+
+    const normalized = loadGenericCiEvidenceExport(join(repoRoot, pathValue));
+    if (!normalized) {
+      return [];
+    }
+
+    const evidence = ciEvidenceSchema.parse({
+      platform: "generic-ci",
+      providerName: normalized.providerName,
+      host: normalized.host,
+      repository: normalized.repository,
+      pipelineName: normalized.pipelineName,
+      pipelineRunId: normalized.pipelineRunId,
+      runAttempt: normalized.runAttempt,
+      event: normalized.event,
+      branch: normalized.branch,
+      commitSha: normalized.commitSha,
+      status: normalized.status,
+      conclusion: normalized.conclusion,
+      htmlUrl: normalized.htmlUrl,
+      jobs: normalized.jobs,
+      artifacts: normalized.artifacts,
+      provenanceSource: "local-export"
+    });
+
+    return [evidence];
+  });
+}
+
+function normalizeImportedCiEvidence(
+  repoRoot: string | undefined,
+  evidenceSources: readonly string[]
+): CiEvidence[] {
+  const seen = new Set<string>();
+  const combined = [...normalizeGitLabCiEvidence(repoRoot, evidenceSources), ...normalizeGenericCiEvidence(repoRoot, evidenceSources)];
+  const normalized: CiEvidence[] = [];
+
+  for (const evidence of combined) {
+    const key = `${evidence.platform}:${evidence.pipelineRunId}:${evidence.pipelineName}:${evidence.repository}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalized.push(evidence);
+  }
+
+  return normalized;
 }
 
 function summarizeCiEvidenceFailures(evidence: CiEvidence): string[] {
@@ -1994,6 +2066,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
       ? asStringArray(intakeMetadata.evidenceSources)
       : releaseRequest.evidenceSources;
     const normalizedEvidenceSources = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
+    const ciEvidence = normalizeImportedCiEvidence(repoRoot, normalizedEvidenceSources);
     const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
     if (missingEvidenceSources.length > 0) {
       throw new Error(`Release evidence source not found: ${missingEvidenceSources[0]}`);
@@ -2047,6 +2120,13 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
           : "No additional local release evidence sources were supplied."
       },
       {
+        name: "imported-ci-evidence",
+        status: ciEvidence.length > 0 ? "passed" : "skipped",
+        detail: ciEvidence.length > 0
+          ? `Using ${ciEvidence.length} imported CI evidence export(s) across ${[...new Set(ciEvidence.map((entry) => entry.pipelineName))].length} pipeline(s).`
+          : "No imported CI evidence exports were supplied."
+      },
+      {
         name: "workspace-version-targets",
         status: versionCheckStatus,
         detail:
@@ -2093,6 +2173,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
       securityReportRefs,
       normalizedEvidenceSources,
       missingEvidenceSources: [],
+      ciEvidence,
       versionResolutions: versionResolutions.map((entry) => ({
         name: entry.name,
         targetVersion: entry.targetVersion,
@@ -2183,6 +2264,9 @@ const releaseAnalystAgent: RuntimeAgent = {
       : releaseRequest.evidenceSources;
     const constraints = asStringArray(intakeMetadata.constraints);
     const allEvidenceRefs = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
+    const importedCiEvidence = normalizedEvidence?.ciEvidence ?? [];
+    const importedCiProviders = [...new Set(importedCiEvidence.map((entry) => entry.providerName ?? entry.pipelineName))];
+    const importedCiFailures = [...new Set(importedCiEvidence.flatMap((entry) => summarizeCiEvidenceFailures(entry)))];
     const versionResolutions = normalizedEvidence?.versionResolutions ?? [];
     const verificationChecks = normalizedEvidence?.localReadinessChecks ?? [
       {
@@ -2205,6 +2289,13 @@ const releaseAnalystAgent: RuntimeAgent = {
         detail: evidenceSources.length > 0
           ? `Using ${evidenceSources.length} bounded local release evidence source(s).`
           : "No additional local release evidence sources were supplied."
+      },
+      {
+        name: "imported-ci-evidence",
+        status: importedCiEvidence.length > 0 ? "passed" : "skipped",
+        detail: importedCiEvidence.length > 0
+          ? `Using ${importedCiEvidence.length} imported CI evidence export(s).`
+          : "No imported CI evidence exports were supplied."
       }
     ];
     const readinessStatus = normalizedEvidence?.readinessStatus ??
@@ -2229,6 +2320,9 @@ const releaseAnalystAgent: RuntimeAgent = {
         ? [`Resolved ${versionResolutions.length} workspace version target(s) before any publish or promotion step.`]
         : []),
       "Review the bounded QA and security evidence before invoking any publish or promotion step.",
+      ...importedCiProviders.map(
+        (providerName) => `Review the imported CI evidence from \`${providerName}\` before any publish or promotion step.`
+      ),
       "Run `agentforge release check --json` and `agentforge release verify --json` before any release cut.",
       ...approvalRecommendations.map(
         (recommendation) => `${recommendation.action}: ${recommendation.classification.replaceAll("_", " ")} (${recommendation.reason})`
@@ -2241,7 +2335,8 @@ const releaseAnalystAgent: RuntimeAgent = {
     ];
     const externalDependencies = [
       ...(qaReportRefs.length > 0 ? ["Validated QA report inputs remain available for reviewer inspection."] : []),
-      ...(securityReportRefs.length > 0 ? ["Validated security report inputs remain available for reviewer inspection."] : [])
+      ...(securityReportRefs.length > 0 ? ["Validated security report inputs remain available for reviewer inspection."] : []),
+      ...importedCiProviders.map((providerName) => `Imported CI evidence from ${providerName} remains available for reviewer inspection.`)
     ];
     const releaseReport = releaseArtifactSchema.parse({
       ...buildLifecycleArtifactEnvelopeBase(
@@ -2288,6 +2383,7 @@ const releaseAnalystAgent: RuntimeAgent = {
           qaReportRefs,
           securityReportRefs,
           evidenceSources,
+          ciEvidence: importedCiEvidence,
           constraints,
           normalizedEvidence: normalizedEvidence ?? null
         },
@@ -2295,7 +2391,8 @@ const releaseAnalystAgent: RuntimeAgent = {
           readinessStatus,
           approvalRecommendations,
           publishingPlan,
-          rollbackNotes
+          rollbackNotes,
+          importedCiFailures
         }
       }
     });
@@ -2652,7 +2749,7 @@ const qaEvidenceNormalizationAgent: RuntimeAgent = {
     const allowlistedCommands = new Set(allowedValidationCommands.map((entry) => entry.command));
     const normalizedExecutedChecks = qaRequest.executedChecks.map(normalizeRequestedCommand);
     const unrecognizedExecutedChecks = normalizedExecutedChecks.filter((command) => !allowlistedCommands.has(command));
-    const ciEvidence = normalizeGitLabCiEvidence(repoRoot, normalizedEvidenceSources);
+    const ciEvidence = normalizeImportedCiEvidence(repoRoot, normalizedEvidenceSources);
     const githubActions = normalizeGitHubActionsEvidence(repoRoot, normalizedEvidenceSources);
     const normalization = qaEvidenceNormalizationSchema.parse({
       targetRef: qaRequest.targetRef,

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -4,7 +4,9 @@ import {
   agentManifestSchema,
   auditBundleSchema,
   benchmarkArtifactSchema,
+  ciArtifactEvidenceSchema,
   ciEvidenceSchema,
+  genericCiEvidenceExportSchema,
   gitlabCiEvidenceExportSchema,
   designArtifactSchema,
   designRequestSchema,
@@ -65,11 +67,15 @@ describe("schema fixtures", () => {
     expect(() => scmReferenceSchema.parse(schemaFixtures.scmReference)).not.toThrow();
     expect(() => scmReferenceSchema.parse(schemaFixtures.gitlabIssueScmReference)).not.toThrow();
     expect(() => scmReferenceSchema.parse(schemaFixtures.gitlabMergeRequestScmReference)).not.toThrow();
+    expect(() => ciArtifactEvidenceSchema.parse(schemaFixtures.genericCiEvidence.artifacts[0])).not.toThrow();
     expect(() => ciEvidenceSchema.parse(schemaFixtures.ciEvidence)).not.toThrow();
     expect(() => ciEvidenceSchema.parse(schemaFixtures.gitlabCiEvidence)).not.toThrow();
+    expect(() => ciEvidenceSchema.parse(schemaFixtures.genericCiEvidence)).not.toThrow();
     expect(() => gitlabCiEvidenceExportSchema.parse(schemaFixtures.gitlabCiEvidenceExport)).not.toThrow();
+    expect(() => genericCiEvidenceExportSchema.parse(schemaFixtures.genericCiEvidenceExport)).not.toThrow();
     expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.adapterCapabilityMetadata)).not.toThrow();
     expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.gitlabAdapterCapabilityMetadata)).not.toThrow();
+    expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.genericCiAdapterCapabilityMetadata)).not.toThrow();
     expect(() => githubActionsEvidenceSchema.parse(schemaFixtures.githubActionsEvidence)).not.toThrow();
     expect(() =>
       githubActionsEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization.githubActions)
@@ -114,7 +120,9 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.releaseRequest).toBeDefined();
     expect(jsonSchemas.githubReference).toBeDefined();
     expect(jsonSchemas.scmReference).toBeDefined();
+    expect(jsonSchemas.ciArtifactEvidence).toBeDefined();
     expect(jsonSchemas.ciEvidence).toBeDefined();
+    expect(jsonSchemas.genericCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.gitlabCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.adapterCapabilityMetadata).toBeDefined();
     expect(jsonSchemas.githubActionsEvidence).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -477,8 +477,16 @@ export const ciJobEvidenceSchema = z.object({
   completedAt: z.string().datetime().optional()
 });
 
+export const ciArtifactEvidenceSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1).optional(),
+  path: z.string().min(1).optional(),
+  htmlUrl: z.string().url().optional()
+});
+
 export const ciEvidenceSchema = z.object({
   platform: ciPlatformSchema,
+  providerName: z.string().min(1).optional(),
   host: z.string().min(1),
   repository: z.string().min(1),
   pipelineName: z.string().min(1),
@@ -491,6 +499,7 @@ export const ciEvidenceSchema = z.object({
   conclusion: githubActionsConclusionSchema.optional(),
   htmlUrl: z.string().url().optional(),
   jobs: z.array(ciJobEvidenceSchema).default([]),
+  artifacts: z.array(ciArtifactEvidenceSchema).default([]),
   provenanceSource: z.enum(["local-export", "adapter-read"]).default("local-export")
 });
 
@@ -517,6 +526,24 @@ export const gitlabCiEvidenceExportSchema = z.object({
   status: gitlabCiJobExportStatusSchema,
   webUrl: z.string().url().optional(),
   jobs: z.array(gitlabCiJobEvidenceExportSchema).default([])
+});
+
+export const genericCiEvidenceExportSchema = z.object({
+  sourcePath: z.string().min(1).optional(),
+  providerName: z.string().min(1),
+  host: z.string().min(1).default("local"),
+  repository: z.string().min(1),
+  pipelineName: z.string().min(1),
+  pipelineRunId: z.string().min(1),
+  runAttempt: z.number().int().positive().default(1),
+  event: z.string().min(1).optional(),
+  branch: z.string().min(1).optional(),
+  commitSha: z.string().min(1).optional(),
+  status: githubActionsRunStatusSchema,
+  conclusion: githubActionsConclusionSchema.optional(),
+  htmlUrl: z.string().url().optional(),
+  jobs: z.array(ciJobEvidenceSchema).default([]),
+  artifacts: z.array(ciArtifactEvidenceSchema).default([])
 });
 
 export const adapterCapabilityKindSchema = z.enum([
@@ -992,6 +1019,7 @@ export const releaseEvidenceNormalizationSchema = z.object({
   securityReportRefs: z.array(z.string().min(1)).default([]),
   normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
   missingEvidenceSources: z.array(z.string().min(1)).default([]),
+  ciEvidence: z.array(ciEvidenceSchema).default([]),
   versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
   localReadinessChecks: z.array(releaseVerificationCheckSchema).default([]),
   readinessStatus: z.enum(["ready", "blocked", "partial"]),
@@ -1222,9 +1250,11 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   auditRedaction: auditRedactionSchema,
   scmReference: scmReferenceSchema,
   ciJobEvidence: ciJobEvidenceSchema,
+  ciArtifactEvidence: ciArtifactEvidenceSchema,
   ciEvidence: ciEvidenceSchema,
   gitlabCiJobEvidenceExport: gitlabCiJobEvidenceExportSchema,
   gitlabCiEvidenceExport: gitlabCiEvidenceExportSchema,
+  genericCiEvidenceExport: genericCiEvidenceExportSchema,
   adapterCapabilityMetadata: adapterCapabilityMetadataSchema,
   githubReference: githubReferenceSchema,
   githubActionsJobEvidence: githubActionsJobEvidenceSchema,
@@ -1854,6 +1884,7 @@ const githubActionsEvidenceFixture = {
 
 const ciEvidenceFixture = {
   platform: "github-actions",
+  providerName: "GitHub Actions",
   host: "github.com",
   repository: "H9-Foundry/AgentForge",
   pipelineName: "CI",
@@ -1879,6 +1910,7 @@ const ciEvidenceFixture = {
       htmlUrl: "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789/job/2"
     }
   ],
+  artifacts: [],
   provenanceSource: "local-export"
 } as const;
 
@@ -1910,6 +1942,7 @@ const gitlabCiEvidenceExportFixture = {
 
 const gitlabCiEvidenceFixture = {
   platform: "gitlab-ci",
+  providerName: "GitLab CI",
   host: "gitlab.com",
   repository: "h9-foundry/platform/agentforge",
   pipelineName: "GitLab CI",
@@ -1933,6 +1966,82 @@ const gitlabCiEvidenceFixture = {
       status: "completed",
       conclusion: "failure",
       htmlUrl: "https://gitlab.com/h9-foundry/platform/agentforge/-/jobs/2"
+    }
+  ],
+  artifacts: [],
+  provenanceSource: "local-export"
+} as const;
+
+const genericCiEvidenceExportFixture = {
+  sourcePath: ".agentops/evidence/buildkite-ci.json",
+  providerName: "Buildkite",
+  host: "buildkite.local",
+  repository: "h9-foundry/platform/agentforge",
+  pipelineName: "Buildkite CI",
+  pipelineRunId: "bk-123",
+  runAttempt: 1,
+  event: "pull_request",
+  branch: "main",
+  commitSha: "caf36447a49fc6e9fc308c34b98424958237aa1e",
+  status: "completed",
+  conclusion: "failure",
+  htmlUrl: "https://buildkite.example.com/organizations/h9-foundry/pipelines/agentforge/builds/123",
+  jobs: [
+    {
+      name: "test",
+      status: "completed",
+      conclusion: "success",
+      htmlUrl: "https://buildkite.example.com/organizations/h9-foundry/pipelines/agentforge/builds/123/jobs/1"
+    },
+    {
+      name: "lint",
+      status: "completed",
+      conclusion: "failure",
+      htmlUrl: "https://buildkite.example.com/organizations/h9-foundry/pipelines/agentforge/builds/123/jobs/2"
+    }
+  ],
+  artifacts: [
+    {
+      name: "junit-report",
+      type: "junit-xml",
+      path: "artifacts/junit.xml"
+    }
+  ]
+} as const;
+
+const genericCiEvidenceFixture = {
+  platform: "generic-ci",
+  providerName: "Buildkite",
+  host: "buildkite.local",
+  repository: "h9-foundry/platform/agentforge",
+  pipelineName: "Buildkite CI",
+  pipelineRunId: "bk-123",
+  runAttempt: 1,
+  event: "pull_request",
+  branch: "main",
+  commitSha: "caf36447a49fc6e9fc308c34b98424958237aa1e",
+  status: "completed",
+  conclusion: "failure",
+  htmlUrl: "https://buildkite.example.com/organizations/h9-foundry/pipelines/agentforge/builds/123",
+  jobs: [
+    {
+      name: "test",
+      status: "completed",
+      conclusion: "success",
+      htmlUrl: "https://buildkite.example.com/organizations/h9-foundry/pipelines/agentforge/builds/123/jobs/1"
+    },
+    {
+      name: "lint",
+      status: "completed",
+      conclusion: "failure",
+      htmlUrl: "https://buildkite.example.com/organizations/h9-foundry/pipelines/agentforge/builds/123/jobs/2"
+    }
+  ],
+  artifacts: [
+    {
+      name: "junit-report",
+      type: "junit-xml",
+      path: "artifacts/junit.xml"
     }
   ],
   provenanceSource: "local-export"
@@ -1961,6 +2070,15 @@ const gitlabAdapterCapabilityMetadataFixture = {
     "merge-request-reference-normalization",
     "local-ci-evidence-ingestion"
   ],
+  trustBoundary: "local-only"
+} as const;
+
+const genericCiAdapterCapabilityMetadataFixture = {
+  platform: "generic",
+  host: "local-ci-export",
+  supportedScmReferenceKinds: [],
+  supportedCiPlatforms: ["generic-ci"],
+  capabilities: ["local-ci-evidence-ingestion"],
   trustBoundary: "local-only"
 } as const;
 
@@ -2334,9 +2452,11 @@ const releaseEvidenceNormalizationFixture = {
   normalizedEvidenceSources: [
     ".agentops/runs/run-789/bundle.json",
     ".agentops/runs/run-790/bundle.json",
-    ".agentops/runs/run-790/summary.md"
+    ".agentops/runs/run-790/summary.md",
+    ".agentops/evidence/buildkite-ci.json"
   ],
   missingEvidenceSources: [],
+  ciEvidence: [genericCiEvidenceFixture],
   versionResolutions: [
     {
       name: "@h9-foundry/agentforge-cli",
@@ -2556,8 +2676,11 @@ export const schemaFixtures = {
   ciEvidence: ciEvidenceFixture,
   gitlabCiEvidenceExport: gitlabCiEvidenceExportFixture,
   gitlabCiEvidence: gitlabCiEvidenceFixture,
+  genericCiEvidenceExport: genericCiEvidenceExportFixture,
+  genericCiEvidence: genericCiEvidenceFixture,
   adapterCapabilityMetadata: adapterCapabilityMetadataFixture,
   gitlabAdapterCapabilityMetadata: gitlabAdapterCapabilityMetadataFixture,
+  genericCiAdapterCapabilityMetadata: genericCiAdapterCapabilityMetadataFixture,
   githubActionsEvidence: githubActionsEvidenceFixture,
   githubHandoffSummary: githubHandoffSummaryFixture,
   githubWorkflowStatusMapping: githubWorkflowStatusMappingFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -37,8 +37,10 @@ import {
   benchmarkArtifactSchema,
   benchmarkComparedRunSchema,
   benchmarkDeterministicDeltaSchema,
+  ciArtifactEvidenceSchema,
   ciEvidenceSchema,
   ciJobEvidenceSchema,
+  genericCiEvidenceExportSchema,
   gitlabCiEvidenceExportSchema,
   gitlabCiJobEvidenceExportSchema,
   effectivePolicySnapshotSchema,
@@ -112,8 +114,10 @@ export type AuditEntry = Infer<typeof auditEntrySchema>;
 export type AuditComponent = Infer<typeof auditComponentSchema>;
 export type AuditProvenance = Infer<typeof auditProvenanceSchema>;
 export type AuditRedaction = Infer<typeof auditRedactionSchema>;
+export type CiArtifactEvidence = Infer<typeof ciArtifactEvidenceSchema>;
 export type CiJobEvidence = Infer<typeof ciJobEvidenceSchema>;
 export type CiEvidence = Infer<typeof ciEvidenceSchema>;
+export type GenericCiEvidenceExport = Infer<typeof genericCiEvidenceExportSchema>;
 export type GitlabCiJobEvidenceExport = Infer<typeof gitlabCiJobEvidenceExportSchema>;
 export type GitlabCiEvidenceExport = Infer<typeof gitlabCiEvidenceExportSchema>;
 export type AdapterCapabilityMetadata = Infer<typeof adapterCapabilityMetadataSchema>;


### PR DESCRIPTION
## Summary
- add a bounded generic CI evidence export contract and normalized `generic-ci` evidence shape
- ingest generic local CI exports in QA and release evidence normalization without adding remote reads or new CLI commands
- update SCM/CI roadmap docs to reflect the first generic local CI evidence wedge

## Testing
- pnpm exec vitest run packages/schemas/src/index.test.ts packages/shared-types/src/index.test.ts packages/cli/src/index.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm build:packages

Closes #169.