### PR TITLE
Add dependency integrity evidence reporting

### DIFF
--- a/.changeset/dependency-integrity-inventory.md
+++ b/.changeset/dependency-integrity-inventory.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add bounded dependency-integrity inventory evidence and surface it through security-review and release-readiness reports.

--- a/docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md
+++ b/docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md
@@ -39,19 +39,31 @@ Available now:
 Not yet available:
 
 - consumer-facing verification guidance beyond the current release tooling
-- broader dependency-integrity and SBOM workflow support
+- full enterprise-grade SBOM generation or distribution verification
 - registry/plugin distribution trust hardening beyond local plugin trust
 - cross-host supply-chain evidence normalization
+
+Implemented now in a bounded first slice:
+
+- workspace-inventory style dependency-integrity evidence for local repos
+- release-readiness dependency-integrity checks derived from local manifests and lockfiles
+- security-review dependency-integrity signals derived from bounded local manifests and lockfiles
 
 ## Remaining Hardening Areas
 
 ### 1. Dependency Integrity
 
-Define how AgentForge should verify and report:
+First bounded implementation available now:
+
+- local manifest inventory with lockfile-aware integrity status
+- deterministic dependency-integrity signals surfaced in `security-report` and `release-report`
+- release-readiness verification checks for dependency-integrity
+
+Still to define or extend:
 
 - lockfile integrity expectations
 - dependency source and update provenance
-- SBOM or inventory outputs where appropriate
+- richer SBOM or inventory outputs where appropriate
 
 ### 2. Artifact And Attestation Verification
 
@@ -120,3 +132,7 @@ This epic should be decomposed into at least:
 2. attestation verification and trust-summary integration for release workflows
 3. plugin and registry distribution hardening requirements aligned to verified activation and consumer trust signals
 
