### PR TITLE
Version public AgentForge packages

### DIFF
--- a/.changeset/attestation-trust-summary.md
+++ b/.changeset/attestation-trust-summary.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add bounded attestation verification evidence and trust-summary reporting for release workflows.

--- a/.changeset/buildkite-ci-evidence-wedge.md
+++ b/.changeset/buildkite-ci-evidence-wedge.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Add a bounded Buildkite CI evidence export contract and normalize Buildkite pipeline exports into shared CI evidence.

--- a/.changeset/dependency-integrity-inventory.md
+++ b/.changeset/dependency-integrity-inventory.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": minor
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
----
-
-Add bounded dependency-integrity inventory evidence and surface it through security-review and release-readiness reports.

--- a/.changeset/generic-release-ci-workflows.md
+++ b/.changeset/generic-release-ci-workflows.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Add provider-agnostic `pipeline-evidence-review` and `deployment-gate-review` workflows with shared CI evidence consumption and lifecycle artifacts.

--- a/.changeset/jenkins-ci-evidence-wedge.md
+++ b/.changeset/jenkins-ci-evidence-wedge.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Add a bounded Jenkins CI evidence export contract and normalize Jenkins pipeline exports into shared CI evidence.

--- a/.changeset/registry-distribution-hardening.md
+++ b/.changeset/registry-distribution-hardening.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-schemas": minor
-"@h9-foundry/agentforge-shared-types": minor
-"@h9-foundry/agentforge-policy-engine": minor
----
-
-Add registry distribution verification metadata and policy hardening for non-manual plugin activation.

--- a/.changeset/release-readiness-ci-summary.md
+++ b/.changeset/release-readiness-ci-summary.md
@@ -1,7 +1,0 @@
----
-"@h9-foundry/agentforge-cli": patch
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Expose normalized host-agnostic CI provenance and status summaries in release-readiness artifacts.

--- a/.changeset/scm-ci-handoff-rendering.md
+++ b/.changeset/scm-ci-handoff-rendering.md
@@ -1,8 +1,0 @@
----
-"@h9-foundry/agentforge-audit": patch
-"@h9-foundry/agentforge-cli": patch
-"@h9-foundry/agentforge-schemas": patch
-"@h9-foundry/agentforge-shared-types": patch
----
-
-Render shared SCM and CI provenance summaries across lifecycle handoff outputs.

--- a/packages/audit/CHANGELOG.md
+++ b/packages/audit/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @h9-foundry/agentforge-audit
 
+## 0.10.0
+
+### Patch Changes
+
+- 25fb68d: Render shared SCM and CI provenance summaries across lifecycle handoff outputs.
+- Updated dependencies [0dbf030]
+- Updated dependencies [ffdab26]
+- Updated dependencies [9261149]
+- Updated dependencies [c3df71b]
+- Updated dependencies [b5253bf]
+- Updated dependencies [0367e8c]
+- Updated dependencies [fa4d206]
+- Updated dependencies [25fb68d]
+  - @h9-foundry/agentforge-shared-types@0.10.0
+
 ## 0.9.0
 
 ### Patch Changes

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-audit",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Audit bundle generation and reporting utilities for AgentForge workflow runs.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,35 @@
 # @h9-foundry/agentforge-cli
 
