### PR TITLE
Reset tracker and published product truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 
 ## What You Can Do Today
 
-- try the current official workflow wedge with the published CLI, without cloning this monorepo
-- initialize a repository, scan it, and run `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage` with the latest published CLI
+- try the current official workflow surface with the published CLI, without cloning this monorepo
+- initialize a repository, scan it, and run `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, `release-readiness`, `incident-handoff`, and `maintenance-triage` with the latest published CLI
 - use the published CLI today for the current official workflow surface, the bounded planning preset startup path, and the local eval runner and compare flow
-- inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, `implementation-proposal`, `qa-report`, `security-report`, and `maintenance-report`
+- inspect generated audit bundles plus lifecycle artifacts such as `planning-brief`, `design-record`, `implementation-proposal`, `qa-report`, `security-report`, `release-report`, `incident-brief`, and `maintenance-report`
 - run `agentforge eval run` and `agentforge eval compare` locally against the deterministic workflow fixture corpus in the latest published CLI
-- evaluate the secure-by-default runtime model before broader SDLC workflow support lands
+- evaluate the secure-by-default runtime model before broader provider, adapter, and integration support lands
 
 ## Adoption Target
 
@@ -85,11 +85,13 @@ For the new lifecycle wedges, `bundle.json` also persists one structured lifecyc
 - `implementation-proposal` emits an `implementation-proposal` artifact with deterministic inventory, validation-command classification, and a proposal-only next-step plan
 - `qa-review` emits a `qa-report`
 - `security-review` emits a `security-report`
+- `release-readiness` emits a `release-report`
+- `incident-handoff` emits an `incident-brief`
 - `maintenance-triage` emits a `maintenance-report`
 
 ## Project Definition
 
-AgentForge provides the runtime, policy, context, audit, and packaging foundation for software engineering workflows that need to reason over a repository without abandoning deterministic controls. The current official workflow surface is local and repo-first: `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, and `maintenance-triage`.
+AgentForge provides the runtime, policy, context, audit, and packaging foundation for software engineering workflows that need to reason over a repository without abandoning deterministic controls. The current official workflow surface is local and repo-first: `pr-review`, `planning-discovery`, `architecture-design-review`, `implementation-proposal`, `qa-review`, `security-review`, `release-readiness`, `incident-handoff`, and `maintenance-triage`.
 
 ## Problem Statement
 
@@ -117,15 +119,17 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 ### Available Now
 
 - secure-by-default runtime, policy, context, audit, and schema foundation
-- seven official local workflow slices:
+- nine official local workflow slices:
   - `.agentops/workflows/pr-review.yaml`
   - `.agentops/workflows/planning-discovery.yaml`
   - `.agentops/workflows/architecture-design-review.yaml`
   - `.agentops/workflows/implementation-proposal.yaml`
   - `.agentops/workflows/qa-review.yaml`
   - `.agentops/workflows/security-review.yaml`
+  - `.agentops/workflows/release-readiness.yaml`
+  - `.agentops/workflows/incident-handoff.yaml`
   - `.agentops/workflows/maintenance-triage.yaml`
-- official in-repo starter agents for context collection, planning analysis, design analysis, implementation planning, QA analysis, security analysis, maintenance analysis, security audit, code review, and test generation; these are bundled workflow assets, not separately supported external packages
+- official in-repo starter agents for context collection, planning analysis, design analysis, implementation planning, QA analysis, security analysis, release analysis, incident analysis, maintenance analysis, security audit, code review, and test generation; these are bundled workflow assets, not separately supported external packages
 - internal starter adapters for filesystem, git, shell, and GitHub-aware mediation
 - public npm packages for the runtime core, CLI, contracts, and audit surfaces
 - GitHub Actions release automation, trusted publishing, and package verification tooling
