### PR TITLE
Add attestation trust summaries

### DIFF
--- a/.changeset/attestation-trust-summary.md
+++ b/.changeset/attestation-trust-summary.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add bounded attestation verification evidence and trust-summary reporting for release workflows.

--- a/docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md
+++ b/docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md
@@ -48,6 +48,8 @@ Implemented now in a bounded first slice:
 - workspace-inventory style dependency-integrity evidence for local repos
 - release-readiness dependency-integrity checks derived from local manifests and lockfiles
 - security-review dependency-integrity signals derived from bounded local manifests and lockfiles
+- local attestation verification evidence normalization for release workflows
+- trust-summary lines derived from bounded attestation or provenance evidence
 
 ## Remaining Hardening Areas
 
@@ -67,7 +69,13 @@ Still to define or extend:
 
 ### 2. Artifact And Attestation Verification
 
-Define how workflows should consume:
+First bounded implementation available now:
+
+- local attestation or provenance verification exports can be normalized into release evidence
+- `release-readiness` can surface trust summary lines and readiness checks from that evidence
+- trusted publishing remains separate from bounded attestation verification
+
+Still to define or extend:
 
 - provenance attestations
 - package verification results
@@ -135,4 +143,5 @@ This epic should be decomposed into at least:
 Status:
 
 - item 1 is now partially implemented as a bounded workspace-inventory and dependency-integrity reporting wedge
-- items 2 and 3 remain next
+- item 2 is now partially implemented as a bounded local attestation-verification and trust-summary wedge
+- item 3 remains next

--- a/docs/release-trust.md
+++ b/docs/release-trust.md
@@ -80,6 +80,12 @@ Use the CLI to separate guidance from verification:
 - `agentforge release verify --json`
   - emits the clean-room verification result as structured JSON for Codex or CI consumption
 
+`release-readiness` can also consume explicit local attestation-verification JSON exports as bounded evidence. That path is read-only and reporting-oriented:
+
+- it adds trust-summary lines and attestation verification checks to the release report
+- it does not replace trusted publishing
+- it does not promote a release automatically based only on attestation presence
+
 ## Build Provenance
 
 `.github/workflows/release-provenance.yml` remains useful even when package publishing is active. It attests the build artifact for the full workspace so reviewers can inspect a reproducible CI build independent of npm publication.

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1641,6 +1641,7 @@ describe("cli smoke flows", () => {
     initializeWorkspace(root);
     ensureRequestsDir(root);
     mkdirSync(join(root, "packages", "cli"), { recursive: true });
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
     writeFileSync(
       join(root, "packages", "cli", "package.json"),
       JSON.stringify(
@@ -1751,13 +1752,36 @@ describe("cli smoke flows", () => {
       )
     );
     writeFileSync(join(securityBundleDir, "summary.md"), "# security summary\n");
+    writeFileSync(
+      join(root, ".agentops", "evidence", "attestation-verification.json"),
+      JSON.stringify(
+        {
+          verifier: "github-artifact-attestation",
+          subject: "@h9-foundry/agentforge-cli@0.7.0",
+          issuer: "https://token.actions.githubusercontent.com",
+          status: "verified",
+          detail: "Verified GitHub artifact attestation for the release package artifact.",
+          predicateType: "https://slsa.dev/provenance/v1",
+          verifiedAt: "2026-03-19T12:45:00.000Z",
+          provenanceRefs: [
+            ".agentops/evidence/attestation-verification.json",
+            "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789"
+          ]
+        },
+        null,
+        2
+      )
+    );
 
     writeYamlFile(join(root, ".agentops", "requests", "release.yaml"), {
       releaseScope: "Prepare the 0.7.0 candidate for maintainer review",
       versionTargets: [{ name: "@h9-foundry/agentforge-cli", version: "0.7.0" }],
       qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
       securityReportRefs: [".agentops/runs/run-security/bundle.json"],
-      evidenceSources: [".agentops/runs/run-security/summary.md"],
+      evidenceSources: [
+        ".agentops/runs/run-security/summary.md",
+        ".agentops/evidence/attestation-verification.json"
+      ],
       constraints: ["Keep release readiness read-only by default"]
     });
 
@@ -1777,6 +1801,8 @@ describe("cli smoke flows", () => {
           approvalRecommendations?: Array<{ action: string; classification: string }>;
           verificationChecks?: Array<{ name: string; status: string }>;
           dependencyIntegritySignals?: string[];
+          trustSummary?: string[];
+          trustStatus?: string;
         };
       }>;
     }>(releaseRun.jsonPath);
@@ -1808,6 +1834,15 @@ describe("cli smoke flows", () => {
         expect.stringContaining("Dependency inventory covers"),
         expect.stringContaining("pnpm-lock.yaml")
       ])
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.trustSummary).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("Verified 1 attestation or provenance evidence export."),
+        expect.stringContaining("Trusted publishing remains reviewed separately")
+      ])
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.trustStatus).toBe(
+      "attestation-verified-trusted-publishing-reviewed-separately"
     );
   });
 