+## 0.10.0
+
+### Minor Changes
+
+- 0dbf030: Add bounded attestation verification evidence and trust-summary reporting for release workflows.
+- 9261149: Add bounded dependency-integrity inventory evidence and surface it through security-review and release-readiness reports.
+
+### Patch Changes
+
+- ffdab26: Add a bounded Buildkite CI evidence export contract and normalize Buildkite pipeline exports into shared CI evidence.
+- c3df71b: Add provider-agnostic `pipeline-evidence-review` and `deployment-gate-review` workflows with shared CI evidence consumption and lifecycle artifacts.
+- b5253bf: Add a bounded Jenkins CI evidence export contract and normalize Jenkins pipeline exports into shared CI evidence.
+- fa4d206: Expose normalized host-agnostic CI provenance and status summaries in release-readiness artifacts.
+- 25fb68d: Render shared SCM and CI provenance summaries across lifecycle handoff outputs.
+- Updated dependencies [0dbf030]
+- Updated dependencies [ffdab26]
+- Updated dependencies [9261149]
+- Updated dependencies [c3df71b]
+- Updated dependencies [b5253bf]
+- Updated dependencies [0367e8c]
+- Updated dependencies [fa4d206]
+- Updated dependencies [25fb68d]
+  - @h9-foundry/agentforge-schemas@0.10.0
+  - @h9-foundry/agentforge-shared-types@0.10.0
+  - @h9-foundry/agentforge-policy-engine@0.10.0
+  - @h9-foundry/agentforge-audit@0.10.0
+  - @h9-foundry/agentforge-context-engine@0.10.0
+  - @h9-foundry/agentforge-runtime@0.10.0
+  - @h9-foundry/agentforge-sdk@0.10.0
+
 ## 0.9.0
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-cli",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Secure-by-default CLI for AgentForge repo-first software engineering workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/context-engine/CHANGELOG.md
+++ b/packages/context-engine/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @h9-foundry/agentforge-context-engine
 
+## 0.10.0
+
+### Patch Changes
+
+- Updated dependencies [0dbf030]
+- Updated dependencies [ffdab26]
+- Updated dependencies [9261149]
+- Updated dependencies [c3df71b]
+- Updated dependencies [b5253bf]
+- Updated dependencies [0367e8c]
+- Updated dependencies [fa4d206]
+- Updated dependencies [25fb68d]
+  - @h9-foundry/agentforge-schemas@0.10.0
+  - @h9-foundry/agentforge-shared-types@0.10.0
+
 ## 0.9.0
 
 ### Patch Changes

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-context-engine",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Repository and execution context collection for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/policy-engine/CHANGELOG.md
+++ b/packages/policy-engine/CHANGELOG.md
@@ -1,5 +1,24 @@
 # @h9-foundry/agentforge-policy-engine
 
+## 0.10.0
+
+### Minor Changes
+
+- 0367e8c: Add registry distribution verification metadata and policy hardening for non-manual plugin activation.
+
+### Patch Changes
+
+- Updated dependencies [0dbf030]
+- Updated dependencies [ffdab26]
+- Updated dependencies [9261149]
+- Updated dependencies [c3df71b]
+- Updated dependencies [b5253bf]
+- Updated dependencies [0367e8c]
+- Updated dependencies [fa4d206]
+- Updated dependencies [25fb68d]
+  - @h9-foundry/agentforge-schemas@0.10.0
+  - @h9-foundry/agentforge-shared-types@0.10.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-policy-engine",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Policy evaluation, path gating, trust enforcement, and redaction for AgentForge workflows.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @h9-foundry/agentforge-runtime
 
+## 0.10.0
+
+### Patch Changes
+
+- Updated dependencies [0dbf030]
+- Updated dependencies [ffdab26]
+- Updated dependencies [9261149]
+- Updated dependencies [c3df71b]
+- Updated dependencies [b5253bf]
+- Updated dependencies [0367e8c]
+- Updated dependencies [fa4d206]
+- Updated dependencies [25fb68d]
+  - @h9-foundry/agentforge-schemas@0.10.0
+  - @h9-foundry/agentforge-shared-types@0.10.0
+  - @h9-foundry/agentforge-policy-engine@0.10.0
+  - @h9-foundry/agentforge-audit@0.10.0
+  - @h9-foundry/agentforge-sdk@0.10.0
+
 ## 0.9.0
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-runtime",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Deterministic workflow runtime and tool mediation engine for AgentForge.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/schemas/CHANGELOG.md
+++ b/packages/schemas/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @h9-foundry/agentforge-schemas
 
