### PR TITLE
Harden registry distribution trust

### DIFF
--- a/.changeset/registry-distribution-hardening.md
+++ b/.changeset/registry-distribution-hardening.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+"@h9-foundry/agentforge-policy-engine": minor
+---
+
+Add registry distribution verification metadata and policy hardening for non-manual plugin activation.

--- a/docs/PLUGIN_REGISTRY_ROADMAP.md
+++ b/docs/PLUGIN_REGISTRY_ROADMAP.md
@@ -36,6 +36,8 @@ Available now:
 - registry metadata contract for read-only catalog records
 - internal read-only catalog validation and compatibility verification in `packages/registry-client`
 - internal approval-gated catalog activation decisions with audit-ready activation records
+- distribution verification metadata on registry catalog entries
+- consumer trust-summary derivation for manual vs verified-distribution registry entries
 
 Not yet available:
 
@@ -70,7 +72,13 @@ This wedge should not install anything automatically.
 
 ### Wedge 3: Verified Plugin Activation
 
-Define the eventual path for:
+First bounded implementation available now:
+
+- registry metadata can declare distribution verification mode and verification evidence refs
+- activation policy can require distribution verification for non-manual channels
+- registry client can derive maintainer and consumer trust signals from distribution metadata
+
+Still to define or extend:
 
 - verified third-party plugin acquisition
 - signature or provenance checks
@@ -123,3 +131,8 @@ This epic should be decomposed into at least:
 1. registry metadata schema and plugin-catalog contract
 2. read-only registry-client discovery and compatibility verification surface
 3. verified third-party plugin activation flow with explicit approval and trust checks
+
+Status:
+
+- items 1 and 2 are implemented in bounded internal form
+- item 3 is now partially implemented through distribution verification metadata, trust summaries, and non-manual activation hardening

--- a/docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md
+++ b/docs/SUPPLY_CHAIN_RELEASE_TRUST_HARDENING.md
@@ -144,4 +144,4 @@ Status:
 
 - item 1 is now partially implemented as a bounded workspace-inventory and dependency-integrity reporting wedge
 - item 2 is now partially implemented as a bounded local attestation-verification and trust-summary wedge
-- item 3 remains next
+- item 3 is now partially implemented through registry distribution verification metadata and non-manual activation hardening

--- a/packages/policy-engine/src/index.test.ts
+++ b/packages/policy-engine/src/index.test.ts
@@ -269,6 +269,55 @@ describe("policy engine", () => {
     });
   });
 
