### PR TITLE
Add Buildkite CI evidence wedge

### DIFF
--- a/.changeset/buildkite-ci-evidence-wedge.md
+++ b/.changeset/buildkite-ci-evidence-wedge.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Add a bounded Buildkite CI evidence export contract and normalize Buildkite pipeline exports into shared CI evidence.

--- a/docs/SCM_CI_INTEGRATIONS_ROADMAP.md
+++ b/docs/SCM_CI_INTEGRATIONS_ROADMAP.md
@@ -36,6 +36,7 @@ Implemented now:
 - adapter capability metadata for bounded host behavior
 - bounded GitLab issue and merge-request normalization into the shared SCM contract
 - bounded local GitLab CI evidence normalization into the shared CI contract
+- bounded local Buildkite CI evidence normalization into the shared CI contract
 - bounded generic CI evidence ingestion for local pipeline status and artifact exports
 
 Not yet available:
@@ -68,12 +69,13 @@ The first additional target validates the host-agnostic model with one concrete 
 
 This provides a meaningful contrast to GitHub without exploding scope.
 
-### Priority 3: Additional Generic CI Evidence
+### Priority 3: Additional Provider And Generic CI Evidence
 
-Status: implemented as the first generic local CI evidence wedge.
+Status: Buildkite wedge next, with the first generic local CI evidence wedge already implemented.
 
 After the first new host pair:
 
+- validate one more explicit provider-specific CI wedge
 - expand to generic CI evidence adapters
 - consider Buildkite, Jenkins, or similar systems where bounded evidence ingestion makes sense
 
@@ -118,4 +120,5 @@ This epic should be decomposed into at least:
 1. host-agnostic SCM and CI reference contracts plus adapter capability metadata
 2. implemented: GitLab issue/MR and CI evidence integration wedge as the first additional concrete host pair
 3. implemented: generic CI evidence adapter surface for bounded local pipeline status and artifact ingestion
-4. next: additional provider-specific CI adapters and richer host-agnostic workflow consumption built on the shared contracts
+4. next: Buildkite CI evidence adapter wedge as the next additional bounded provider
+5. next: richer host-agnostic workflow consumption built on the shared contracts

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1198,16 +1198,15 @@ describe("cli smoke flows", () => {
     );
   });
 