+## 0.10.0
+
+### Minor Changes
+
+- 0dbf030: Add bounded attestation verification evidence and trust-summary reporting for release workflows.
+- 9261149: Add bounded dependency-integrity inventory evidence and surface it through security-review and release-readiness reports.
+- 0367e8c: Add registry distribution verification metadata and policy hardening for non-manual plugin activation.
+
+### Patch Changes
+
+- ffdab26: Add a bounded Buildkite CI evidence export contract and normalize Buildkite pipeline exports into shared CI evidence.
+- c3df71b: Add provider-agnostic `pipeline-evidence-review` and `deployment-gate-review` workflows with shared CI evidence consumption and lifecycle artifacts.
+- b5253bf: Add a bounded Jenkins CI evidence export contract and normalize Jenkins pipeline exports into shared CI evidence.
+- fa4d206: Expose normalized host-agnostic CI provenance and status summaries in release-readiness artifacts.
+- 25fb68d: Render shared SCM and CI provenance summaries across lifecycle handoff outputs.
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/schemas/package.json
+++ b/packages/schemas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-schemas",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Shared schema contracts for AgentForge workflows, policy, context, and audit data.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/sdk/CHANGELOG.md
+++ b/packages/sdk/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @h9-foundry/agentforge-sdk
 
+## 0.10.0
+
+### Patch Changes
+
+- Updated dependencies [0dbf030]
+- Updated dependencies [ffdab26]
+- Updated dependencies [9261149]
+- Updated dependencies [c3df71b]
+- Updated dependencies [b5253bf]
+- Updated dependencies [0367e8c]
+- Updated dependencies [fa4d206]
+- Updated dependencies [25fb68d]
+  - @h9-foundry/agentforge-shared-types@0.10.0
+
 ## 0.9.0
 
 ### Patch Changes

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-sdk",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "SDK interfaces for AgentForge agents, adapters, providers, and runtime integrations.",
   "license": "MIT",
   "author": "H9 Foundry",

--- a/packages/shared-types/CHANGELOG.md
+++ b/packages/shared-types/CHANGELOG.md
@@ -1,5 +1,30 @@
 # @h9-foundry/agentforge-shared-types
 
+## 0.10.0
+
+### Minor Changes
+
+- 0dbf030: Add bounded attestation verification evidence and trust-summary reporting for release workflows.
+- 9261149: Add bounded dependency-integrity inventory evidence and surface it through security-review and release-readiness reports.
+- 0367e8c: Add registry distribution verification metadata and policy hardening for non-manual plugin activation.
+
+### Patch Changes
+
+- ffdab26: Add a bounded Buildkite CI evidence export contract and normalize Buildkite pipeline exports into shared CI evidence.
+- c3df71b: Add provider-agnostic `pipeline-evidence-review` and `deployment-gate-review` workflows with shared CI evidence consumption and lifecycle artifacts.
+- b5253bf: Add a bounded Jenkins CI evidence export contract and normalize Jenkins pipeline exports into shared CI evidence.
+- fa4d206: Expose normalized host-agnostic CI provenance and status summaries in release-readiness artifacts.
+- 25fb68d: Render shared SCM and CI provenance summaries across lifecycle handoff outputs.
+- Updated dependencies [0dbf030]
+- Updated dependencies [ffdab26]
+- Updated dependencies [9261149]
+- Updated dependencies [c3df71b]
+- Updated dependencies [b5253bf]
+- Updated dependencies [0367e8c]
+- Updated dependencies [fa4d206]
+- Updated dependencies [25fb68d]
+  - @h9-foundry/agentforge-schemas@0.10.0
+
 ## 0.9.0
 
 ### Minor Changes

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@h9-foundry/agentforge-shared-types",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Shared TypeScript types inferred from the AgentForge schema contracts.",
   "license": "MIT",
   "author": "H9 Foundry",


### PR DESCRIPTION
## Summary
- regenerate the public package versioning branch from current main
- version public AgentForge packages to 0.10.0
- replace stale release PR #244, which was behind main and would have dropped newer workflow changes

## Verification
- pnpm release:verify