+  it("denies non-manual plugin activation when distribution verification metadata is missing", () => {
+    const engine = createPolicyEngine(
+      {
+        version: 1,
+        environment: "local",
+        resolvedAt: new Date().toISOString(),
+        defaults: {
+          executionMode: "inspect",
+          modelAccess: false,
+          network: "deny",
+          writes: "approval_required"
+        },
+        paths: {
+          allowedRead: ["**/*"],
+          allowedWrite: [".agentops/runs/**", "tests/**"],
+          blocked: [".env*", "secrets/**"]
+        },
+        plugins: {
+          allowedTiers: ["core", "verified"],
+          allowedSources: ["official", "local"],
+          requireReviewed: true
+        },
+        tools: {
+          "filesystem.read-file": { effect: "allow" }
+        }
+      },
+      "/repo"
+    );
+
+    expect(
+      engine.evaluatePluginActivation(
+        "remote-review",
+        { tier: "verified", source: "official", reviewed: true },
+        {
+          distributionChannel: "npm",
+          activationSupport: "approval-required",
+          verificationMode: "none",
+          verificationEvidenceRefs: [],
+          approvalGranted: true
+        }
+      )
+    ).toEqual({
+      allowed: false,
+      effect: "deny",
+      requiresApproval: false,
+      reason: "Plugin distribution verification is required for remote-review before non-manual activation"
+    });
+  });
+
   it("sanitizes lifecycle artifact summaries and nested payload strings", () => {
     const engine = createPolicyEngine(
       {

--- a/packages/policy-engine/src/index.ts
+++ b/packages/policy-engine/src/index.ts
@@ -22,7 +22,10 @@ export interface PolicyDecision {
 }
 
 export interface PluginActivationDecisionOptions {
+  readonly distributionChannel?: "manual" | "npm";
   readonly activationSupport: "not-supported" | "approval-required";
+  readonly verificationMode?: "none" | "checksum" | "attestation";
+  readonly verificationEvidenceRefs?: readonly string[];
   readonly compatibilityIssues?: readonly { readonly message: string }[];
   readonly approvalGranted?: boolean;
 }
@@ -289,6 +292,19 @@ export function createPolicyEngine(policy: EffectivePolicySnapshot, repoRoot: st
         effect: "deny",
         requiresApproval: false,
         reason: `Plugin compatibility check failed for ${name}: ${options.compatibilityIssues?.[0]?.message ?? "Unknown incompatibility"}`
+      };
+    }
+
+    if (
+      options.distributionChannel &&
+      options.distributionChannel !== "manual" &&
+      (options.verificationMode === "none" || (options.verificationEvidenceRefs?.length ?? 0) === 0)
+    ) {
+      return {
+        allowed: false,
+        effect: "deny",
+        requiresApproval: false,
+        reason: `Plugin distribution verification is required for ${name} before non-manual activation`
       };
     }
 

--- a/packages/registry-client/src/index.test.ts
+++ b/packages/registry-client/src/index.test.ts
@@ -123,6 +123,32 @@ describe("RegistryClient read-only catalog discovery", () => {
     expect(results[0]?.compatible).toBe(true);
   });
 
+  it("derives consumer trust signals for manual and verified-distribution catalog entries", () => {
+    const repoRoot = createRepoFixture();
+    repoRoots.push(repoRoot);
+    const client = new RegistryClient(repoRoot);
+
+    const manualSummary = client.summarizeCatalogEntryTrust(createCatalogEntryFixture());
+    const verifiedSummary = client.summarizeCatalogEntryTrust(
+      registryPluginCatalogEntrySchema.parse(JSON.parse(JSON.stringify(schemaFixtures.verifiedRegistryPluginCatalogEntry)))
+    );
+
+    expect(manualSummary.status).toBe("local-manual");
+    expect(manualSummary.consumerSignals).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("manual-only"),
+        expect.stringContaining("Activation remains approval-gated")
+      ])
+    );
+    expect(verifiedSummary.status).toBe("verification-present");
+    expect(verifiedSummary.consumerSignals).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("attestation verification support"),
+        expect.stringContaining("Verification evidence refs")
+      ])
+    );
+  });
+
   it("prepares approval-gated activation decisions with audit-ready output", () => {
     const repoRoot = createRepoFixture();
     repoRoots.push(repoRoot);
@@ -142,6 +168,7 @@ describe("RegistryClient read-only catalog discovery", () => {
     );
 
     expect(decision.activated).toBe(false);
+    expect(decision.trustSummary.status).toBe("local-manual");
     expect(decision.policyDecision.effect).toBe("approval_required");
     expect(decision.auditEntry.status).toBe("blocked");
     expect(decision.auditEntry.blockedActions).toEqual(["Plugin activation requires approval for Local Review Plugin"]);

--- a/packages/registry-client/src/index.ts
+++ b/packages/registry-client/src/index.ts
@@ -44,7 +44,10 @@ export interface RegistryActivationPolicyEvaluator {
     name: string,
     trust: TrustMetadata,
     options: {
+      distributionChannel: RegistryPluginCatalogEntry["distribution"]["channel"];
       activationSupport: RegistryPluginCatalogEntry["distribution"]["activationSupport"];
+      verificationMode: RegistryPluginCatalogEntry["distribution"]["verificationMode"];
+      verificationEvidenceRefs: readonly string[];
       compatibilityIssues?: readonly RegistryCompatibilityIssue[];
       approvalGranted?: boolean;
     }
@@ -61,9 +64,16 @@ export interface RegistryActivationOptions {
 export interface RegistryActivationDecision {
   readonly entry: RegistryPluginCatalogEntry;
   readonly compatibility: RegistryDiscoveryResult;
+  readonly trustSummary: RegistryDistributionTrustSummary;
   readonly policyDecision: RegistryActivationPolicyDecision;
   readonly activated: boolean;
   readonly auditEntry: AuditEntry;
+}
+
+export interface RegistryDistributionTrustSummary {
+  readonly status: "local-manual" | "verification-required" | "verification-present";
+  readonly consumerSignals: string[];
+  readonly verificationEvidenceRefs: string[];
 }
 
 interface WorkspacePackageRecord {
@@ -279,7 +289,7 @@ function evaluateCatalogEntryCompatibility(
 }
 
 function createActivationAuditEntry(
-  decision: Pick<RegistryActivationDecision, "entry" | "policyDecision" | "activated">
+  decision: Pick<RegistryActivationDecision, "entry" | "policyDecision" | "activated" | "trustSummary">
 ): AuditEntry {
   const timestamp = new Date().toISOString();
   const blockedReason = decision.policyDecision.reason ? [decision.policyDecision.reason] : [];
@@ -293,8 +303,8 @@ function createActivationAuditEntry(
     completedAt: timestamp,
     status: decision.activated ? "success" : "blocked",
     summary: decision.activated
-      ? `Activated catalog plugin ${decision.entry.displayName}`
-      : `Did not activate catalog plugin ${decision.entry.displayName}`,
+      ? `Activated catalog plugin ${decision.entry.displayName} with ${decision.trustSummary.status} distribution trust posture`
+      : `Did not activate catalog plugin ${decision.entry.displayName}; distribution trust posture is ${decision.trustSummary.status}`,
     toolsRequested: [],
     toolsExecuted: [],
     blockedActions: blockedReason,
@@ -328,6 +338,53 @@ function pickRuntimeAgent(moduleValue: unknown): RuntimeAgent | undefined {
   }
 
   return Object.values(moduleValue).find((candidate): candidate is RuntimeAgent => isRuntimeAgent(candidate));
+}
+
+function summarizeCatalogEntryTrust(entry: RegistryPluginCatalogEntry): RegistryDistributionTrustSummary {
+  const consumerSignals = [
+    entry.distribution.channel === "manual"
+      ? "Distribution remains manual-only and outside remote registry install flows."
+      : `Distribution channel is ${entry.distribution.channel} and remains approval-gated for activation.`,
+    entry.distribution.activationSupport === "approval-required"
+      ? "Activation remains approval-gated."
+      : "Activation is not currently supported for this distribution path."
+  ];
+
+  if (entry.distribution.verificationMode === "attestation") {
+    consumerSignals.push("Distribution declares attestation verification support.");
+  } else if (entry.distribution.verificationMode === "checksum") {
+    consumerSignals.push("Distribution declares checksum verification support.");
+  } else {
+    consumerSignals.push("Distribution does not yet declare verification support beyond manual trust review.");
+  }
+
+  if (entry.distribution.verificationEvidenceRefs.length > 0) {
+    consumerSignals.push(
+      `Verification evidence refs: ${entry.distribution.verificationEvidenceRefs.join(", ")}.`
+    );
+  }
+
+  if (entry.distribution.channel === "manual") {
+    return {
+      status: "local-manual",
+      consumerSignals,
+      verificationEvidenceRefs: [...entry.distribution.verificationEvidenceRefs]
+    };
+  }
+
+  if (entry.distribution.verificationMode === "none" || entry.distribution.verificationEvidenceRefs.length === 0) {
+    return {
+      status: "verification-required",
+      consumerSignals,
+      verificationEvidenceRefs: [...entry.distribution.verificationEvidenceRefs]
+    };
+  }
+
+  return {
+    status: "verification-present",
+    consumerSignals,
+    verificationEvidenceRefs: [...entry.distribution.verificationEvidenceRefs]
+  };
 }
 
 export class RegistryClient {
@@ -366,11 +423,16 @@ export class RegistryClient {
     return this.discoverCatalogEntries(this.loadCatalogFromFile(catalogPath), options);
   }
 
+  summarizeCatalogEntryTrust(entry: RegistryPluginCatalogEntry): RegistryDistributionTrustSummary {
+    return summarizeCatalogEntryTrust(entry);
+  }
+
   prepareCatalogAgentActivation(
     entry: RegistryPluginCatalogEntry,
     policy: RegistryActivationPolicyEvaluator,
     options: RegistryActivationOptions = {}
   ): RegistryActivationDecision {
+    const trustSummary = summarizeCatalogEntryTrust(entry);
     const compatibility = evaluateCatalogEntryCompatibility(entry, {
       agentforgeVersion: options.agentforgeVersion ?? readAgentForgeVersion(this.repoRoot),
       manifestVersion: options.manifestVersion ?? CURRENT_AGENT_MANIFEST_VERSION,
@@ -378,7 +440,10 @@ export class RegistryClient {
       pluginType: "agent"
     });
     const policyDecision = policy.evaluatePluginActivation(entry.displayName, entry.trust, {
+      distributionChannel: entry.distribution.channel,
       activationSupport: entry.distribution.activationSupport,
+      verificationMode: entry.distribution.verificationMode,
+      verificationEvidenceRefs: entry.distribution.verificationEvidenceRefs,
       compatibilityIssues: compatibility.issues,
       approvalGranted: options.approvalGranted
     });
@@ -386,6 +451,7 @@ export class RegistryClient {
     const decision = {
       entry,
       compatibility,
+      trustSummary,
       policyDecision,
       activated
     };

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -91,6 +91,7 @@ describe("schema fixtures", () => {
     expect(() => normalizedValidationCommandSchema.parse(schemaFixtures.normalizedValidationCommand)).not.toThrow();
     expect(() => implementationInventorySchema.parse(schemaFixtures.implementationInventory)).not.toThrow();
     expect(() => registryPluginCatalogEntrySchema.parse(schemaFixtures.registryPluginCatalogEntry)).not.toThrow();
+    expect(() => registryPluginCatalogEntrySchema.parse(schemaFixtures.verifiedRegistryPluginCatalogEntry)).not.toThrow();
     expect(() => registryPluginCatalogSchema.parse(schemaFixtures.registryPluginCatalog)).not.toThrow();
     expect(() => incidentArtifactSchema.parse(schemaFixtures.incidentArtifact)).not.toThrow();
     expect(() => evalArtifactSchema.parse(schemaFixtures.evalArtifact)).not.toThrow();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -17,6 +17,7 @@ export const registryPluginTypeSchema = z.enum(["agent", "adapter", "workflow"])
 export const registryDistributionChannelSchema = z.enum(["manual", "npm"]);
 export const registryInstallSupportSchema = z.enum(["manual-only", "not-supported"]);
 export const registryActivationSupportSchema = z.enum(["not-supported", "approval-required"]);
+export const registryDistributionVerificationModeSchema = z.enum(["none", "checksum", "attestation"]);
 export const lifecycleArtifactKindSchema = z.enum([
   "planning-brief",
   "design-record",
@@ -103,7 +104,9 @@ export const registryPluginDistributionSchema = z.object({
   version: z.string().min(1),
   reference: z.string().min(1),
   installSupport: registryInstallSupportSchema.default("manual-only"),
-  activationSupport: registryActivationSupportSchema.default("not-supported")
+  activationSupport: registryActivationSupportSchema.default("not-supported"),
+  verificationMode: registryDistributionVerificationModeSchema.default("none"),
+  verificationEvidenceRefs: z.array(z.string().min(1)).default([])
 });
 
 export const registryPluginCatalogEntrySchema = z.object({
@@ -2704,7 +2707,41 @@ export const schemaFixtures = {
       version: "0.1.0",
       reference: "packages/local-review",
       installSupport: "manual-only",
-      activationSupport: "approval-required"
+      activationSupport: "approval-required",
+      verificationMode: "none",
+      verificationEvidenceRefs: []
+    }
+  },
+  verifiedRegistryPluginCatalogEntry: {
+    id: "remote-review",
+    displayName: "Remote Review Plugin",
+    pluginType: "agent",
+    description: "Catalog entry for a remote review plugin with verified distribution metadata.",
+    catalog: {
+      domain: "review",
+      supportLevel: "planned",
+      maturity: "prototype",
+      trustScope: "official-and-reviewed-local"
+    },
+    trust: {
+      tier: "verified",
+      source: "official",
+      reviewed: true
+    },
+    compatibility: {
+      agentforgeVersionRange: ">=0.9.0",
+      manifestVersion: 1,
+      supportedWorkflowDomains: ["review", "test"]
+    },
+    distribution: {
+      channel: "npm",
+      packageName: "@example/remote-review",
+      version: "1.2.3",
+      reference: "npm:@example/remote-review@1.2.3",
+      installSupport: "not-supported",
+      activationSupport: "approval-required",
+      verificationMode: "attestation",
+      verificationEvidenceRefs: ["https://example.com/attestations/remote-review"]
     }
   },
   registryPluginCatalog: {
@@ -2738,7 +2775,9 @@ export const schemaFixtures = {
           version: "0.1.0",
           reference: "packages/local-review",
           installSupport: "manual-only",
-          activationSupport: "approval-required"
+          activationSupport: "approval-required",
+          verificationMode: "none",
+          verificationEvidenceRefs: []
         }
       }
     ]


### PR DESCRIPTION
## Summary
- add registry distribution verification metadata to the catalog contract
- derive consumer trust summaries from registry distribution metadata
- require distribution verification for future non-manual plugin activation channels

Stacked on #242.

Closes #172

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/registry-client/src/index.test.ts packages/policy-engine/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`