### PR TITLE
Consume shared CI evidence in release-readiness

### DIFF
--- a/.changeset/release-readiness-ci-summary.md
+++ b/.changeset/release-readiness-ci-summary.md
@@ -1,0 +1,7 @@
+---
+"@h9-foundry/agentforge-cli": patch
+"@h9-foundry/agentforge-schemas": patch
+"@h9-foundry/agentforge-shared-types": patch
+---
+
+Expose normalized host-agnostic CI provenance and status summaries in release-readiness artifacts.

--- a/docs/RELEASE_CICD_WORKFLOWS.md
+++ b/docs/RELEASE_CICD_WORKFLOWS.md
@@ -165,9 +165,9 @@ Implemented on current `main`:
 1. release request schema and official `release-readiness` workflow asset
 2. `release-analyst` starter agent and `release-report` artifact emission
 3. deterministic CI evidence ingestion and release-state normalization across bounded local evidence
+4. richer host-agnostic CI provenance and status summaries in `release-report`
 
 Next release-family follow-ons:
 
-1. richer host-agnostic CI evidence consumption in `release-readiness`
-2. additional release and deployment-gate variants built on the bounded release wedge
-3. approval-gated publish/promotion orchestration aligned to release-trust controls
+1. additional release and deployment-gate variants built on the bounded release wedge
+2. approval-gated publish/promotion orchestration aligned to release-trust controls

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1845,7 +1845,7 @@ describe("cli smoke flows", () => {
     );
   });
 