@@ -156,8 +160,8 @@ AgentForge is an early open-source platform core, not a complete end-to-end SDLC
 | Build / implementation | Available now | `implementation-proposal` is an official local workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
 | Review / test / QA | Available now | `pr-review` remains official, and `qa-review` is now an official local workflow that consumes an implementation proposal and emits a `qa-report` artifact without widening the default side-effect posture. |
 | Security / compliance / DevSecOps | Available now | `security-review` is an official local workflow that consumes bounded local evidence, emits a `security-report` artifact, and keeps the default path read-only; broader security variants remain planned. |
-| Release / CI/CD | Partial | Release verification and package publishing exist; broader CI/CD workflow coverage is planned. |
-| Operate / incidents / observability handoff | Planned | Not implemented yet. |
+| Release / CI/CD | Available now | `release-readiness` is an official local workflow that consumes bounded local release evidence, emits a `release-report` artifact, and keeps publish or promotion follow-ons outside the default read-only path. |
+| Operate / incidents / observability handoff | Available now | `incident-handoff` is an official local workflow that consumes staged local incident evidence, emits an `incident-brief` artifact, and keeps the default path local-first and read-only. |
 | Maintain / upgrades / docs hygiene | Available now | `maintenance-triage` is an official local workflow that consumes bounded maintenance evidence, emits a `maintenance-report` artifact, and keeps the default path read-only; broader maintenance variants remain planned. |
 
 See [docs/SDLC_COVERAGE.md](docs/SDLC_COVERAGE.md) for the detailed lifecycle map and [docs/SUPPORT_MATRIX.md](docs/SUPPORT_MATRIX.md) for the current support matrix.