-  it("ingests bounded generic CI evidence exports during qa-review", async () => {
+  it("ingests bounded Buildkite CI evidence exports during qa-review", async () => {
     const root = createFixtureRepo();
 
     initProject(root);
     mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
     writeFileSync(
-      join(root, ".agentops", "evidence", "generic-ci.json"),
+      join(root, ".agentops", "evidence", "buildkite-ci.json"),
       JSON.stringify(
         {
-          providerName: "Buildkite",
           host: "buildkite.local",
           repository: "H9-Foundry/fixture",
           pipelineName: "Buildkite CI",
@@ -1251,7 +1250,7 @@ describe("cli smoke flows", () => {
       [
         "targetRef: package.json",
         "evidenceSources:",
-        "  - .agentops/evidence/generic-ci.json",
+        "  - .agentops/evidence/buildkite-ci.json",
         "executedChecks:",
         "  - pnpm test",
         "focusAreas:",
@@ -1868,31 +1867,31 @@ describe("cli smoke flows", () => {
       join(root, ".agentops", "evidence", "generic-ci.json"),
       JSON.stringify(
         {
-          providerName: "Buildkite",
-          host: "buildkite.local",
+          providerName: "Jenkins",
+          host: "jenkins.local",
           repository: "H9-Foundry/fixture",
-          pipelineName: "Buildkite CI",
-          pipelineRunId: "bk-123",
+          pipelineName: "Jenkins CI",
+          pipelineRunId: "jenkins-42",
           runAttempt: 1,
-          event: "pull_request",
+          event: "push",
           branch: "main",
           commitSha: "abc123",
           status: "completed",
-          conclusion: "failure",
-          htmlUrl: "https://buildkite.example.com/builds/123",
+          conclusion: "success",
+          htmlUrl: "https://jenkins.example.com/job/agentforge/42",
           jobs: [
             {
               name: "test",
               status: "completed",
               conclusion: "success",
-              htmlUrl: "https://buildkite.example.com/builds/123/jobs/1"
+              htmlUrl: "https://jenkins.example.com/job/agentforge/42/test"
             }
           ],
           artifacts: [
             {
-              name: "junit-report",
-              type: "junit-xml",
-              path: "artifacts/junit.xml"
+              name: "coverage-report",
+              type: "html-report",
+              path: "artifacts/coverage/index.html"
             }
           ]
         },
@@ -1987,10 +1986,10 @@ describe("cli smoke flows", () => {
       expect.arrayContaining([expect.objectContaining({ name: "imported-ci-evidence", status: "passed" })])
     );
     expect(bundle.lifecycleArtifacts[0]?.payload?.publishingPlan).toEqual(
-      expect.arrayContaining(["Review the imported CI evidence from `Buildkite` before any publish or promotion step."])
+      expect.arrayContaining(["Review the imported CI evidence from `Jenkins` before any publish or promotion step."])
     );
     expect(bundle.lifecycleArtifacts[0]?.payload?.externalDependencies).toEqual(
-      expect.arrayContaining(["Imported CI evidence from Buildkite remains available for reviewer inspection."])
+      expect.arrayContaining(["Imported CI evidence from Jenkins remains available for reviewer inspection."])
     );
   });
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -5,6 +5,7 @@ import {
   agentManifestSchema,
   agentOutputSchema,
   attestationVerificationEvidenceSchema,
+  buildkiteCiEvidenceExportSchema,
   ciEvidenceSchema,
   dependencyIntegrityEvidenceSchema,
   genericCiEvidenceExportSchema,
@@ -34,6 +35,7 @@ import {
 import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
 import type {
   AttestationVerificationEvidence,
+  BuildkiteCiEvidenceExport,
   CiEvidence,
   DependencyIntegrityEvidence,
   DependencyInventoryEntry,
@@ -652,6 +654,17 @@ function loadGitLabCiEvidenceExport(bundlePath: string): GitlabCiEvidenceExport 
   return result.success ? result.data : undefined;
 }
 
+function loadBuildkiteCiEvidenceExport(bundlePath: string): BuildkiteCiEvidenceExport | undefined {
+  if (!existsSync(bundlePath) || !bundlePath.endsWith(".json")) {
+    return undefined;
+  }
+
+  const parsed = JSON.parse(readFileSync(bundlePath, "utf8")) as unknown;
+  const candidate = isRecord(parsed) ? { ...parsed, sourcePath: parsed.sourcePath ?? bundlePath } : parsed;
+  const result = buildkiteCiEvidenceExportSchema.safeParse(candidate);
+  return result.success ? result.data : undefined;
+}
+
 function loadGenericCiEvidenceExport(bundlePath: string): GenericCiEvidenceExport | undefined {
   if (!existsSync(bundlePath) || !bundlePath.endsWith(".json")) {
     return undefined;
@@ -766,12 +779,53 @@ function normalizeGenericCiEvidence(
   });
 }
 
+function normalizeBuildkiteCiEvidence(
+  repoRoot: string | undefined,
+  evidenceSources: readonly string[]
+): CiEvidence[] {
+  return evidenceSources.flatMap((pathValue) => {
+    if (!repoRoot) {
+      return [];
+    }
+
+    const normalized = loadBuildkiteCiEvidenceExport(join(repoRoot, pathValue));
+    if (!normalized) {
+      return [];
+    }
+
+    const evidence = ciEvidenceSchema.parse({
+      platform: "buildkite",
+      providerName: "Buildkite",
+      host: normalized.host,
+      repository: normalized.repository,
+      pipelineName: normalized.pipelineName,
+      pipelineRunId: normalized.pipelineRunId,
+      runAttempt: normalized.runAttempt,
+      event: normalized.event,
+      branch: normalized.branch,
+      commitSha: normalized.commitSha,
+      status: normalized.status,
+      conclusion: normalized.conclusion,
+      htmlUrl: normalized.htmlUrl,
+      jobs: normalized.jobs,
+      artifacts: normalized.artifacts,
+      provenanceSource: "local-export"
+    });
+
+    return [evidence];
+  });
+}
+
 function normalizeImportedCiEvidence(
   repoRoot: string | undefined,
   evidenceSources: readonly string[]
 ): CiEvidence[] {
   const seen = new Set<string>();
-  const combined = [...normalizeGitLabCiEvidence(repoRoot, evidenceSources), ...normalizeGenericCiEvidence(repoRoot, evidenceSources)];
+  const combined = [
+    ...normalizeGitLabCiEvidence(repoRoot, evidenceSources),
+    ...normalizeBuildkiteCiEvidence(repoRoot, evidenceSources),
+    ...normalizeGenericCiEvidence(repoRoot, evidenceSources)
+  ];
   const normalized: CiEvidence[] = [];
 
   for (const evidence of combined) {

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   auditBundleSchema,
   benchmarkArtifactSchema,
   attestationVerificationEvidenceSchema,
+  buildkiteCiEvidenceExportSchema,
   ciArtifactEvidenceSchema,
   ciEvidenceSchema,
   dependencyIntegrityEvidenceSchema,
@@ -73,14 +74,17 @@ describe("schema fixtures", () => {
     expect(() => ciArtifactEvidenceSchema.parse(schemaFixtures.genericCiEvidence.artifacts[0])).not.toThrow();
     expect(() => ciEvidenceSchema.parse(schemaFixtures.ciEvidence)).not.toThrow();
     expect(() => ciEvidenceSchema.parse(schemaFixtures.gitlabCiEvidence)).not.toThrow();
+    expect(() => ciEvidenceSchema.parse(schemaFixtures.buildkiteCiEvidence)).not.toThrow();
     expect(() => ciEvidenceSchema.parse(schemaFixtures.genericCiEvidence)).not.toThrow();
     expect(() => dependencyInventoryEntrySchema.parse(schemaFixtures.dependencyIntegrityEvidence.inventoryEntries[0])).not.toThrow();
     expect(() => dependencyIntegrityEvidenceSchema.parse(schemaFixtures.dependencyIntegrityEvidence)).not.toThrow();
     expect(() => attestationVerificationEvidenceSchema.parse(schemaFixtures.attestationVerificationEvidence)).not.toThrow();
     expect(() => gitlabCiEvidenceExportSchema.parse(schemaFixtures.gitlabCiEvidenceExport)).not.toThrow();
+    expect(() => buildkiteCiEvidenceExportSchema.parse(schemaFixtures.buildkiteCiEvidenceExport)).not.toThrow();
     expect(() => genericCiEvidenceExportSchema.parse(schemaFixtures.genericCiEvidenceExport)).not.toThrow();
     expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.adapterCapabilityMetadata)).not.toThrow();
     expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.gitlabAdapterCapabilityMetadata)).not.toThrow();
+    expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.buildkiteAdapterCapabilityMetadata)).not.toThrow();
     expect(() => adapterCapabilityMetadataSchema.parse(schemaFixtures.genericCiAdapterCapabilityMetadata)).not.toThrow();
     expect(() => githubActionsEvidenceSchema.parse(schemaFixtures.githubActionsEvidence)).not.toThrow();
     expect(() =>
@@ -132,6 +136,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.dependencyInventoryEntry).toBeDefined();
     expect(jsonSchemas.dependencyIntegrityEvidence).toBeDefined();
     expect(jsonSchemas.attestationVerificationEvidence).toBeDefined();
+    expect(jsonSchemas.buildkiteCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.genericCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.gitlabCiEvidenceExport).toBeDefined();
     expect(jsonSchemas.adapterCapabilityMetadata).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -456,7 +456,7 @@ export const githubActionsEvidenceNormalizationSchema = z.object({
 
 export const scmPlatformSchema = z.enum(["github", "gitlab", "generic"]);
 export const scmReferenceKindSchema = z.enum(["issue", "pull_request", "merge_request", "commit", "branch"]);
-export const ciPlatformSchema = z.enum(["github-actions", "gitlab-ci", "generic-ci"]);
+export const ciPlatformSchema = z.enum(["github-actions", "gitlab-ci", "buildkite", "generic-ci"]);
 
 export const scmReferenceSchema = z.object({
   platform: scmPlatformSchema,
@@ -529,6 +529,23 @@ export const gitlabCiEvidenceExportSchema = z.object({
   status: gitlabCiJobExportStatusSchema,
   webUrl: z.string().url().optional(),
   jobs: z.array(gitlabCiJobEvidenceExportSchema).default([])
+});
+
+export const buildkiteCiEvidenceExportSchema = z.object({
+  sourcePath: z.string().min(1).optional(),
+  host: z.string().min(1).default("buildkite.com"),
+  repository: z.string().min(1),
+  pipelineName: z.string().min(1).default("Buildkite"),
+  pipelineRunId: z.string().min(1),
+  runAttempt: z.number().int().positive().default(1),
+  event: z.string().min(1).optional(),
+  branch: z.string().min(1).optional(),
+  commitSha: z.string().min(1).optional(),
+  status: githubActionsRunStatusSchema,
+  conclusion: githubActionsConclusionSchema.optional(),
+  htmlUrl: z.string().url().optional(),
+  jobs: z.array(ciJobEvidenceSchema).default([]),
+  artifacts: z.array(ciArtifactEvidenceSchema).default([])
 });
 
 export const genericCiEvidenceExportSchema = z.object({
@@ -1311,6 +1328,7 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   ciEvidence: ciEvidenceSchema,
   gitlabCiJobEvidenceExport: gitlabCiJobEvidenceExportSchema,
   gitlabCiEvidenceExport: gitlabCiEvidenceExportSchema,
+  buildkiteCiEvidenceExport: buildkiteCiEvidenceExportSchema,
   genericCiEvidenceExport: genericCiEvidenceExportSchema,
   dependencyInventoryEntry: dependencyInventoryEntrySchema,
   dependencyIntegrityEvidence: dependencyIntegrityEvidenceSchema,
@@ -2044,9 +2062,8 @@ const gitlabCiEvidenceFixture = {
   provenanceSource: "local-export"
 } as const;
 
-const genericCiEvidenceExportFixture = {
+const buildkiteCiEvidenceExportFixture = {
   sourcePath: ".agentops/evidence/buildkite-ci.json",
-  providerName: "Buildkite",
   host: "buildkite.local",
   repository: "h9-foundry/platform/agentforge",
   pipelineName: "Buildkite CI",
@@ -2081,8 +2098,8 @@ const genericCiEvidenceExportFixture = {
   ]
 } as const;
 
-const genericCiEvidenceFixture = {
-  platform: "generic-ci",
+const buildkiteCiEvidenceFixture = {
+  platform: "buildkite",
   providerName: "Buildkite",
   host: "buildkite.local",
   repository: "h9-foundry/platform/agentforge",
@@ -2119,6 +2136,69 @@ const genericCiEvidenceFixture = {
   provenanceSource: "local-export"
 } as const;
 
+const genericCiEvidenceExportFixture = {
+  sourcePath: ".agentops/evidence/generic-ci.json",
+  providerName: "Jenkins",
+  host: "jenkins.local",
+  repository: "h9-foundry/platform/agentforge",
+  pipelineName: "Jenkins CI",
+  pipelineRunId: "jenkins-42",
+  runAttempt: 1,
+  event: "push",
+  branch: "main",
+  commitSha: "caf36447a49fc6e9fc308c34b98424958237aa1e",
+  status: "completed",
+  conclusion: "success",
+  htmlUrl: "https://jenkins.example.com/job/agentforge/42",
+  jobs: [
+    {
+      name: "test",
+      status: "completed",
+      conclusion: "success",
+      htmlUrl: "https://jenkins.example.com/job/agentforge/42/test"
+    }
+  ],
+  artifacts: [
+    {
+      name: "coverage-report",
+      type: "html-report",
+      path: "artifacts/coverage/index.html"
+    }
+  ]
+} as const;
+
+const genericCiEvidenceFixture = {
+  platform: "generic-ci",
+  providerName: "Jenkins",
+  host: "jenkins.local",
+  repository: "h9-foundry/platform/agentforge",
+  pipelineName: "Jenkins CI",
+  pipelineRunId: "jenkins-42",
+  runAttempt: 1,
+  event: "push",
+  branch: "main",
+  commitSha: "caf36447a49fc6e9fc308c34b98424958237aa1e",
+  status: "completed",
+  conclusion: "success",
+  htmlUrl: "https://jenkins.example.com/job/agentforge/42",
+  jobs: [
+    {
+      name: "test",
+      status: "completed",
+      conclusion: "success",
+      htmlUrl: "https://jenkins.example.com/job/agentforge/42/test"
+    }
+  ],
+  artifacts: [
+    {
+      name: "coverage-report",
+      type: "html-report",
+      path: "artifacts/coverage/index.html"
+    }
+  ],
+  provenanceSource: "local-export"
+} as const;
+
 const adapterCapabilityMetadataFixture = {
   platform: "github",
   host: "github.com",
@@ -2142,6 +2222,15 @@ const gitlabAdapterCapabilityMetadataFixture = {
     "merge-request-reference-normalization",
     "local-ci-evidence-ingestion"
   ],
+  trustBoundary: "local-only"
+} as const;
+
+const buildkiteAdapterCapabilityMetadataFixture = {
+  platform: "generic",
+  host: "buildkite.local",
+  supportedScmReferenceKinds: [],
+  supportedCiPlatforms: ["buildkite"],
+  capabilities: ["local-ci-evidence-ingestion"],
   trustBoundary: "local-only"
 } as const;
 
@@ -2589,10 +2678,11 @@ const releaseEvidenceNormalizationFixture = {
     ".agentops/runs/run-789/bundle.json",
     ".agentops/runs/run-790/bundle.json",
     ".agentops/runs/run-790/summary.md",
-    ".agentops/evidence/buildkite-ci.json"
+    ".agentops/evidence/buildkite-ci.json",
+    ".agentops/evidence/generic-ci.json"
   ],
   missingEvidenceSources: [],
-  ciEvidence: [genericCiEvidenceFixture],
+  ciEvidence: [buildkiteCiEvidenceFixture, genericCiEvidenceFixture],
   dependencyIntegrityEvidence: [dependencyIntegrityEvidenceFixture],
   attestationVerificationEvidence: [attestationVerificationEvidenceFixture],
   versionResolutions: [
@@ -2861,10 +2951,13 @@ export const schemaFixtures = {
   attestationVerificationEvidence: attestationVerificationEvidenceFixture,
   gitlabCiEvidenceExport: gitlabCiEvidenceExportFixture,
   gitlabCiEvidence: gitlabCiEvidenceFixture,
+  buildkiteCiEvidenceExport: buildkiteCiEvidenceExportFixture,
+  buildkiteCiEvidence: buildkiteCiEvidenceFixture,
   genericCiEvidenceExport: genericCiEvidenceExportFixture,
   genericCiEvidence: genericCiEvidenceFixture,
   adapterCapabilityMetadata: adapterCapabilityMetadataFixture,
   gitlabAdapterCapabilityMetadata: gitlabAdapterCapabilityMetadataFixture,
+  buildkiteAdapterCapabilityMetadata: buildkiteAdapterCapabilityMetadataFixture,
   genericCiAdapterCapabilityMetadata: genericCiAdapterCapabilityMetadataFixture,
   githubActionsEvidence: githubActionsEvidenceFixture,
   githubHandoffSummary: githubHandoffSummaryFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -38,6 +38,7 @@ import {
   benchmarkArtifactSchema,
   benchmarkComparedRunSchema,
   benchmarkDeterministicDeltaSchema,
+  buildkiteCiEvidenceExportSchema,
   ciArtifactEvidenceSchema,
   ciEvidenceSchema,
   dependencyIntegrityEvidenceSchema,
@@ -121,6 +122,7 @@ export type AuditRedaction = Infer<typeof auditRedactionSchema>;
 export type CiArtifactEvidence = Infer<typeof ciArtifactEvidenceSchema>;
 export type CiJobEvidence = Infer<typeof ciJobEvidenceSchema>;
 export type CiEvidence = Infer<typeof ciEvidenceSchema>;
+export type BuildkiteCiEvidenceExport = Infer<typeof buildkiteCiEvidenceExportSchema>;
 export type DependencyInventoryEntry = Infer<typeof dependencyInventoryEntrySchema>;
 export type DependencyIntegrityEvidence = Infer<typeof dependencyIntegrityEvidenceSchema>;
 export type GenericCiEvidenceExport = Infer<typeof genericCiEvidenceExportSchema>;


### PR DESCRIPTION
## Summary
- add explicit Buildkite CI export contracts and fixtures
- normalize Buildkite pipeline and job exports into shared `CiEvidence`
- preserve generic CI ingestion for non-Buildkite providers while updating SCM/CI roadmap truth

Closes #246

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/cli/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`