--- a/packages/cli/src/internal/builtin-agents.test.ts
+++ b/packages/cli/src/internal/builtin-agents.test.ts
@@ -856,13 +856,31 @@ describe("builtin release evidence normalizer", () => {
     const root = mkdtempSync(join(tmpdir(), "agentforge-release-evidence-"));
     mkdirSync(join(root, ".agentops", "runs", "run-qa"), { recursive: true });
     mkdirSync(join(root, ".agentops", "runs", "run-security"), { recursive: true });
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
     mkdirSync(join(root, "packages", "cli"), { recursive: true });
+    writeFileSync(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+    writeFileSync(
+      join(root, "package.json"),
+      JSON.stringify(
+        {
+          name: "fixture-root",
+          devDependencies: {
+            typescript: "^5.8.0"
+          }
+        },
+        null,
+        2
+      )
+    );
     writeFileSync(
       join(root, "packages", "cli", "package.json"),
       JSON.stringify(
         {
           name: "@h9-foundry/agentforge-cli",
-          version: "0.6.0"
+          version: "0.6.0",
+          dependencies: {
+            "@h9-foundry/agentforge-schemas": "workspace:*"
+          }
         },
         null,
         2
@@ -898,6 +916,26 @@ describe("builtin release evidence normalizer", () => {
       )
     );
     writeFileSync(join(root, ".agentops", "runs", "run-security", "summary.md"), "# security summary\n");
+    writeFileSync(
+      join(root, ".agentops", "evidence", "attestation-verification.json"),
+      JSON.stringify(
+        {
+          verifier: "github-artifact-attestation",
+          subject: "@h9-foundry/agentforge-cli@0.7.0",
+          issuer: "https://token.actions.githubusercontent.com",
+          status: "verified",
+          detail: "Verified GitHub artifact attestation for the release package artifact.",
+          predicateType: "https://slsa.dev/provenance/v1",
+          verifiedAt: "2026-03-19T12:45:00.000Z",
+          provenanceRefs: [
+            ".agentops/evidence/attestation-verification.json",
+            "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789"
+          ]
+        },
+        null,
+        2
+      )
+    );
 
     const agent = createBuiltinAgentRegistry().get("release-evidence-normalizer");
     expect(agent).toBeDefined();
@@ -920,7 +958,10 @@ describe("builtin release evidence normalizer", () => {
             versionTargets: [{ name: "@h9-foundry/agentforge-cli", version: "0.7.0" }],
             qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
             securityReportRefs: [".agentops/runs/run-security/bundle.json"],
-            evidenceSources: [".agentops/runs/run-security/summary.md"],
+            evidenceSources: [
+              ".agentops/runs/run-security/summary.md",
+              ".agentops/evidence/attestation-verification.json"
+            ],
             constraints: ["Keep the workflow read-only"]
           }
         },
@@ -929,7 +970,10 @@ describe("builtin release evidence normalizer", () => {
             metadata: {
               qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
               securityReportRefs: [".agentops/runs/run-security/bundle.json"],
-              evidenceSources: [".agentops/runs/run-security/summary.md"]
+              evidenceSources: [
+                ".agentops/runs/run-security/summary.md",
+                ".agentops/evidence/attestation-verification.json"
+              ]
             }
           }
         }
@@ -941,7 +985,8 @@ describe("builtin release evidence normalizer", () => {
     expect(output.metadata?.normalizedEvidenceSources).toEqual([
       ".agentops/runs/run-qa/bundle.json",
       ".agentops/runs/run-security/bundle.json",
-      ".agentops/runs/run-security/summary.md"
+      ".agentops/runs/run-security/summary.md",
+      ".agentops/evidence/attestation-verification.json"
     ]);
     expect(output.metadata?.versionResolutions).toEqual([
       expect.objectContaining({
@@ -956,6 +1001,97 @@ describe("builtin release evidence normalizer", () => {
         expect.objectContaining({ action: "publish-packages", classification: "approval_required" }),
         expect.objectContaining({ action: "promote-release", classification: "approval_required" })
       ])
+    );
+    expect(output.metadata?.dependencyIntegrityEvidence).toEqual(
+      expect.arrayContaining([expect.objectContaining({ integrityStatus: "verified-lockfile", lockfilePath: "pnpm-lock.yaml" })])
+    );
+    expect(output.metadata?.attestationVerificationEvidence).toEqual(
+      expect.arrayContaining([expect.objectContaining({ verifier: "github-artifact-attestation", status: "verified" })])
+    );
+    expect(output.metadata?.trustSummary).toEqual(
+      expect.arrayContaining([expect.stringContaining("Verified 1 attestation or provenance evidence export.")])
+    );
+    expect(output.metadata?.localReadinessChecks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "attestation-verification", status: "passed" })])
+    );
+  });
+
+  it("blocks release readiness when supplied attestation verification evidence fails", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agentforge-release-attestation-fail-"));
+    mkdirSync(join(root, ".agentops", "runs", "run-qa"), { recursive: true });
+    mkdirSync(join(root, ".agentops", "runs", "run-security"), { recursive: true });
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+    mkdirSync(join(root, "packages", "cli"), { recursive: true });
+    writeFileSync(join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+    writeFileSync(join(root, "package.json"), JSON.stringify({ name: "fixture-root" }, null, 2));
+    writeFileSync(
+      join(root, "packages", "cli", "package.json"),
+      JSON.stringify({ name: "@h9-foundry/agentforge-cli", version: "0.6.0" }, null, 2)
+    );
+    writeFileSync(join(root, ".agentops", "runs", "run-qa", "bundle.json"), JSON.stringify({ lifecycleArtifacts: [{ artifactKind: "qa-report" }] }, null, 2));
+    writeFileSync(join(root, ".agentops", "runs", "run-security", "bundle.json"), JSON.stringify({ lifecycleArtifacts: [{ artifactKind: "security-report" }] }, null, 2));
+    writeFileSync(join(root, ".agentops", "runs", "run-security", "summary.md"), "# security summary\n");
+    writeFileSync(
+      join(root, ".agentops", "evidence", "attestation-verification.json"),
+      JSON.stringify(
+        {
+          verifier: "github-artifact-attestation",
+          subject: "@h9-foundry/agentforge-cli@0.7.0",
+          issuer: "https://token.actions.githubusercontent.com",
+          status: "failed",
+          detail: "The supplied attestation did not match the expected release subject.",
+          provenanceRefs: [".agentops/evidence/attestation-verification.json"]
+        },
+        null,
+        2
+      )
+    );
+
+    const agent = createBuiltinAgentRegistry().get("release-evidence-normalizer");
+    expect(agent).toBeDefined();
+
+    const output = await agent!.execute({
+      state: {} as never,
+      stateSlice: {
+        repo: {
+          root,
+          name: "fixture-root",
+          branch: "main",
+          packageManager: "pnpm",
+          languages: ["typescript"],
+          ci: false,
+          detectedFiles: []
+        },
+        workflowInputs: {
+          releaseRequest: {
+            releaseScope: "Prepare the next release candidate",
+            versionTargets: [{ name: "@h9-foundry/agentforge-cli", version: "0.7.0" }],
+            qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+            securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+            evidenceSources: [".agentops/evidence/attestation-verification.json"],
+            constraints: ["Keep the workflow read-only"]
+          }
+        },
+        agentResults: {
+          intake: {
+            metadata: {
+              qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+              securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+              evidenceSources: [".agentops/evidence/attestation-verification.json"]
+            }
+          }
+        }
+      } as never,
+      policy: {} as never,
+      invokeTool: async () => ({}) as never
+    });
+
+    expect(output.metadata?.readinessStatus).toBe("blocked");
+    expect(output.metadata?.localReadinessChecks).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: "attestation-verification", status: "failed" })])
+    );
+    expect(output.metadata?.trustSummary).toEqual(
+      expect.arrayContaining([expect.stringContaining("attestation verification failure")])
     );
   });
 });

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import {
   agentManifestSchema,
   agentOutputSchema,
+  attestationVerificationEvidenceSchema,
   ciEvidenceSchema,
   dependencyIntegrityEvidenceSchema,
   genericCiEvidenceExportSchema,
@@ -32,6 +33,7 @@ import {
 } from "@h9-foundry/agentforge-schemas";
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 import type {
+  AttestationVerificationEvidence,
   CiEvidence,
   DependencyIntegrityEvidence,
   DependencyInventoryEntry,
@@ -419,6 +421,88 @@ function buildDependencyIntegritySignals(
 
     return signals;
   });
+}
+
+function loadAttestationVerificationEvidence(bundlePath: string): AttestationVerificationEvidence | undefined {
+  if (!existsSync(bundlePath) || !bundlePath.endsWith(".json")) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(readFileSync(bundlePath, "utf8")) as unknown;
+  const candidate = isRecord(parsed) ? { ...parsed, sourcePath: parsed.sourcePath ?? bundlePath } : parsed;
+  const result = attestationVerificationEvidenceSchema.safeParse(candidate);
+  return result.success ? result.data : undefined;
+}
+
+function normalizeAttestationVerificationEvidence(
+  repoRoot: string | undefined,
+  evidenceSources: readonly string[]
+): AttestationVerificationEvidence[] {
+  const seen = new Set<string>();
+  const normalized: AttestationVerificationEvidence[] = [];
+
+  for (const pathValue of evidenceSources) {
+    if (!repoRoot) {
+      continue;
+    }
+
+    const evidence = loadAttestationVerificationEvidence(join(repoRoot, pathValue));
+    if (!evidence) {
+      continue;
+    }
+
+    const key = `${evidence.verifier}:${evidence.subject}:${evidence.status}:${evidence.sourcePath ?? pathValue}`;
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    normalized.push(evidence);
+  }
+
+  return normalized;
+}
+
+function buildReleaseTrustSummary(
+  evidenceEntries: readonly AttestationVerificationEvidence[]
+): string[] {
+  if (evidenceEntries.length === 0) {
+    return ["Trusted publishing remains reviewed separately; no attestation verification evidence was supplied."];
+  }
+
+  const failedCount = evidenceEntries.filter((entry) => entry.status === "failed").length;
+  const verifiedCount = evidenceEntries.filter((entry) => entry.status === "verified").length;
+  const skippedCount = evidenceEntries.filter((entry) => entry.status === "skipped").length;
+  const summary = [];
+
+  if (verifiedCount > 0) {
+    summary.push(`Verified ${verifiedCount} attestation or provenance evidence export${verifiedCount === 1 ? "" : "s"}.`);
+  }
+
+  if (failedCount > 0) {
+    summary.push(`Detected ${failedCount} attestation verification failure${failedCount === 1 ? "" : "s"} that require release follow-up.`);
+  }
+
+  if (skippedCount > 0) {
+    summary.push(`Skipped ${skippedCount} attestation verification evidence export${skippedCount === 1 ? "" : "s"} based on the supplied local evidence.`);
+  }
+
+  summary.push("Trusted publishing remains reviewed separately from bounded attestation verification.");
+  return summary;
+}
+
+function resolveReleaseTrustStatus(
+  evidenceEntries: readonly AttestationVerificationEvidence[]
+): string {
+  if (evidenceEntries.some((entry) => entry.status === "failed")) {
+    return "attestation-verification-failed";
+  }
+
+  if (evidenceEntries.some((entry) => entry.status === "verified")) {
+    return "attestation-verified-trusted-publishing-reviewed-separately";
+  }
+
+  return "trusted-publishing-reviewed-separately";
 }
 
 function loadBundleArtifactKinds(bundlePath: string): string[] {
@@ -2233,6 +2317,8 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
       : releaseRequest.evidenceSources;
     const normalizedEvidenceSources = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
     const ciEvidence = normalizeImportedCiEvidence(repoRoot, normalizedEvidenceSources);
+    const attestationVerificationEvidence = normalizeAttestationVerificationEvidence(repoRoot, normalizedEvidenceSources);
+    const trustSummary = buildReleaseTrustSummary(attestationVerificationEvidence);
     const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
     if (missingEvidenceSources.length > 0) {
       throw new Error(`Release evidence source not found: ${missingEvidenceSources[0]}`);
@@ -2267,6 +2353,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
     );
     const dependencyIntegritySignals = buildDependencyIntegritySignals(dependencyIntegrityEvidence);
     const hasMissingDependencyIntegrity = dependencyIntegrityEvidence.some((entry) => entry.integrityStatus === "missing-lockfile");
+    const hasFailedAttestationVerification = attestationVerificationEvidence.some((entry) => entry.status === "failed");
     const missingPackages = versionResolutions.filter((entry) => entry.status === "package-missing").map((entry) => entry.name);
     const versionCheckStatus = missingPackages.length === 0 ? "passed" : "failed";
     const baseReadinessStatus =
@@ -2278,6 +2365,8 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
     const readinessStatus =
       missingPackages.length > 0
         ? "blocked"
+        : hasFailedAttestationVerification
+          ? "blocked"
         : hasMissingDependencyIntegrity && baseReadinessStatus === "ready"
           ? "partial"
           : baseReadinessStatus;
@@ -2324,6 +2413,16 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
           "No dependency manifests were available for bounded integrity verification."
       },
       {
+        name: "attestation-verification",
+        status:
+          attestationVerificationEvidence.length === 0
+            ? "skipped"
+            : hasFailedAttestationVerification
+              ? "failed"
+              : "passed",
+        detail: trustSummary[0]
+      },
+      {
         name: "workspace-version-targets",
         status: versionCheckStatus,
         detail:
@@ -2362,6 +2461,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
     const provenanceRefs = [
       ...normalizedEvidenceSources,
       ...dependencyIntegrityEvidence.flatMap((entry) => entry.provenanceRefs),
+      ...attestationVerificationEvidence.flatMap((entry) => entry.provenanceRefs),
       ...versionResolutions
         .map((entry) => entry.manifestPath)
         .filter((value): value is string => Boolean(value))
@@ -2373,6 +2473,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
       missingEvidenceSources: [],
       ciEvidence,
       dependencyIntegrityEvidence,
+      attestationVerificationEvidence,
       versionResolutions: versionResolutions.map((entry) => ({
         name: entry.name,
         targetVersion: entry.targetVersion,
@@ -2382,6 +2483,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
       localReadinessChecks,
       readinessStatus,
       approvalRecommendations,
+      trustSummary,
       provenanceRefs: [...new Set(provenanceRefs)]
     });
 
@@ -2466,6 +2568,8 @@ const releaseAnalystAgent: RuntimeAgent = {
     const importedCiEvidence = normalizedEvidence?.ciEvidence ?? [];
     const dependencyIntegrityEvidence = normalizedEvidence?.dependencyIntegrityEvidence ?? [];
     const dependencyIntegritySignals = buildDependencyIntegritySignals(dependencyIntegrityEvidence);
+    const attestationVerificationEvidence = normalizedEvidence?.attestationVerificationEvidence ?? [];
+    const trustSummary = normalizedEvidence?.trustSummary ?? buildReleaseTrustSummary(attestationVerificationEvidence);
     const importedCiProviders = [...new Set(importedCiEvidence.map((entry) => entry.providerName ?? entry.pipelineName))];
     const importedCiFailures = [...new Set(importedCiEvidence.flatMap((entry) => summarizeCiEvidenceFailures(entry)))];
     const versionResolutions = normalizedEvidence?.versionResolutions ?? [];
@@ -2521,6 +2625,7 @@ const releaseAnalystAgent: RuntimeAgent = {
         ? [`Resolved ${versionResolutions.length} workspace version target(s) before any publish or promotion step.`]
         : []),
       ...dependencyIntegritySignals.map((signal) => `${signal} Review dependency integrity before any publish or promotion step.`),
+      ...trustSummary.map((line) => `${line} Keep publish execution separate from verification.`),
       "Review the bounded QA and security evidence before invoking any publish or promotion step.",
       ...importedCiProviders.map(
         (providerName) => `Review the imported CI evidence from \`${providerName}\` before any publish or promotion step.`
@@ -2559,11 +2664,12 @@ const releaseAnalystAgent: RuntimeAgent = {
         verificationChecks: verificationChecks.map((check) => ({ ...check })),
         versionResolutions,
         dependencyIntegritySignals,
+        trustSummary,
         approvalRecommendations: approvalRecommendations.map((recommendation) =>
           releaseApprovalRecommendationSchema.parse(recommendation)
         ),
         publishingPlan,
-        trustStatus: "trusted-publishing-reviewed-separately",
+        trustStatus: resolveReleaseTrustStatus(attestationVerificationEvidence),
         publishedPackages: [],
         tagRefs: [],
         provenanceRefs: allEvidenceRefs,
@@ -2588,6 +2694,7 @@ const releaseAnalystAgent: RuntimeAgent = {
           evidenceSources,
           ciEvidence: importedCiEvidence,
           dependencyIntegrityEvidence,
+          attestationVerificationEvidence,
           constraints,
           normalizedEvidence: normalizedEvidence ?? null
         },
@@ -2596,6 +2703,7 @@ const releaseAnalystAgent: RuntimeAgent = {
           approvalRecommendations,
           publishingPlan,
           rollbackNotes,
+          trustSummary,
           importedCiFailures
         }
       }

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -4,6 +4,7 @@ import {
   agentManifestSchema,
   auditBundleSchema,
   benchmarkArtifactSchema,
+  attestationVerificationEvidenceSchema,
   ciArtifactEvidenceSchema,
   ciEvidenceSchema,
   dependencyIntegrityEvidenceSchema,
@@ -75,6 +76,7 @@ describe("schema fixtures", () => {
     expect(() => ciEvidenceSchema.parse(schemaFixtures.genericCiEvidence)).not.toThrow();
     expect(() => dependencyInventoryEntrySchema.parse(schemaFixtures.dependencyIntegrityEvidence.inventoryEntries[0])).not.toThrow();
     expect(() => dependencyIntegrityEvidenceSchema.parse(schemaFixtures.dependencyIntegrityEvidence)).not.toThrow();
+    expect(() => attestationVerificationEvidenceSchema.parse(schemaFixtures.attestationVerificationEvidence)).not.toThrow();
     expect(() => gitlabCiEvidenceExportSchema.parse(schemaFixtures.gitlabCiEvidenceExport)).not.toThrow();
     expect(() => genericCiEvidenceExportSchema.parse(schemaFixtures.genericCiEvidenceExport)).not.toThrow();
     expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.adapterCapabilityMetadata)).not.toThrow();
@@ -128,6 +130,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.ciEvidence).toBeDefined();
     expect(jsonSchemas.dependencyInventoryEntry).toBeDefined();
     expect(jsonSchemas.dependencyIntegrityEvidence).toBeDefined();
+    expect(jsonSchemas.attestationVerificationEvidence).toBeDefined();
     expect(jsonSchemas.genericCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.gitlabCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.adapterCapabilityMetadata).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -581,6 +581,18 @@ export const dependencyIntegrityEvidenceSchema = z.object({
   provenanceRefs: z.array(z.string().min(1)).default([])
 });
 
+export const attestationVerificationEvidenceSchema = z.object({
+  sourcePath: z.string().min(1).optional(),
+  verifier: z.enum(["github-artifact-attestation", "npm-provenance", "local-verifier"]),
+  subject: z.string().min(1),
+  issuer: z.string().min(1),
+  status: z.enum(["verified", "failed", "skipped"]),
+  detail: z.string().min(1),
+  predicateType: z.string().min(1).optional(),
+  verifiedAt: z.string().datetime().optional(),
+  provenanceRefs: z.array(z.string().min(1)).default([])
+});
+
 export const adapterCapabilityKindSchema = z.enum([
   "issue-reference-normalization",
   "pull-request-reference-normalization",
@@ -1058,10 +1070,12 @@ export const releaseEvidenceNormalizationSchema = z.object({
   missingEvidenceSources: z.array(z.string().min(1)).default([]),
   ciEvidence: z.array(ciEvidenceSchema).default([]),
   dependencyIntegrityEvidence: z.array(dependencyIntegrityEvidenceSchema).default([]),
+  attestationVerificationEvidence: z.array(attestationVerificationEvidenceSchema).default([]),
   versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
   localReadinessChecks: z.array(releaseVerificationCheckSchema).default([]),
   readinessStatus: z.enum(["ready", "blocked", "partial"]),
   approvalRecommendations: z.array(releaseApprovalRecommendationSchema).default([]),
+  trustSummary: z.array(z.string().min(1)).default([]),
   provenanceRefs: z.array(z.string().min(1)).default([])
 });
 
@@ -1072,6 +1086,7 @@ export const releaseArtifactPayloadSchema = z.object({
   verificationChecks: z.array(releaseVerificationCheckSchema).default([]),
   versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
   dependencyIntegritySignals: z.array(z.string().min(1)).default([]),
+  trustSummary: z.array(z.string().min(1)).default([]),
   approvalRecommendations: z.array(releaseApprovalRecommendationSchema).default([]),
   publishingPlan: z.array(z.string().min(1)).default([]),
   trustStatus: z.string().min(1),
@@ -1296,6 +1311,7 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   genericCiEvidenceExport: genericCiEvidenceExportSchema,
   dependencyInventoryEntry: dependencyInventoryEntrySchema,
   dependencyIntegrityEvidence: dependencyIntegrityEvidenceSchema,
+  attestationVerificationEvidence: attestationVerificationEvidenceSchema,
   adapterCapabilityMetadata: adapterCapabilityMetadataSchema,
   githubReference: githubReferenceSchema,
   githubActionsJobEvidence: githubActionsJobEvidenceSchema,
@@ -1627,6 +1643,10 @@ const releaseArtifactFixture = {
     dependencyIntegritySignals: [
       "Dependency inventory covers 2 manifest(s) with 4 declared dependency entries.",
       "Workspace dependency integrity is verified against pnpm-lock.yaml."
+    ],
+    trustSummary: [
+      "Verified 1 attestation or provenance evidence export.",
+      "Trusted publishing remains reviewed separately from bounded attestation verification."
     ],
     approvalRecommendations: [
       {
@@ -2248,6 +2268,21 @@ const dependencyIntegrityEvidenceFixture = {
   provenanceRefs: ["package.json", "packages/cli/package.json", "pnpm-lock.yaml"]
 } as const;
 
+const attestationVerificationEvidenceFixture = {
+  sourcePath: ".agentops/evidence/attestation-verification.json",
+  verifier: "github-artifact-attestation",
+  subject: "@h9-foundry/agentforge-cli@0.7.0",
+  issuer: "https://token.actions.githubusercontent.com",
+  status: "verified",
+  detail: "Verified GitHub artifact attestation for the release package artifact.",
+  predicateType: "https://slsa.dev/provenance/v1",
+  verifiedAt: "2026-03-19T12:45:00.000Z",
+  provenanceRefs: [
+    ".agentops/evidence/attestation-verification.json",
+    "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789"
+  ]
+} as const;
+
 const securityEvidenceNormalizationFixture = {
   targetRef: ".agentops/runs/run-790/bundle.json",
   targetType: "artifact-bundle",
@@ -2556,6 +2591,7 @@ const releaseEvidenceNormalizationFixture = {
   missingEvidenceSources: [],
   ciEvidence: [genericCiEvidenceFixture],
   dependencyIntegrityEvidence: [dependencyIntegrityEvidenceFixture],
+  attestationVerificationEvidence: [attestationVerificationEvidenceFixture],
   versionResolutions: [
     {
       name: "@h9-foundry/agentforge-cli",
@@ -2568,6 +2604,7 @@ const releaseEvidenceNormalizationFixture = {
     { name: "qa-report-refs", status: "passed", detail: "Using one validated QA report reference." },
     { name: "security-report-refs", status: "passed", detail: "Using one validated security report reference." },
     { name: "dependency-integrity", status: "passed", detail: "Dependency inventory is verified against pnpm-lock.yaml." },
+    { name: "attestation-verification", status: "passed", detail: "Verified 1 attestation or provenance evidence export." },
     { name: "workspace-version-targets", status: "passed", detail: "Resolved one workspace version target." }
   ],
   readinessStatus: "ready",
@@ -2583,12 +2620,18 @@ const releaseEvidenceNormalizationFixture = {
       reason: "Promotion remains a release-significant side effect and requires explicit maintainer approval."
     }
   ],
+  trustSummary: [
+    "Verified 1 attestation or provenance evidence export.",
+    "Trusted publishing remains reviewed separately from bounded attestation verification."
+  ],
   provenanceRefs: [
     ".agentops/runs/run-789/bundle.json",
     ".agentops/runs/run-790/bundle.json",
     ".agentops/runs/run-790/summary.md",
     "package.json",
-    "packages/cli/package.json"
+    "packages/cli/package.json",
+    ".agentops/evidence/attestation-verification.json",
+    "https://github.com/H9-Foundry/AgentForge/actions/runs/123456789"
   ]
 } as const;
 
@@ -2776,6 +2819,7 @@ export const schemaFixtures = {
   gitlabMergeRequestScmReference: gitlabMergeRequestScmReferenceFixture,
   ciEvidence: ciEvidenceFixture,
   dependencyIntegrityEvidence: dependencyIntegrityEvidenceFixture,
+  attestationVerificationEvidence: attestationVerificationEvidenceFixture,
   gitlabCiEvidenceExport: gitlabCiEvidenceExportFixture,
   gitlabCiEvidence: gitlabCiEvidenceFixture,
   genericCiEvidenceExport: genericCiEvidenceExportFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -7,6 +7,7 @@ import {
   agentforgeConfigSchema,
   agentOutputSchema,
   approvalCheckpointSchema,
+  attestationVerificationEvidenceSchema,
   auditBundleSchema,
   auditComponentSchema,
   lifecycleArtifactAuditLinkSchema,
@@ -112,6 +113,7 @@ export type ProposedAction = Infer<typeof proposedActionSchema>;
 export type ToolRequest = Infer<typeof toolRequestSchema>;
 export type ToolResult = Infer<typeof toolResultSchema>;
 export type ApprovalCheckpoint = Infer<typeof approvalCheckpointSchema>;
+export type AttestationVerificationEvidence = Infer<typeof attestationVerificationEvidenceSchema>;
 export type AuditEntry = Infer<typeof auditEntrySchema>;
 export type AuditComponent = Infer<typeof auditComponentSchema>;
 export type AuditProvenance = Infer<typeof auditProvenanceSchema>;


### PR DESCRIPTION
## Summary
- add bounded attestation verification evidence contracts and shared types
- normalize local attestation verification evidence into `release-readiness`
- surface trust summary lines and attestation readiness checks in release reports

Stacked on #241.

Closes #171

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/cli/src/internal/builtin-agents.test.ts packages/cli/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`