-  it("consumes generic imported CI evidence during release-readiness", async () => {
+  it("consumes host-agnostic imported CI evidence during release-readiness", async () => {
     const root = createFixtureRepo();
     initializeWorkspace(root);
     ensureRequestsDir(root);
@@ -1858,6 +1858,41 @@ describe("cli smoke flows", () => {
           name: "@h9-foundry/agentforge-cli",
           version: "0.6.0",
           type: "module"
+        },
+        null,
+        2
+      )
+    );
+    writeFileSync(
+      join(root, ".agentops", "evidence", "buildkite-ci.json"),
+      JSON.stringify(
+        {
+          host: "buildkite.com",
+          repository: "H9-Foundry/fixture",
+          pipelineName: "release",
+          pipelineRunId: "bk-42",
+          runAttempt: 1,
+          event: "push",
+          branch: "main",
+          commitSha: "abc123",
+          status: "completed",
+          conclusion: "success",
+          htmlUrl: "https://buildkite.example.com/organizations/h9-foundry/pipelines/release/builds/42",
+          jobs: [
+            {
+              name: "publish-check",
+              status: "completed",
+              conclusion: "success",
+              htmlUrl: "https://buildkite.example.com/organizations/h9-foundry/pipelines/release/builds/42#job-publish-check"
+            }
+          ],
+          artifacts: [
+            {
+              name: "build-log",
+              type: "text-log",
+              path: "artifacts/build.log"
+            }
+          ]
         },
         null,
         2
@@ -1965,7 +2000,7 @@ describe("cli smoke flows", () => {
       versionTargets: [{ name: "@h9-foundry/agentforge-cli", version: "0.7.0" }],
       qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
       securityReportRefs: [".agentops/runs/run-security/bundle.json"],
-      evidenceSources: [".agentops/evidence/generic-ci.json"],
+      evidenceSources: [".agentops/evidence/buildkite-ci.json", ".agentops/evidence/generic-ci.json"],
       constraints: ["Keep release readiness read-only by default"]
     });
 
@@ -1975,6 +2010,7 @@ describe("cli smoke flows", () => {
         artifactKind: string;
         payload?: {
           verificationChecks?: Array<{ name: string; status: string }>;
+          ciEvidenceSummary?: Array<{ provider: string; platform: string; statusSummary: string }>;
           publishingPlan?: string[];
           externalDependencies?: string[];
         };
@@ -1985,11 +2021,31 @@ describe("cli smoke flows", () => {
     expect(bundle.lifecycleArtifacts[0]?.payload?.verificationChecks).toEqual(
       expect.arrayContaining([expect.objectContaining({ name: "imported-ci-evidence", status: "passed" })])
     );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.ciEvidenceSummary).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          provider: "Buildkite",
+          platform: "buildkite",
+          statusSummary: expect.stringContaining("completed from local-export evidence with success")
+        }),
+        expect.objectContaining({
+          provider: "Jenkins",
+          platform: "generic-ci",
+          statusSummary: expect.stringContaining("completed from local-export evidence with success")
+        })
+      ])
+    );
     expect(bundle.lifecycleArtifacts[0]?.payload?.publishingPlan).toEqual(
-      expect.arrayContaining(["Review the imported CI evidence from `Jenkins` before any publish or promotion step."])
+      expect.arrayContaining([
+        expect.stringContaining("Buildkite (buildkite) pipeline `release` run `bk-42`"),
+        expect.stringContaining("Jenkins (generic-ci) pipeline `Jenkins CI` run `jenkins-42`")
+      ])
     );
     expect(bundle.lifecycleArtifacts[0]?.payload?.externalDependencies).toEqual(
-      expect.arrayContaining(["Imported CI evidence from Jenkins remains available for reviewer inspection."])
+      expect.arrayContaining([
+        "Buildkite (buildkite) pipeline `release` run `bk-42` remains available for reviewer inspection.",
+        "Jenkins (generic-ci) pipeline `Jenkins CI` run `jenkins-42` remains available for reviewer inspection."
+      ])
     );
   });
 

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -25,6 +25,7 @@ import {
   qaRequestSchema,
   releaseApprovalRecommendationSchema,
   releaseArtifactSchema,
+  releaseCiEvidenceSummarySchema,
   releaseEvidenceNormalizationSchema,
   releaseRequestSchema,
   securityArtifactSchema,
@@ -62,6 +63,7 @@ import type {
   QaEvidenceNormalization,
   QaRequest,
   ReleaseArtifact,
+  ReleaseCiEvidenceSummary,
   ReleaseEvidenceNormalization,
   ReleaseRequest,
   ScmReference,
@@ -853,6 +855,36 @@ function summarizeCiEvidenceFailures(evidence: CiEvidence): string[] {
       : [];
 
   return [...failedJobs, ...runLevelFailure];
+}
+
+function formatCiEvidenceStatus(evidence: Pick<CiEvidence, "status" | "conclusion">): string {
+  if (evidence.status === "completed" && evidence.conclusion) {
+    return evidence.conclusion;
+  }
+
+  return evidence.status;
+}
+
+function summarizeCiEvidenceForRelease(evidence: CiEvidence): ReleaseCiEvidenceSummary {
+  const provider = evidence.providerName ?? evidence.pipelineName;
+  const displayLabel = `${provider} (${evidence.platform}) pipeline \`${evidence.pipelineName}\` run \`${evidence.pipelineRunId}\``;
+
+  return releaseCiEvidenceSummarySchema.parse({
+    provider,
+    platform: evidence.platform,
+    host: evidence.host,
+    repository: evidence.repository,
+    pipelineName: evidence.pipelineName,
+    pipelineRunId: evidence.pipelineRunId,
+    status: evidence.status,
+    conclusion: evidence.conclusion,
+    branch: evidence.branch,
+    commitSha: evidence.commitSha,
+    failingChecks: summarizeCiEvidenceFailures(evidence),
+    provenanceSource: evidence.provenanceSource,
+    displayLabel,
+    statusSummary: `${displayLabel} completed from ${evidence.provenanceSource} evidence with ${formatCiEvidenceStatus(evidence)}.`
+  });
 }
 
 function derivePackageScope(pathValue: string): string | undefined {
@@ -2371,6 +2403,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
       : releaseRequest.evidenceSources;
     const normalizedEvidenceSources = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
     const ciEvidence = normalizeImportedCiEvidence(repoRoot, normalizedEvidenceSources);
+    const ciEvidenceSummary = ciEvidence.map((entry) => summarizeCiEvidenceForRelease(entry));
     const attestationVerificationEvidence = normalizeAttestationVerificationEvidence(repoRoot, normalizedEvidenceSources);
     const trustSummary = buildReleaseTrustSummary(attestationVerificationEvidence);
     const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
@@ -2526,6 +2559,7 @@ const releaseEvidenceNormalizationAgent: RuntimeAgent = {
       normalizedEvidenceSources,
       missingEvidenceSources: [],
       ciEvidence,
+      ciEvidenceSummary,
       dependencyIntegrityEvidence,
       attestationVerificationEvidence,
       versionResolutions: versionResolutions.map((entry) => ({
@@ -2620,12 +2654,12 @@ const releaseAnalystAgent: RuntimeAgent = {
     const constraints = asStringArray(intakeMetadata.constraints);
     const allEvidenceRefs = [...new Set([...qaReportRefs, ...securityReportRefs, ...evidenceSources])];
     const importedCiEvidence = normalizedEvidence?.ciEvidence ?? [];
+    const ciEvidenceSummary = normalizedEvidence?.ciEvidenceSummary ?? importedCiEvidence.map((entry) => summarizeCiEvidenceForRelease(entry));
     const dependencyIntegrityEvidence = normalizedEvidence?.dependencyIntegrityEvidence ?? [];
     const dependencyIntegritySignals = buildDependencyIntegritySignals(dependencyIntegrityEvidence);
     const attestationVerificationEvidence = normalizedEvidence?.attestationVerificationEvidence ?? [];
     const trustSummary = normalizedEvidence?.trustSummary ?? buildReleaseTrustSummary(attestationVerificationEvidence);
-    const importedCiProviders = [...new Set(importedCiEvidence.map((entry) => entry.providerName ?? entry.pipelineName))];
-    const importedCiFailures = [...new Set(importedCiEvidence.flatMap((entry) => summarizeCiEvidenceFailures(entry)))];
+    const importedCiFailures = [...new Set(ciEvidenceSummary.flatMap((entry) => entry.failingChecks))];
     const versionResolutions = normalizedEvidence?.versionResolutions ?? [];
     const verificationChecks = normalizedEvidence?.localReadinessChecks ?? [
       {
@@ -2653,7 +2687,7 @@ const releaseAnalystAgent: RuntimeAgent = {
         name: "imported-ci-evidence",
         status: importedCiEvidence.length > 0 ? "passed" : "skipped",
         detail: importedCiEvidence.length > 0
-          ? `Using ${importedCiEvidence.length} imported CI evidence export(s).`
+          ? `Using ${importedCiEvidence.length} imported CI evidence export(s) across ${ciEvidenceSummary.map((entry) => entry.provider).join(", ")}.`
           : "No imported CI evidence exports were supplied."
       }
     ];
@@ -2681,8 +2715,8 @@ const releaseAnalystAgent: RuntimeAgent = {
       ...dependencyIntegritySignals.map((signal) => `${signal} Review dependency integrity before any publish or promotion step.`),
       ...trustSummary.map((line) => `${line} Keep publish execution separate from verification.`),
       "Review the bounded QA and security evidence before invoking any publish or promotion step.",
-      ...importedCiProviders.map(
-        (providerName) => `Review the imported CI evidence from \`${providerName}\` before any publish or promotion step.`
+      ...ciEvidenceSummary.map(
+        (entry) => `Review ${entry.displayLabel} (${formatCiEvidenceStatus(entry)}) before any publish or promotion step.`
       ),
       "Run `agentforge release check --json` and `agentforge release verify --json` before any release cut.",
       ...approvalRecommendations.map(
@@ -2697,7 +2731,7 @@ const releaseAnalystAgent: RuntimeAgent = {
     const externalDependencies = [
       ...(qaReportRefs.length > 0 ? ["Validated QA report inputs remain available for reviewer inspection."] : []),
       ...(securityReportRefs.length > 0 ? ["Validated security report inputs remain available for reviewer inspection."] : []),
-      ...importedCiProviders.map((providerName) => `Imported CI evidence from ${providerName} remains available for reviewer inspection.`)
+      ...ciEvidenceSummary.map((entry) => `${entry.displayLabel} remains available for reviewer inspection.`)
     ];
     const releaseReport = releaseArtifactSchema.parse({
       ...buildLifecycleArtifactEnvelopeBase(
@@ -2717,6 +2751,7 @@ const releaseAnalystAgent: RuntimeAgent = {
         readinessStatus,
         verificationChecks: verificationChecks.map((check) => ({ ...check })),
         versionResolutions,
+        ciEvidenceSummary,
         dependencyIntegritySignals,
         trustSummary,
         approvalRecommendations: approvalRecommendations.map((recommendation) =>
@@ -2747,6 +2782,7 @@ const releaseAnalystAgent: RuntimeAgent = {
           securityReportRefs,
           evidenceSources,
           ciEvidence: importedCiEvidence,
+          ciEvidenceSummary,
           dependencyIntegrityEvidence,
           attestationVerificationEvidence,
           constraints,

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -38,6 +38,7 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  releaseCiEvidenceSummarySchema,
   releaseEvidenceNormalizationSchema,
   releaseRequestSchema,
   registryPluginCatalogEntrySchema,
@@ -103,6 +104,7 @@ describe("schema fixtures", () => {
     expect(() => qaEvidenceNormalizationSchema.parse(schemaFixtures.qaEvidenceNormalization)).not.toThrow();
     expect(() => securityEvidenceNormalizationSchema.parse(schemaFixtures.securityEvidenceNormalization)).not.toThrow();
     expect(() => releaseEvidenceNormalizationSchema.parse(schemaFixtures.releaseEvidenceNormalization)).not.toThrow();
+    expect(() => releaseCiEvidenceSummarySchema.parse(schemaFixtures.releaseArtifact.payload.ciEvidenceSummary[0])).not.toThrow();
     expect(() => maintenanceEvidenceNormalizationSchema.parse(schemaFixtures.maintenanceEvidenceNormalization)).not.toThrow();
   });
 
@@ -151,6 +153,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.qaEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.securityEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.maintenanceEvidenceNormalization).toBeDefined();
+    expect(jsonSchemas.releaseCiEvidenceSummary).toBeDefined();
     expect(jsonSchemas.releaseEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.lifecycleArtifactEnvelope).toBeDefined();
     expect(jsonSchemas.planningArtifact).toBeDefined();

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -967,6 +967,23 @@ export const releaseApprovalRecommendationSchema = z.object({
   reason: z.string().min(1)
 });
 
+export const releaseCiEvidenceSummarySchema = z.object({
+  provider: z.string().min(1),
+  platform: ciPlatformSchema,
+  host: z.string().min(1),
+  repository: z.string().min(1),
+  pipelineName: z.string().min(1),
+  pipelineRunId: z.string().min(1),
+  status: githubActionsRunStatusSchema,
+  conclusion: githubActionsConclusionSchema.optional(),
+  branch: z.string().min(1).optional(),
+  commitSha: z.string().min(1).optional(),
+  failingChecks: z.array(z.string().min(1)).default([]),
+  provenanceSource: z.enum(["local-export", "adapter-read"]).default("local-export"),
+  displayLabel: z.string().min(1),
+  statusSummary: z.string().min(1)
+});
+
 export const releaseRequestSchema = z.object({
   releaseScope: z.string().min(1),
   versionTargets: z.array(releaseVersionTargetSchema).min(1),
@@ -1089,6 +1106,7 @@ export const releaseEvidenceNormalizationSchema = z.object({
   normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
   missingEvidenceSources: z.array(z.string().min(1)).default([]),
   ciEvidence: z.array(ciEvidenceSchema).default([]),
+  ciEvidenceSummary: z.array(releaseCiEvidenceSummarySchema).default([]),
   dependencyIntegrityEvidence: z.array(dependencyIntegrityEvidenceSchema).default([]),
   attestationVerificationEvidence: z.array(attestationVerificationEvidenceSchema).default([]),
   versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
@@ -1105,6 +1123,7 @@ export const releaseArtifactPayloadSchema = z.object({
   readinessStatus: z.enum(["ready", "blocked", "partial"]),
   verificationChecks: z.array(releaseVerificationCheckSchema).default([]),
   versionResolutions: z.array(releaseVersionResolutionSchema).default([]),
+  ciEvidenceSummary: z.array(releaseCiEvidenceSummarySchema).default([]),
   dependencyIntegritySignals: z.array(z.string().min(1)).default([]),
   trustSummary: z.array(z.string().min(1)).default([]),
   approvalRecommendations: z.array(releaseApprovalRecommendationSchema).default([]),
@@ -1371,6 +1390,7 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   releaseVersionTarget: releaseVersionTargetSchema,
   releaseVersionResolution: releaseVersionResolutionSchema,
   releaseApprovalRecommendation: releaseApprovalRecommendationSchema,
+  releaseCiEvidenceSummary: releaseCiEvidenceSummarySchema,
   releaseEvidenceNormalization: releaseEvidenceNormalizationSchema,
   releaseArtifactPayload: releaseArtifactPayloadSchema,
   maintenanceArtifactPayload: maintenanceArtifactPayloadSchema,
@@ -1659,6 +1679,24 @@ const releaseArtifactFixture = {
         targetVersion: "0.4.1",
         currentVersion: "0.4.0",
         status: "pending-version-bump"
+      }
+    ],
+    ciEvidenceSummary: [
+      {
+        provider: "GitHub Actions",
+        platform: "github-actions",
+        host: "github.com",
+        repository: "H9-Foundry/AgentForge",
+        pipelineName: "publish",
+        pipelineRunId: "321",
+        status: "completed",
+        conclusion: "success",
+        branch: "main",
+        commitSha: "abc123",
+        failingChecks: [],
+        provenanceSource: "adapter-read",
+        displayLabel: "GitHub Actions (github-actions) pipeline `publish` run `321`",
+        statusSummary: "GitHub Actions (github-actions) pipeline `publish` run `321` completed from adapter-read evidence with success."
       }
     ],
     dependencyIntegritySignals: [
@@ -2683,6 +2721,40 @@ const releaseEvidenceNormalizationFixture = {
   ],
   missingEvidenceSources: [],
   ciEvidence: [buildkiteCiEvidenceFixture, genericCiEvidenceFixture],
+  ciEvidenceSummary: [
+    {
+      provider: "Buildkite",
+      platform: "buildkite",
+      host: "buildkite.com",
+      repository: "H9-Foundry/AgentForge",
+      pipelineName: "release",
+      pipelineRunId: "bk-42",
+      status: "completed",
+      conclusion: "success",
+      branch: "main",
+      commitSha: "abc123",
+      failingChecks: [],
+      provenanceSource: "local-export",
+      displayLabel: "Buildkite (buildkite) pipeline `release` run `bk-42`",
+      statusSummary: "Buildkite (buildkite) pipeline `release` run `bk-42` completed from local-export evidence with success."
+    },
+    {
+      provider: "Jenkins",
+      platform: "generic-ci",
+      host: "jenkins.local",
+      repository: "H9-Foundry/AgentForge",
+      pipelineName: "Jenkins CI",
+      pipelineRunId: "jenkins-42",
+      status: "completed",
+      conclusion: "success",
+      branch: "main",
+      commitSha: "abc123",
+      failingChecks: [],
+      provenanceSource: "local-export",
+      displayLabel: "Jenkins (generic-ci) pipeline `Jenkins CI` run `jenkins-42`",
+      statusSummary: "Jenkins (generic-ci) pipeline `Jenkins CI` run `jenkins-42` completed from local-export evidence with success."
+    }
+  ],
   dependencyIntegrityEvidence: [dependencyIntegrityEvidenceFixture],
   attestationVerificationEvidence: [attestationVerificationEvidenceFixture],
   versionResolutions: [

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -77,6 +77,7 @@ import {
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
   releaseApprovalRecommendationSchema,
+  releaseCiEvidenceSummarySchema,
   securityEvidenceNormalizationSchema,
   securityArtifactPayloadSchema,
   securityArtifactSchema,
@@ -138,6 +139,7 @@ export type GithubHandoffSummary = Infer<typeof githubHandoffSummarySchema>;
 export type GithubReference = Infer<typeof githubReferenceSchema>;
 export type ScmReference = Infer<typeof scmReferenceSchema>;
 export type GithubWorkflowStatusMapping = Infer<typeof githubWorkflowStatusMappingSchema>;
+export type ReleaseCiEvidenceSummary = Infer<typeof releaseCiEvidenceSummarySchema>;
 export type LifecycleArtifactWorkflowReference = Infer<typeof lifecycleArtifactWorkflowReferenceSchema>;
 export type LifecycleArtifactSourceReference = Infer<typeof lifecycleArtifactSourceReferenceSchema>;
 export type LifecycleArtifactRepoReference = Infer<typeof lifecycleArtifactRepoReferenceSchema>;


### PR DESCRIPTION
## Summary
- add structured host-agnostic CI provenance summaries to release normalization and `release-report`
- consume mixed imported CI evidence in `release-readiness` without changing the public request shape
- update release workflow docs and shared schema coverage for the richer CI consumption slice

Closes #247

## Validation
- `pnpm exec vitest run packages/schemas/src/index.test.ts packages/cli/src/index.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm build:packages`
- `pnpm test; echo EXIT:$?`