+Status:
+
+- item 1 is now partially implemented as a bounded workspace-inventory and dependency-integrity reporting wedge
+- items 2 and 3 remain next

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1529,9 +1529,27 @@ describe("cli smoke flows", () => {
     expect(securityRun.findings).toBe(0);
     expect(securityRun.artifactKinds).toContain("security-report");
 
-    const bundle = readJson<{ workflow: string; lifecycleArtifacts: Array<{ artifactKind: string }> }>(securityRun.jsonPath);
+    const bundle = readJson<{
+      workflow: string;
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: {
+          dependencyIntegritySignals?: string[];
+          followUpWork?: string[];
+        };
+      }>;
+    }>(securityRun.jsonPath);
     expect(bundle.workflow).toBe("security-review");
     expect(bundle.lifecycleArtifacts.some((artifact) => artifact.artifactKind === "security-report")).toBe(true);
+    expect(bundle.lifecycleArtifacts[0]?.payload?.dependencyIntegritySignals).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Dependency inventory covers"),
+        expect.stringContaining("pnpm-lock.yaml")
+      ])
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.followUpWork).toEqual(
+      expect.arrayContaining([expect.stringContaining("Dependency inventory covers")])
+    );
   });
 
   it("fails release-readiness before reasoning when the request is missing", async () => {
@@ -1758,6 +1776,7 @@ describe("cli smoke flows", () => {
           versionResolutions?: Array<{ name: string; status: string }>;
           approvalRecommendations?: Array<{ action: string; classification: string }>;
           verificationChecks?: Array<{ name: string; status: string }>;
+          dependencyIntegritySignals?: string[];
         };
       }>;
     }>(releaseRun.jsonPath);
@@ -1773,7 +1792,22 @@ describe("cli smoke flows", () => {
       expect.arrayContaining([expect.objectContaining({ action: "publish-packages", classification: "approval_required" })])
     );
     expect(bundle.lifecycleArtifacts[0]?.payload?.verificationChecks?.map((check) => check.name)).toEqual(
-      expect.arrayContaining(["qa-report-refs", "security-report-refs", "local-release-evidence", "workspace-version-targets"])
+      expect.arrayContaining([
+        "qa-report-refs",
+        "security-report-refs",
+        "local-release-evidence",
+        "dependency-integrity",
+        "workspace-version-targets"
+      ])
+    );
+    expect(
+      bundle.lifecycleArtifacts[0]?.payload?.verificationChecks?.find((check) => check.name === "dependency-integrity")
+    ).toEqual(expect.objectContaining({ status: "passed" }));
+    expect(bundle.lifecycleArtifacts[0]?.payload?.dependencyIntegritySignals).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Dependency inventory covers"),
+        expect.stringContaining("pnpm-lock.yaml")
+      ])
     );
   });
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -5,6 +5,7 @@ import {
   agentManifestSchema,
   agentOutputSchema,
   ciEvidenceSchema,
+  dependencyIntegrityEvidenceSchema,
   genericCiEvidenceExportSchema,
   designArtifactSchema,
   githubActionsEvidenceSchema,
@@ -32,6 +33,8 @@ import {
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 import type {
   CiEvidence,
+  DependencyIntegrityEvidence,
+  DependencyInventoryEntry,
   DesignArtifact,
   DesignRequest,
   GenericCiEvidenceExport,
@@ -150,6 +153,11 @@ interface WorkspacePackageResolution {
   readonly manifestPath?: string;
 }
 
+interface WorkspacePackageManifest {
+  readonly packageName: string;
+  readonly dependencyEntries: DependencyInventoryEntry[];
+}
+
 function resolveWorkspacePackage(root: string | undefined, packageName: string): WorkspacePackageResolution {
   if (!root) {
     return {};
@@ -181,6 +189,13 @@ function resolveWorkspacePackage(root: string | undefined, packageName: string):
 
   return {};
 }
+
+const dependencyManifestSections = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies"
+] as const satisfies readonly DependencyInventoryEntry["dependencyType"][];
 
 const allowedValidationScriptNames = new Set(["test", "lint", "typecheck", "build", "build:packages", "release:verify"]);
 const fallbackValidationPackageManagers = ["pnpm", "npm", "yarn"] as const;
@@ -253,6 +268,157 @@ function collectValidationCommands(
   }
 
   return discoveredValidationCommands;
+}
+
+function findDependencyLockfile(repoRoot: string | undefined, packageManager: string): string | undefined {
+  if (!repoRoot) {
+    return undefined;
+  }
+
+  const orderedCandidates =
+    packageManager === "pnpm"
+      ? ["pnpm-lock.yaml", "package-lock.json", "yarn.lock"]
+      : packageManager === "npm"
+        ? ["package-lock.json", "pnpm-lock.yaml", "yarn.lock"]
+        : packageManager === "yarn"
+          ? ["yarn.lock", "pnpm-lock.yaml", "package-lock.json"]
+          : ["pnpm-lock.yaml", "package-lock.json", "yarn.lock"];
+
+  return orderedCandidates.find((lockfilePath) => existsSync(join(repoRoot, lockfilePath)));
+}
+
+function readPackageManifestDependencies(repoRoot: string | undefined, manifestPath: string): WorkspacePackageManifest | undefined {
+  if (!repoRoot) {
+    return undefined;
+  }
+
+  const absolutePath = join(repoRoot, manifestPath);
+  if (!existsSync(absolutePath)) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(readFileSync(absolutePath, "utf8")) as unknown;
+  if (!isRecord(parsed)) {
+    return undefined;
+  }
+
+  const packageName = typeof parsed.name === "string" && parsed.name.length > 0 ? parsed.name : manifestPath.replace(/\/package\.json$/, "");
+  const dependencyEntries: DependencyInventoryEntry[] = [];
+
+  for (const section of dependencyManifestSections) {
+    const sectionValue = parsed[section];
+    if (!isRecord(sectionValue)) {
+      continue;
+    }
+
+    for (const [dependencyName, requestedVersion] of Object.entries(sectionValue)) {
+      if (typeof requestedVersion !== "string") {
+        continue;
+      }
+
+      dependencyEntries.push({
+        manifestPath,
+        packageName,
+        dependencyName,
+        dependencyType: section,
+        requestedVersion
+      });
+    }
+  }
+
+  return {
+    packageName,
+    dependencyEntries
+  };
+}
+
+function resolveDependencyManifestPaths(
+  repoRoot: string | undefined,
+  candidatePaths: readonly string[]
+): string[] {
+  if (!repoRoot) {
+    return [];
+  }
+
+  const normalizedCandidates =
+    candidatePaths.length > 0
+      ? candidatePaths
+      : existsSync(join(repoRoot, "package.json"))
+        ? ["package.json"]
+        : [];
+
+  const manifestPaths = normalizedCandidates.flatMap((candidatePath) => {
+    const normalizedCandidate = candidatePath.replace(/^\.\//, "");
+    const manifestPath = normalizedCandidate.endsWith("package.json")
+      ? normalizedCandidate
+      : `${normalizedCandidate.replace(/\/$/, "")}/package.json`;
+    return existsSync(join(repoRoot, manifestPath)) ? [manifestPath] : [];
+  });
+
+  return [...new Set(manifestPaths)];
+}
+
+function collectDependencyIntegrityEvidence(
+  repoRoot: string | undefined,
+  packageManager: string,
+  manifestPaths: readonly string[]
+): DependencyIntegrityEvidence[] {
+  if (!repoRoot || manifestPaths.length === 0) {
+    return [];
+  }
+
+  const manifests = manifestPaths
+    .map((manifestPath) => readPackageManifestDependencies(repoRoot, manifestPath))
+    .filter((manifest): manifest is WorkspacePackageManifest => Boolean(manifest));
+  if (manifests.length === 0) {
+    return [];
+  }
+
+  const inventoryEntries = manifests.flatMap((manifest) => manifest.dependencyEntries);
+  const packageNames = [...new Set(manifests.map((manifest) => manifest.packageName))];
+  const lockfilePath = findDependencyLockfile(repoRoot, packageManager);
+  const integrityStatus =
+    lockfilePath
+      ? "verified-lockfile"
+      : inventoryEntries.length === 0
+        ? "manifest-only"
+        : "missing-lockfile";
+
+  return [
+    dependencyIntegrityEvidenceSchema.parse({
+      inventoryFormat: "workspace-inventory",
+      packageManager,
+      integrityStatus,
+      lockfilePath,
+      manifestPaths,
+      packageNames,
+      packageCount: packageNames.length,
+      dependencyEntryCount: inventoryEntries.length,
+      inventoryEntries,
+      provenanceSource: "workspace-scan",
+      provenanceRefs: [...new Set([...manifestPaths, ...(lockfilePath ? [lockfilePath] : [])])]
+    })
+  ];
+}
+
+function buildDependencyIntegritySignals(
+  evidenceEntries: readonly DependencyIntegrityEvidence[]
+): string[] {
+  return evidenceEntries.flatMap((evidence) => {
+    const signals = [
+      `Dependency inventory covers ${evidence.packageCount} manifest(s) with ${evidence.dependencyEntryCount} declared dependency entr${evidence.dependencyEntryCount === 1 ? "y" : "ies"}.`
+    ];
+
+    if (evidence.integrityStatus === "verified-lockfile" && evidence.lockfilePath) {
+      signals.push(`Workspace dependency integrity is verified against ${evidence.lockfilePath}.`);
+    } else if (evidence.integrityStatus === "missing-lockfile") {
+      signals.push("Workspace dependency manifests were found without a recognized lockfile.");
+    } else {
+      signals.push("Workspace dependency inventory is manifest-only and does not include lockfile verification.");
+    }
+
+    return signals;
+  });
 }
 
 function loadBundleArtifactKinds(bundlePath: string): string[] {
@@ -2087,6 +2253,20 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
         manifestPath: resolved.manifestPath
       };
     });
+    const dependencyManifestPaths = resolveDependencyManifestPaths(repoRoot, [
+      "package.json",
+      ...versionResolutions
+        .map((entry) => entry.manifestPath)
+        .filter((value): value is string => Boolean(value))
+        .map((manifestPath) => manifestPath.replace(`${repoRoot ?? ""}/`, ""))
+    ]);
+    const dependencyIntegrityEvidence = collectDependencyIntegrityEvidence(
+      repoRoot,
+      stateSlice.repo?.packageManager || "unknown",
+      dependencyManifestPaths
+    );
+    const dependencyIntegritySignals = buildDependencyIntegritySignals(dependencyIntegrityEvidence);
+    const hasMissingDependencyIntegrity = dependencyIntegrityEvidence.some((entry) => entry.integrityStatus === "missing-lockfile");
     const missingPackages = versionResolutions.filter((entry) => entry.status === "package-missing").map((entry) => entry.name);
     const versionCheckStatus = missingPackages.length === 0 ? "passed" : "failed";
     const baseReadinessStatus =
@@ -2095,7 +2275,12 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
         : qaReportRefs.length > 0 || securityReportRefs.length > 0
           ? "partial"
           : "blocked";
-    const readinessStatus = missingPackages.length > 0 ? "blocked" : baseReadinessStatus;
+    const readinessStatus =
+      missingPackages.length > 0
+        ? "blocked"
+        : hasMissingDependencyIntegrity && baseReadinessStatus === "ready"
+          ? "partial"
+          : baseReadinessStatus;
 
     const localReadinessChecks = [
       {
@@ -2125,6 +2310,18 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
         detail: ciEvidence.length > 0
           ? `Using ${ciEvidence.length} imported CI evidence export(s) across ${[...new Set(ciEvidence.map((entry) => entry.pipelineName))].length} pipeline(s).`
           : "No imported CI evidence exports were supplied."
+      },
+      {
+        name: "dependency-integrity",
+        status:
+          dependencyIntegrityEvidence.length === 0
+            ? "skipped"
+            : hasMissingDependencyIntegrity
+              ? "failed"
+              : "passed",
+        detail:
+          dependencyIntegritySignals[0] ??
+          "No dependency manifests were available for bounded integrity verification."
       },
       {
         name: "workspace-version-targets",
@@ -2164,6 +2361,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
     ];
     const provenanceRefs = [
       ...normalizedEvidenceSources,
+      ...dependencyIntegrityEvidence.flatMap((entry) => entry.provenanceRefs),
       ...versionResolutions
         .map((entry) => entry.manifestPath)
         .filter((value): value is string => Boolean(value))
@@ -2174,6 +2372,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
       normalizedEvidenceSources,
       missingEvidenceSources: [],
       ciEvidence,
+      dependencyIntegrityEvidence,
       versionResolutions: versionResolutions.map((entry) => ({
         name: entry.name,
         targetVersion: entry.targetVersion,
@@ -2265,6 +2464,8 @@ const releaseAnalystAgent: RuntimeAgent = {
     const constraints = asStringArray(intakeMetadata.constraints);
     const allEvidenceRefs = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
     const importedCiEvidence = normalizedEvidence?.ciEvidence ?? [];
+    const dependencyIntegrityEvidence = normalizedEvidence?.dependencyIntegrityEvidence ?? [];
+    const dependencyIntegritySignals = buildDependencyIntegritySignals(dependencyIntegrityEvidence);
     const importedCiProviders = [...new Set(importedCiEvidence.map((entry) => entry.providerName ?? entry.pipelineName))];
     const importedCiFailures = [...new Set(importedCiEvidence.flatMap((entry) => summarizeCiEvidenceFailures(entry)))];
     const versionResolutions = normalizedEvidence?.versionResolutions ?? [];
@@ -2319,6 +2520,7 @@ const releaseAnalystAgent: RuntimeAgent = {
       ...(versionResolutions.length > 0
         ? [`Resolved ${versionResolutions.length} workspace version target(s) before any publish or promotion step.`]
         : []),
+      ...dependencyIntegritySignals.map((signal) => `${signal} Review dependency integrity before any publish or promotion step.`),
       "Review the bounded QA and security evidence before invoking any publish or promotion step.",
       ...importedCiProviders.map(
         (providerName) => `Review the imported CI evidence from \`${providerName}\` before any publish or promotion step.`
@@ -2356,6 +2558,7 @@ const releaseAnalystAgent: RuntimeAgent = {
         readinessStatus,
         verificationChecks: verificationChecks.map((check) => ({ ...check })),
         versionResolutions,
+        dependencyIntegritySignals,
         approvalRecommendations: approvalRecommendations.map((recommendation) =>
           releaseApprovalRecommendationSchema.parse(recommendation)
         ),
@@ -2384,6 +2587,7 @@ const releaseAnalystAgent: RuntimeAgent = {
           securityReportRefs,
           evidenceSources,
           ciEvidence: importedCiEvidence,
+          dependencyIntegrityEvidence,
           constraints,
           normalizedEvidence: normalizedEvidence ?? null
         },
@@ -2463,15 +2667,23 @@ const securityEvidenceNormalizationAgent: RuntimeAgent = {
       targetType === "artifact-bundle"
         ? [...new Set(loadBundleArtifactPayloadPaths(targetPath).map(derivePackageScope).filter((value): value is string => Boolean(value)))]
         : [];
+    const dependencyIntegrityEvidence = collectDependencyIntegrityEvidence(
+      repoRoot,
+      stateSlice.repo?.packageManager || "unknown",
+      resolveDependencyManifestPaths(repoRoot, ["package.json", ...affectedPackages])
+    );
+    const dependencyIntegritySignals = buildDependencyIntegritySignals(dependencyIntegrityEvidence);
     const securitySignals = [
       ...(referencedArtifactKinds.length > 0 ? [`Referenced artifact kinds: ${referencedArtifactKinds.join(", ")}`] : []),
       ...(affectedPackages.length > 0 ? [`Affected packages inferred from bounded artifact payloads: ${affectedPackages.join(", ")}`] : []),
       ...(normalizedFocusAreas.length > 0 ? [`Requested focus areas: ${normalizedFocusAreas.join(", ")}`] : []),
+      ...dependencyIntegritySignals,
       "Security evidence collection remains local, read-only, and bounded to validated references."
     ];
     const provenanceRefs = [
       securityRequest.targetRef,
       ...securityRequest.evidenceSources,
+      ...dependencyIntegrityEvidence.flatMap((entry) => entry.provenanceRefs),
       ...referencedArtifactKinds.map((artifactKind) => `${securityRequest.targetRef}#${artifactKind}`)
     ];
     const normalization = securityEvidenceNormalizationSchema.parse({
@@ -2482,6 +2694,7 @@ const securityEvidenceNormalizationAgent: RuntimeAgent = {
       missingEvidenceSources: [],
       normalizedFocusAreas,
       securitySignals,
+      dependencyIntegrityEvidence,
       provenanceRefs: [...new Set(provenanceRefs)],
       affectedPackages
     });
@@ -2552,6 +2765,8 @@ const securityAnalystAgent: RuntimeAgent = {
     const normalizedFocusAreas =
       normalizedEvidence?.normalizedFocusAreas ?? asStringArray(intakeMetadata.focusAreas);
     const normalizedConstraints = asStringArray(intakeMetadata.constraints);
+    const dependencyIntegrityEvidence = normalizedEvidence?.dependencyIntegrityEvidence ?? [];
+    const dependencyIntegritySignals = buildDependencyIntegritySignals(dependencyIntegrityEvidence);
     const evidenceSources =
       normalizedEvidence?.normalizedEvidenceSources && normalizedEvidence.normalizedEvidenceSources.length > 0
         ? normalizedEvidence.normalizedEvidenceSources
@@ -2592,6 +2807,7 @@ const securityAnalystAgent: RuntimeAgent = {
     ];
     const followUpWork = [
       ...(normalizedEvidence?.securitySignals ?? []),
+      ...dependencyIntegritySignals,
       ...(referencedArtifactKinds.length > 0
         ? [`Confirm the security posture for referenced artifacts: ${referencedArtifactKinds.join(", ")}.`]
         : []),
@@ -2632,8 +2848,9 @@ const securityAnalystAgent: RuntimeAgent = {
             ? "release-blocking security findings require resolution before promotion."
             : securityRequest.releaseContext === "candidate"
               ? "candidate release requires explicit security review before promotion."
-              : "no release context was supplied; security output remains advisory.",
-        followUpWork
+            : "no release context was supplied; security output remains advisory.",
+        followUpWork,
+        dependencyIntegritySignals
       }
     });
 
@@ -2652,6 +2869,7 @@ const securityAnalystAgent: RuntimeAgent = {
           focusAreas,
           constraints: normalizedConstraints,
           referencedArtifactKinds,
+          dependencyIntegrityEvidence,
           normalizedEvidence: normalizedEvidence ?? null
         },
         synthesizedAssessment: {

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -6,6 +6,8 @@ import {
   benchmarkArtifactSchema,
   ciArtifactEvidenceSchema,
   ciEvidenceSchema,
+  dependencyIntegrityEvidenceSchema,
+  dependencyInventoryEntrySchema,
   genericCiEvidenceExportSchema,
   gitlabCiEvidenceExportSchema,
   designArtifactSchema,
@@ -71,6 +73,8 @@ describe("schema fixtures", () => {
     expect(() => ciEvidenceSchema.parse(schemaFixtures.ciEvidence)).not.toThrow();
     expect(() => ciEvidenceSchema.parse(schemaFixtures.gitlabCiEvidence)).not.toThrow();
     expect(() => ciEvidenceSchema.parse(schemaFixtures.genericCiEvidence)).not.toThrow();
+    expect(() => dependencyInventoryEntrySchema.parse(schemaFixtures.dependencyIntegrityEvidence.inventoryEntries[0])).not.toThrow();
+    expect(() => dependencyIntegrityEvidenceSchema.parse(schemaFixtures.dependencyIntegrityEvidence)).not.toThrow();
     expect(() => gitlabCiEvidenceExportSchema.parse(schemaFixtures.gitlabCiEvidenceExport)).not.toThrow();
     expect(() => genericCiEvidenceExportSchema.parse(schemaFixtures.genericCiEvidenceExport)).not.toThrow();
     expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.adapterCapabilityMetadata)).not.toThrow();
@@ -122,6 +126,8 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.scmReference).toBeDefined();
     expect(jsonSchemas.ciArtifactEvidence).toBeDefined();
     expect(jsonSchemas.ciEvidence).toBeDefined();
+    expect(jsonSchemas.dependencyInventoryEntry).toBeDefined();
+    expect(jsonSchemas.dependencyIntegrityEvidence).toBeDefined();
     expect(jsonSchemas.genericCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.gitlabCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.adapterCapabilityMetadata).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -546,6 +546,41 @@ export const genericCiEvidenceExportSchema = z.object({
   artifacts: z.array(ciArtifactEvidenceSchema).default([])
 });
 
+export const dependencyManifestSectionSchema = z.enum([
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies"
+]);
+
+export const dependencyInventoryEntrySchema = z.object({
+  manifestPath: z.string().min(1),
+  packageName: z.string().min(1),
+  dependencyName: z.string().min(1),
+  dependencyType: dependencyManifestSectionSchema,
+  requestedVersion: z.string().min(1)
+});
+
+export const dependencyIntegrityStatusSchema = z.enum([
+  "verified-lockfile",
+  "manifest-only",
+  "missing-lockfile"
+]);
+
+export const dependencyIntegrityEvidenceSchema = z.object({
+  inventoryFormat: z.literal("workspace-inventory"),
+  packageManager: z.string().min(1),
+  integrityStatus: dependencyIntegrityStatusSchema,
+  lockfilePath: z.string().min(1).optional(),
+  manifestPaths: z.array(z.string().min(1)).default([]),
+  packageNames: z.array(z.string().min(1)).default([]),
+  packageCount: z.number().int().min(0),
+  dependencyEntryCount: z.number().int().min(0),
+  inventoryEntries: z.array(dependencyInventoryEntrySchema).default([]),
+  provenanceSource: z.enum(["workspace-scan", "local-export"]).default("workspace-scan"),
+  provenanceRefs: z.array(z.string().min(1)).default([])
+});
+
 export const adapterCapabilityKindSchema = z.enum([
   "issue-reference-normalization",
   "pull-request-reference-normalization",
@@ -593,6 +628,7 @@ export const securityEvidenceNormalizationSchema = z.object({
   missingEvidenceSources: z.array(z.string().min(1)).default([]),
   normalizedFocusAreas: z.array(z.string().min(1)).default([]),
   securitySignals: z.array(z.string().min(1)).default([]),
+  dependencyIntegrityEvidence: z.array(dependencyIntegrityEvidenceSchema).default([]),
   provenanceRefs: z.array(z.string().min(1)).default([]),
   affectedPackages: z.array(z.string().min(1)).default([])
 });
@@ -851,7 +887,8 @@ export const securityArtifactPayloadSchema = z.object({
   severitySummary: z.string().min(1),
   mitigations: z.array(z.string().min(1)).default([]),
   releaseImpact: z.string().min(1),
-  followUpWork: z.array(z.string().min(1)).default([])
+  followUpWork: z.array(z.string().min(1)).default([]),
+  dependencyIntegritySignals: z.array(z.string().min(1)).default([])
 });
 
 export const implementationArtifactPayloadSchema = z.object({
@@ -1020,6 +1057,7 @@ export const releaseEvidenceNormalizationSchema = z.object({
   normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
   missingEvidenceSources: z.array(z.string().min(1)).default([]),
   ciEvidence: z.array(ciEvidenceSchema).default([]),
+  dependencyIntegrityEvidence: z.array(dependencyIntegrityEvidenceSchema).default([]),
   versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
   localReadinessChecks: z.array(releaseVerificationCheckSchema).default([]),
   readinessStatus: z.enum(["ready", "blocked", "partial"]),
@@ -1033,6 +1071,7 @@ export const releaseArtifactPayloadSchema = z.object({
   readinessStatus: z.enum(["ready", "blocked", "partial"]),
   verificationChecks: z.array(releaseVerificationCheckSchema).default([]),
   versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
+  dependencyIntegritySignals: z.array(z.string().min(1)).default([]),
   approvalRecommendations: z.array(releaseApprovalRecommendationSchema).default([]),
   publishingPlan: z.array(z.string().min(1)).default([]),
   trustStatus: z.string().min(1),
@@ -1255,6 +1294,8 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   gitlabCiJobEvidenceExport: gitlabCiJobEvidenceExportSchema,
   gitlabCiEvidenceExport: gitlabCiEvidenceExportSchema,
   genericCiEvidenceExport: genericCiEvidenceExportSchema,
+  dependencyInventoryEntry: dependencyInventoryEntrySchema,
+  dependencyIntegrityEvidence: dependencyIntegrityEvidenceSchema,
   adapterCapabilityMetadata: adapterCapabilityMetadataSchema,
   githubReference: githubReferenceSchema,
   githubActionsJobEvidence: githubActionsJobEvidenceSchema,
@@ -1533,7 +1574,11 @@ const securityArtifactFixture = {
     severitySummary: "highest severity: medium; 1 synthesized security finding.",
     mitigations: ["Review dependency-risk evidence before release promotion."],
     releaseImpact: "candidate release requires explicit security review before promotion.",
-    followUpWork: ["Use deterministic security evidence normalization outputs before broader promotion."]
+    followUpWork: ["Use deterministic security evidence normalization outputs before broader promotion."],
+    dependencyIntegritySignals: [
+      "Dependency inventory covers 2 manifest(s) with 4 declared dependency entries.",
+      "Workspace dependency integrity is verified against pnpm-lock.yaml."
+    ]
   }
 } as const;
 
@@ -1578,6 +1623,10 @@ const releaseArtifactFixture = {
         currentVersion: "0.4.0",
         status: "pending-version-bump"
       }
+    ],
+    dependencyIntegritySignals: [
+      "Dependency inventory covers 2 manifest(s) with 4 declared dependency entries.",
+      "Workspace dependency integrity is verified against pnpm-lock.yaml."
     ],
     approvalRecommendations: [
       {
@@ -2156,6 +2205,49 @@ const qaEvidenceNormalizationFixture = {
   }
 } as const;
 
+const dependencyIntegrityEvidenceFixture = {
+  inventoryFormat: "workspace-inventory",
+  packageManager: "pnpm",
+  integrityStatus: "verified-lockfile",
+  lockfilePath: "pnpm-lock.yaml",
+  manifestPaths: ["package.json", "packages/cli/package.json"],
+  packageNames: ["fixture", "@h9-foundry/agentforge-cli"],
+  packageCount: 2,
+  dependencyEntryCount: 4,
+  inventoryEntries: [
+    {
+      manifestPath: "package.json",
+      packageName: "fixture",
+      dependencyName: "typescript",
+      dependencyType: "devDependencies",
+      requestedVersion: "^5.8.0"
+    },
+    {
+      manifestPath: "package.json",
+      packageName: "fixture",
+      dependencyName: "vitest",
+      dependencyType: "devDependencies",
+      requestedVersion: "^4.1.0"
+    },
+    {
+      manifestPath: "packages/cli/package.json",
+      packageName: "@h9-foundry/agentforge-cli",
+      dependencyName: "@h9-foundry/agentforge-schemas",
+      dependencyType: "dependencies",
+      requestedVersion: "workspace:*"
+    },
+    {
+      manifestPath: "packages/cli/package.json",
+      packageName: "@h9-foundry/agentforge-cli",
+      dependencyName: "@h9-foundry/agentforge-shared-types",
+      dependencyType: "dependencies",
+      requestedVersion: "workspace:*"
+    }
+  ],
+  provenanceSource: "workspace-scan",
+  provenanceRefs: ["package.json", "packages/cli/package.json", "pnpm-lock.yaml"]
+} as const;
+
 const securityEvidenceNormalizationFixture = {
   targetRef: ".agentops/runs/run-790/bundle.json",
   targetType: "artifact-bundle",
@@ -2165,11 +2257,17 @@ const securityEvidenceNormalizationFixture = {
   normalizedFocusAreas: ["dependency-risk", "release-readiness"],
   securitySignals: [
     "Referenced artifact kinds: implementation-proposal",
-    "Affected packages inferred from bounded artifact payloads: packages/cli, packages/runtime"
+    "Affected packages inferred from bounded artifact payloads: packages/cli, packages/runtime",
+    "Dependency inventory covers 2 manifest(s) with 4 declared dependency entries.",
+    "Workspace dependency integrity is verified against pnpm-lock.yaml."
   ],
+  dependencyIntegrityEvidence: [dependencyIntegrityEvidenceFixture],
   provenanceRefs: [
     ".agentops/runs/run-790/bundle.json#implementation-proposal",
-    ".agentops/runs/run-790/summary.md"
+    ".agentops/runs/run-790/summary.md",
+    "package.json",
+    "packages/cli/package.json",
+    "pnpm-lock.yaml"
   ],
   affectedPackages: ["packages/cli", "packages/runtime"]
 } as const;
@@ -2457,6 +2555,7 @@ const releaseEvidenceNormalizationFixture = {
   ],
   missingEvidenceSources: [],
   ciEvidence: [genericCiEvidenceFixture],
+  dependencyIntegrityEvidence: [dependencyIntegrityEvidenceFixture],
   versionResolutions: [
     {
       name: "@h9-foundry/agentforge-cli",
@@ -2468,6 +2567,7 @@ const releaseEvidenceNormalizationFixture = {
   localReadinessChecks: [
     { name: "qa-report-refs", status: "passed", detail: "Using one validated QA report reference." },
     { name: "security-report-refs", status: "passed", detail: "Using one validated security report reference." },
+    { name: "dependency-integrity", status: "passed", detail: "Dependency inventory is verified against pnpm-lock.yaml." },
     { name: "workspace-version-targets", status: "passed", detail: "Resolved one workspace version target." }
   ],
   readinessStatus: "ready",
@@ -2487,6 +2587,7 @@ const releaseEvidenceNormalizationFixture = {
     ".agentops/runs/run-789/bundle.json",
     ".agentops/runs/run-790/bundle.json",
     ".agentops/runs/run-790/summary.md",
+    "package.json",
     "packages/cli/package.json"
   ]
 } as const;
@@ -2674,6 +2775,7 @@ export const schemaFixtures = {
   gitlabIssueScmReference: gitlabIssueScmReferenceFixture,
   gitlabMergeRequestScmReference: gitlabMergeRequestScmReferenceFixture,
   ciEvidence: ciEvidenceFixture,
+  dependencyIntegrityEvidence: dependencyIntegrityEvidenceFixture,
   gitlabCiEvidenceExport: gitlabCiEvidenceExportFixture,
   gitlabCiEvidence: gitlabCiEvidenceFixture,
   genericCiEvidenceExport: genericCiEvidenceExportFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -39,6 +39,8 @@ import {
   benchmarkDeterministicDeltaSchema,
   ciArtifactEvidenceSchema,
   ciEvidenceSchema,
+  dependencyIntegrityEvidenceSchema,
+  dependencyInventoryEntrySchema,
   ciJobEvidenceSchema,
   genericCiEvidenceExportSchema,
   gitlabCiEvidenceExportSchema,
@@ -117,6 +119,8 @@ export type AuditRedaction = Infer<typeof auditRedactionSchema>;
 export type CiArtifactEvidence = Infer<typeof ciArtifactEvidenceSchema>;
 export type CiJobEvidence = Infer<typeof ciJobEvidenceSchema>;
 export type CiEvidence = Infer<typeof ciEvidenceSchema>;
+export type DependencyInventoryEntry = Infer<typeof dependencyInventoryEntrySchema>;
+export type DependencyIntegrityEvidence = Infer<typeof dependencyIntegrityEvidenceSchema>;
 export type GenericCiEvidenceExport = Infer<typeof genericCiEvidenceExportSchema>;
 export type GitlabCiJobEvidenceExport = Infer<typeof gitlabCiJobEvidenceExportSchema>;
 export type GitlabCiEvidenceExport = Infer<typeof gitlabCiEvidenceExportSchema>;


### PR DESCRIPTION
## Summary
- add bounded dependency-integrity inventory schemas and shared types
- normalize dependency-integrity evidence into `security-review` and `release-readiness`
- surface dependency-integrity signals in security and release artifacts, tests, and supply-chain roadmap docs

Closes #170

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/cli/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`