--- a/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
+++ b/docs/OPERATIONS_INCIDENT_WORKFLOWS.md
@@ -4,7 +4,7 @@ This document defines the design target for issue [#60](https://github.com/H9-Fo
 
 It now records the implemented `incident-handoff` intake wedge and the remaining planned expansion beyond that first operations entry point.
 
-It does **not** claim that the broader operations or incident workflow family is fully implemented or officially promoted today.
+It does **not** claim that the broader operations or incident workflow family is fully implemented today beyond the first official `incident-handoff` wedge.
 
 ## Why This Exists
 
@@ -41,11 +41,11 @@ Available now:
 Not yet available:
 
 - broader operations or observability adapter support
-- official promotion of `incident-handoff` while the evaluator-path bug remains open
+- broader incident and operations variants beyond `incident-handoff`
 
 ## Recommended Initial Workflow Family
 
-Phase 2 should define one first official wedge:
+Phase 2 should build on the current first official wedge:
 
 - `incident-handoff`
 
@@ -81,9 +81,8 @@ This expansion should not:
 - workflow name: `incident-handoff`
 - trigger: `manual`
 - primary lifecycle domain: `operate`
-- support level at the intake-only implementation slice: `partial`
-- official promotion only after `incident-analyst`, `incident-brief`, deterministic evidence normalization, and the evaluator path are all implemented and validated
-- maturity at first implementation: `mvp`
+- support level at the current implementation slice: `official`
+- current maturity: `mvp`
 
 ### Entry Model
 
@@ -168,5 +167,5 @@ Implemented on current `main`:
 
 Next incident family follow-ons:
 
-1. resolve the evaluator-path bug before official promotion of `incident-handoff`
-2. add broader operations and observability integrations only through explicit, approval-aware adapters
+1. add broader operations and observability integrations only through explicit, approval-aware adapters
+2. add additional incident variants such as postmortem review and alert triage without weakening the local-first posture

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -4,7 +4,9 @@ This document defines how maintainers should work through the AgentForge backlog
 
 It is a **maintainer operating flow**, not a shipped product workflow. Official runtime workflow support is tracked in [docs/SUPPORT_MATRIX.md](SUPPORT_MATRIX.md); this document exists to sequence backlog work and maintain truthful queue state.
 
-The live execution tracker for this process is [#83](https://github.com/H9-Foundry/AgentForge/issues/83).
+The live execution tracker for this process is [#245](https://github.com/H9-Foundry/AgentForge/issues/245).
+
+The original Phase 1 foundation tracker is [#83](https://github.com/H9-Foundry/AgentForge/issues/83) and should now be treated as a completed baseline record rather than the live next-work queue.
 
 ## Operating Posture
 
@@ -47,7 +49,9 @@ Rules:
 
 Current active lane:
 
-1. [#63](https://github.com/H9-Foundry/AgentForge/issues/63) evals and benchmarks framework
+1. [#245](https://github.com/H9-Foundry/AgentForge/issues/245) Phase 2 provider and integration expansion tracker
+2. [#246](https://github.com/H9-Foundry/AgentForge/issues/246) Buildkite CI evidence adapter wedge
+3. [#247](https://github.com/H9-Foundry/AgentForge/issues/247) host-agnostic CI evidence consumption in `release-readiness`
 
 ### Ready Lane
 
@@ -55,10 +59,9 @@ Work that is explicitly designed or queued next, but should not start until the 
 
 Current ready lane:
 
-2. [#62](https://github.com/H9-Foundry/AgentForge/issues/62) plugin and registry roadmap
-3. [#64](https://github.com/H9-Foundry/AgentForge/issues/64) additional SCM and CI integrations roadmap
-4. [#65](https://github.com/H9-Foundry/AgentForge/issues/65) supply-chain and release trust hardening
-5. the plug-and-play external adoption and less-technical user readiness umbrella plus its child issues for preset startup, external agent packaging, quick-path onboarding, local-only readiness criteria, and published CLI parity
+4. [#248](https://github.com/H9-Foundry/AgentForge/issues/248) host-agnostic SCM and CI handoff summary rendering across lifecycle artifacts
+5. additional provider-specific SCM and CI wedges after the first Phase 2 CI follow-ons land
+6. deeper supply-chain and enterprise trust work reopened only after the next provider/integration family is defined explicitly
 
 ### Parallel Safe Lane
 
@@ -90,9 +93,9 @@ Work that is part of the roadmap and ordered relative to dependencies, but not y
 
 Current mapped lane:
 
-- Phase 2 workflow implementation follow-ons under [#139](https://github.com/H9-Foundry/AgentForge/issues/139) through [#159](https://github.com/H9-Foundry/AgentForge/issues/159) (substantially implemented)
-- eval runner / benchmark completion under [#165](https://github.com/H9-Foundry/AgentForge/issues/165) and [#166](https://github.com/H9-Foundry/AgentForge/issues/166)
-- the external adoption/readiness umbrella tracks cross-cutting productization work that depends on these slices but is not satisfied by workflow breadth alone
+- Phase 1 workflow implementation follow-ons under [#139](https://github.com/H9-Foundry/AgentForge/issues/139) through [#159](https://github.com/H9-Foundry/AgentForge/issues/159) are implemented on `main`
+- eval runner / benchmark completion under [#165](https://github.com/H9-Foundry/AgentForge/issues/165) and [#166](https://github.com/H9-Foundry/AgentForge/issues/166) is implemented on `main`
+- the external adoption/readiness umbrella is implemented in its first bounded form and now informs Phase 2 acceptance rather than acting as the active queue
 
 ### Deferred Lane
 
@@ -107,6 +110,7 @@ Current deferred lane:
 - Do not start broader workflow MVP work before the Phase 1 contract docs exist.
 - Do not start build, QA, security, release, maintenance, or operations workflow design until the planning/discovery and architecture/design MVP specs are written.
 - Do not start Phase 3 ecosystem and Phase 4 governance work as active implementation unless the earlier workflow contracts and MVP specs are stable enough to support them.
+- Do not start a new broad implementation family until the live queue tracker reflects the actual completed baseline on `main`.
 
 ## Maintainer Loop
 
@@ -197,4 +201,4 @@ A slice is done when:
 - newcomer usability impact was assessed for user-visible or public-contract changes
 - residual risks are called out explicitly
 
-The queue tracker stays open until the current dependency chain and active execution rules change materially.
+The live queue tracker should be rolled forward when a dependency family is complete; completed trackers should remain as phase-baseline records rather than continuing to list already-merged work as upcoming.

--- a/docs/RELEASE_CICD_WORKFLOWS.md
+++ b/docs/RELEASE_CICD_WORKFLOWS.md
@@ -4,7 +4,7 @@ This document defines the design target for issue [#59](https://github.com/H9-Fo
 
 It describes how AgentForge should grow from the current release/readiness tooling into a broader release and CI/CD workflow family.
 
-It does **not** claim that a broader CI/CD workflow family is implemented or officially shipped today.
+It does **not** claim that a broader CI/CD workflow family is fully implemented today beyond the first official `release-readiness` wedge.
 
 ## Why This Exists
 
@@ -34,7 +34,7 @@ Available now:
 - release validation and publish automation
 - package/version verification
 - audit and lifecycle artifact infrastructure
-- bounded `release-readiness` request validation and workflow asset scaffolding
+- official `release-readiness` workflow asset and request validation
 - bounded `release-report` artifact emission from the local `release-readiness` workflow
 - deterministic release-state normalization across bounded local evidence, QA/security report refs, and workspace version targets
 - approval-classified publish or promotion follow-on recommendations that remain read-only by default
@@ -46,7 +46,7 @@ Not yet available:
 
 ## Recommended Initial Workflow Family
 
-Phase 2 should define one first official wedge:
+Phase 2 should build on the current first official wedge:
 
 - `release-readiness`
 
@@ -56,7 +56,7 @@ Later planned variants can include:
 - `deployment-gate-review`
 - `promotion-approval`
 
-Only `release-readiness` should be targeted for first implementation planning.
+`release-readiness` is already implemented on current `main`; later release-family work should extend it rather than reopening first-wedge planning.
 
 ## User Jobs
 
@@ -83,9 +83,8 @@ This expansion should not:
 - workflow name: `release-readiness`
 - trigger: `manual`
 - primary lifecycle domain: `release`
-- support level at the intake-only implementation slice: `partial`
-- official promotion only after the evaluator path is stable and the workflow is documented against the published npm surface
-- maturity at first implementation: `mvp`
+- support level at the current implementation slice: `official`
+- current maturity: `mvp`
 
 ### Entry Model
 
@@ -161,9 +160,14 @@ Adapter expectations:
 
 ## Follow-On Implementation Slices
 
-This epic should be decomposed into at least:
+Implemented on current `main`:
 
 1. release request schema and official `release-readiness` workflow asset
 2. `release-analyst` starter agent and `release-report` artifact emission
-3. deterministic CI evidence ingestion and release-state normalization
-4. approval-gated publish/promotion orchestration aligned to release-trust controls
+3. deterministic CI evidence ingestion and release-state normalization across bounded local evidence
+
+Next release-family follow-ons:
+
+1. richer host-agnostic CI evidence consumption in `release-readiness`
+2. additional release and deployment-gate variants built on the bounded release wedge
+3. approval-gated publish/promotion orchestration aligned to release-trust controls

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -24,10 +24,11 @@ This roadmap separates current implementation from near-term platform work and l
 The current shipped baseline is:
 
 - secure runtime, policy, context, schema, audit, and CLI core
-- one official local `pr-review` workflow
-- one set of official starter agents
+- nine official local workflow wedges across review, planning, design, implementation, QA, security, release, incident handoff, and maintenance
+- one set of official in-repo starter agents for those workflows
 - internal starter adapters
 - release, package verification, and trusted publishing automation
+- published eval runner and compare flow
 
 ## Phase 1: Platform Foundation
 
@@ -85,11 +86,13 @@ The current shipped baseline is:
 
 The backlog execution model is documented in [docs/QUEUE_EXECUTION_FLOW.md](QUEUE_EXECUTION_FLOW.md).
 
-Use [#83](https://github.com/H9-Foundry/AgentForge/issues/83) as the live execution tracker for:
+Use [#245](https://github.com/H9-Foundry/AgentForge/issues/245) as the live execution tracker for:
 
 - active versus ready versus mapped versus deferred queue lanes
 - dependency ordering across the next slices
 - dogfooding and validation gates for each slice
+
+Treat [#83](https://github.com/H9-Foundry/AgentForge/issues/83) as the completed Phase 1 baseline tracker.
 
 The first Phase 1 newcomer-usability lane was completed under [#97](https://github.com/H9-Foundry/AgentForge/issues/97).
 

--- a/docs/SDLC_COVERAGE.md
+++ b/docs/SDLC_COVERAGE.md
@@ -17,8 +17,8 @@ Workflow coverage is not the same thing as plug-and-play external usability. A l
 | Build / implementation | Available now | `implementation-proposal` is an official local workflow that validates `.agentops/requests/implementation.yaml`, requires a `designRecordRef`, and emits an `implementation-proposal` artifact without widening the default side-effect posture. | Expand from proposal-only implementation planning into downstream QA, security review, and gated apply-capable follow-ons. |
 | Review / test / QA | Available now | `pr-review` remains available, and `qa-review` is now an official local workflow that validates `.agentops/requests/qa.yaml`, consumes an implementation proposal bundle, and emits a `qa-report` artifact with deterministic evidence normalization. | Broaden into additional QA variants such as regression triage and release-readiness QA. |
 | Security / compliance / DevSecOps | Available now | `security-review` is an official local workflow that validates `.agentops/requests/security.yaml`, consumes bounded local evidence, and emits a `security-report` artifact without widening the default side-effect posture. | Expand beyond `security-review` into additional security/DevSecOps variants, adapters, and evals. |
-| Release / CI/CD | In progress | Release verification, trusted publishing, package validation, and GitHub workflows exist. | Add broader release/CI workflow coverage beyond package publishing. |
-| Operate / incident response / observability handoff | Planned | No official workflow yet. | Add incident-handoff and operational context workflows. |
+| Release / CI/CD | Available now | `release-readiness` is an official local workflow that validates `.agentops/requests/release.yaml`, consumes bounded local release evidence, and emits a `release-report` artifact without widening the default side-effect posture. | Expand into additional release and CI/CD variants such as pipeline evidence review and deployment-gate review. |
+| Operate / incident response / observability handoff | Available now | `incident-handoff` is an official local workflow that validates `.agentops/requests/incident.yaml`, consumes staged local incident evidence, and emits an `incident-brief` artifact with deterministic provenance and follow-up routing. | Expand into additional incident and operations variants such as postmortem review and alert triage. |
 | Maintain / upgrade / docs / dependency hygiene | Available now | `maintenance-triage` is an official local workflow that validates `.agentops/requests/maintenance.yaml`, consumes bounded maintenance evidence, and emits a `maintenance-report` artifact with deterministic routing support. | Expand into additional maintenance variants such as dependency-upgrade review, docs-hygiene review, and backlog refresh. |
 
 ## Official Workflows
@@ -43,20 +43,21 @@ Workflow coverage is not the same thing as plug-and-play external usability. A l
 - `security-review`
   - location: `.agentops/workflows/security-review.yaml`
   - purpose: validate a security request, consume bounded local evidence, and emit a `security-report` lifecycle artifact with deterministic evidence normalization and tighter policy handling
+- `release-readiness`
+  - location: `.agentops/workflows/release-readiness.yaml`
+  - purpose: validate a release request, consume bounded local release evidence, and emit a `release-report` lifecycle artifact without widening the default side-effect posture
+- `incident-handoff`
+  - location: `.agentops/workflows/incident-handoff.yaml`
+  - purpose: validate an incident request, consume staged local incident evidence, and emit an `incident-brief` lifecycle artifact with deterministic provenance capture and routing
 - `maintenance-triage`
   - location: `.agentops/workflows/maintenance-triage.yaml`
   - purpose: validate a maintenance request, consume bounded maintenance evidence, and emit a `maintenance-report` lifecycle artifact with deterministic routing support
-
-### In progress
-
-- release / CI-CD
-- operations / incident response / observability handoff
 
 ### Planned
 
 - additional QA variants beyond `qa-review`
 - security/DevSecOps
-- release/CI-CD
+- additional release/CI-CD variants
 - additional operations/incident variants
 - additional maintenance/dependency/docs hygiene variants
 
@@ -73,6 +74,8 @@ Workflow coverage is not the same thing as plug-and-play external usability. A l
 - `implementation-planner`
 - `qa-analyst`
 - `security-analyst`
+- `release-analyst`
+- `incident-analyst`
 - `maintenance-analyst`
 
 ### Planned expansion areas

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -27,10 +27,12 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `implementation-proposal` | Official | CLI-first implementation workflow that consumes a design record, emits an `implementation-proposal` artifact, and keeps the default path read-only and proposal-only. |
 | `qa-review` | Official | Dedicated QA workflow that consumes an implementation proposal and emits a `qa-report` artifact with deterministic evidence normalization ahead of reasoning. |
 | `security-review` | Official | Dedicated security workflow that consumes bounded local evidence, emits a `security-report` artifact, and keeps the default path read-only with tighter policy handling. |
+| `release-readiness` | Official | Dedicated release workflow that consumes bounded local release evidence, emits a `release-report` artifact, and keeps publish or promotion follow-ons outside the default read-only path. |
+| `incident-handoff` | Official | Dedicated operations workflow that consumes staged local incident evidence, emits an `incident-brief` artifact, and keeps the default path local-first and read-only. |
 | `maintenance-triage` | Official | Dedicated maintenance workflow that consumes bounded maintenance evidence, emits a `maintenance-report` artifact, and keeps the default path read-only with deterministic routing support. |
 | security / DevSecOps extensions | Planned | Additional security variants beyond `security-review` are not implemented yet. |
-| release / CI-CD | Planned | Release automation exists, but not as a broader official SDLC workflow family. |
-| operations / incident handoff | Planned | Roadmap item only. |
+| release / CI-CD extensions | Planned | Additional release and CI/CD variants beyond `release-readiness` are not implemented yet. |
+| operations / incident variants | Planned | Additional operations and incident variants beyond `incident-handoff` are not implemented yet. |
 | maintenance / dependency/docs hygiene variants | Planned | Additional maintenance variants beyond `maintenance-triage` are not implemented yet. |
 
 ## Agent Support
@@ -45,11 +47,13 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `implementation-planner` | Official | Starter implementation agent for `implementation-proposal`. |
 | `qa-analyst` | Official | Starter QA agent for `qa-review`; supported as an in-repo workflow asset, not as a standalone external package. |
 | `security-analyst` | Official | Starter security agent for `security-review`; supported as an in-repo workflow asset, not as a standalone external package. |
+| `release-analyst` | Official | Starter release agent for `release-readiness`; supported as an in-repo workflow asset, not as a standalone external package. |
+| `incident-analyst` | Official | Starter incident agent for `incident-handoff`; supported as an in-repo workflow asset, not as a standalone external package. |
 | `maintenance-analyst` | Official | Starter maintenance agent for `maintenance-triage`; supported as an in-repo workflow asset, not as a standalone external package. |
 | `security-audit` | Official | Current starter agent. |
 | `code-review` | Official | Current starter agent. |
 | `test-generation` | Official | Current starter agent. |
-| release/operations agents | Planned | Not implemented yet. |
+| additional release/operations agents | Planned | Further release and incident variants remain unimplemented. |
 
 ## Adapter And Integration Support
 
@@ -59,8 +63,8 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | git adapter | Internal | Used by the runtime, not a separately supported public package. |
 | shell adapter | Internal | Present, but side effects remain tightly constrained by policy. |
 | GitHub adapter | Internal | Current GitHub-aware mediation is narrow and intentionally bounded. |
-| additional SCM integrations | Planned | Not implemented yet. |
-| additional CI integrations | Planned | Not implemented yet. |
+| additional SCM integrations | Partial | Shared SCM contracts now exist and the bounded GitLab reference wedge is implemented; broader host support remains planned. |
+| additional CI integrations | Partial | Shared CI contracts plus bounded GitHub, GitLab, and generic local CI evidence ingestion now exist; broader provider support remains planned. |
 | observability/incident integrations | Planned | Not implemented yet. |
 | registry integrations | Planned | `packages/registry-client` remains a future-facing surface. |
 
@@ -107,7 +111,8 @@ See [docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md](EXTERNAL_LOCAL_ADOPTION_READINES
 | implementation planning on the AgentForge repo | Official | Covered by `implementation-proposal` with deterministic inventory and proposal-only output. |
 | PR review and QA on the AgentForge repo | Official | Covered by `pr-review` for repository review and `qa-review` for dedicated QA handoff and `qa-report` artifacts. |
 | security and maintenance triage on the AgentForge repo | Official | Covered by `security-review` and `maintenance-triage` with bounded evidence normalization and lifecycle artifact output. |
-| release/readiness verification on the AgentForge repo | Official | Covered by `release guide`, `release check`, and `release verify`. |
+| release/readiness verification on the AgentForge repo | Official | Covered by `release-readiness` plus `release guide`, `release check`, and `release verify`. |
+| incident handoff on the AgentForge repo | Official | Covered by `incident-handoff` with staged evidence intake and `incident-brief` artifact output. |
 | autonomous implementation on the AgentForge repo | Planned | Not an official supported mode yet. |
 
 ## Compatibility Notes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # AgentForge Architecture
 
-AgentForge is currently an early SDLC platform core with one official workflow wedge: secure local repository review. The architecture is intentionally broader than that single workflow so the platform can expand across more lifecycle domains without abandoning deterministic control.
+AgentForge is currently an early SDLC platform core with an official local workflow surface that spans review, planning, design, implementation, QA, security, release readiness, incident handoff, and maintenance. The architecture is intentionally broader than the current workflow set so the platform can expand across more lifecycle domains without abandoning deterministic control.
 
 ## Package Map
 
@@ -35,8 +35,16 @@ AgentForge is currently an early SDLC platform core with one official workflow w
 ## Current Official Workflow Surface
 
 - `.agentops/workflows/pr-review.yaml`
+- `.agentops/workflows/planning-discovery.yaml`
+- `.agentops/workflows/architecture-design-review.yaml`
+- `.agentops/workflows/implementation-proposal.yaml`
+- `.agentops/workflows/qa-review.yaml`
+- `.agentops/workflows/security-review.yaml`
+- `.agentops/workflows/release-readiness.yaml`
+- `.agentops/workflows/incident-handoff.yaml`
+- `.agentops/workflows/maintenance-triage.yaml`
 
-That is the only official workflow asset today. Broader workflow coverage belongs to the roadmap, not to the current implementation claim.
+Broader workflow coverage beyond those bundled assets still belongs to the roadmap rather than the current implementation claim.
 
 ## Extension Surfaces
 


### PR DESCRIPTION
## Summary
- promote `release-readiness` and `incident-handoff` consistently across the published support story
- move the live queue tracker from #83 to #245 and close Phase 1 as a completed baseline
- align roadmap, support, SDLC, and architecture docs with the actual `main` and published `0.9.0` surface

Part of #245

## Validation
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`