### PR TITLE
Add promotion approval review workflow

### DIFF
--- a/.agentops/workflows/promotion-approval.yaml
+++ b/.agentops/workflows/promotion-approval.yaml
@@ -1,0 +1,25 @@
+version: 1
+name: promotion-approval
+description: Review promotion approval readiness using bounded CI evidence plus ready release and deployment gate artifacts.
+trigger: manual
+catalog:
+  domain: release
+  supportLevel: official
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: promotion-approval-intake
+    outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: promotion-approval-evidence-normalizer
+    outputs_to: agentResults.evidence
+  - id: promotion
+    kind: reasoning
+    agent: promotion-approval-analyst
+    outputs_to: agentResults.promotion
+  - id: report
+    kind: report
+    outputs_to: reports.final

--- a/.changeset/promotion-approval-review-workflow.md
+++ b/.changeset/promotion-approval-review-workflow.md
@@ -1,0 +1,8 @@
+---
+"@h9-foundry/agentforge-audit": minor
+"@h9-foundry/agentforge-cli": minor
+"@h9-foundry/agentforge-schemas": minor
+"@h9-foundry/agentforge-shared-types": minor
+---
+
+Add the `promotion-approval` workflow, request/artifact contracts, and shared handoff rendering for approval-oriented release review on `main`.

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -50,7 +50,7 @@ Rules:
 Current active lane:
 
 1. [#245](https://github.com/H9-Foundry/AgentForge/issues/245) Phase 2 provider and integration expansion tracker
-2. no active implementation slice is assigned after `#262`; close the current public release loop before starting the next Phase 2 family
+2. [#261](https://github.com/H9-Foundry/AgentForge/issues/261) Promotion approval review follow-on
 
 ### Ready Lane
 
@@ -58,10 +58,9 @@ Work that is explicitly designed or queued next, but should not start until the 
 
 Current ready lane:
 
-3. [#261](https://github.com/H9-Foundry/AgentForge/issues/261) Promotion approval review follow-on
-4. additional generic release and CI workflow consumption after the current provider-agnostic review family is published and validated from npm
-5. additional provider-specific SCM and CI wedges after the generic release and CI workflow family is stable
-6. deeper supply-chain and enterprise trust work reopened only after the next provider/integration family is defined explicitly
+3. additional generic release and CI workflow consumption after the current provider-agnostic review family is published and validated from npm
+4. additional provider-specific SCM and CI wedges after the generic release and CI workflow family is stable
+5. deeper supply-chain and enterprise trust work reopened only after the next provider/integration family is defined explicitly
 
 ### Parallel Safe Lane
 

--- a/docs/RELEASE_CICD_WORKFLOWS.md
+++ b/docs/RELEASE_CICD_WORKFLOWS.md
@@ -37,16 +37,17 @@ Available now:
 - official `release-readiness` workflow asset and request validation
 - official `pipeline-evidence-review` workflow asset and request validation
 - official `deployment-gate-review` workflow asset and request validation
+- official `promotion-approval` workflow asset and request validation on `main`
 - bounded `release-report` artifact emission from the local `release-readiness` workflow
 - bounded `pipeline-report` artifact emission from the local `pipeline-evidence-review` workflow
 - bounded `deployment-gate-report` artifact emission from the local `deployment-gate-review` workflow
+- bounded `promotion-approval-report` artifact emission from the local `promotion-approval` workflow on `main`
 - deterministic release-state normalization across bounded local evidence, QA/security report refs, and workspace version targets
 - deterministic pipeline and deployment-gate normalization across bounded local CI evidence and referenced lifecycle artifacts
 - approval-classified publish or promotion follow-on recommendations that remain read-only by default
 
 Not yet available:
 
-- approval-oriented promotion follow-ons beyond the current review workflows
 - publish or deploy orchestration on the default local path
 - broader host-agnostic pipeline orchestration beyond the current local review family
 
@@ -57,12 +58,9 @@ Phase 2 now builds on the current official local release and CI review family:
 - `release-readiness`
 - `pipeline-evidence-review`
 - `deployment-gate-review`
-
-Later planned variants can include:
-
 - `promotion-approval`
 
-The three current workflows are already implemented on `main`; later release-family work should extend them rather than reopening first-wedge planning.
+The four current workflows are implemented on `main`. `promotion-approval` remains source-build only until the next npm release; later release-family work should extend this bounded review family rather than reopening first-wedge planning.
 
 ## User Jobs
 
@@ -174,8 +172,8 @@ Implemented on current `main`:
 4. richer host-agnostic CI provenance and status summaries in `release-report`
 5. `pipeline-evidence-review` workflow, request schema, starter agents, and `pipeline-report` artifact
 6. `deployment-gate-review` workflow, request schema, starter agents, and `deployment-gate-report` artifact
+7. `promotion-approval` workflow, request schema, starter agents, and `promotion-approval-report` artifact on `main`
 
 Next release-family follow-ons:
 
-1. approval-oriented promotion follow-ons built on the bounded release and deployment review family
-2. approval-gated publish or promotion orchestration aligned to release-trust controls
+1. approval-gated publish or promotion orchestration aligned to release-trust controls

--- a/docs/SDLC_COVERAGE.md
+++ b/docs/SDLC_COVERAGE.md
@@ -17,7 +17,7 @@ Workflow coverage is not the same thing as plug-and-play external usability. A l
 | Build / implementation | Available now | `implementation-proposal` is an official local workflow that validates `.agentops/requests/implementation.yaml`, requires a `designRecordRef`, and emits an `implementation-proposal` artifact without widening the default side-effect posture. | Expand from proposal-only implementation planning into downstream QA, security review, and gated apply-capable follow-ons. |
 | Review / test / QA | Available now | `pr-review` remains available, and `qa-review` is now an official local workflow that validates `.agentops/requests/qa.yaml`, consumes an implementation proposal bundle, and emits a `qa-report` artifact with deterministic evidence normalization. | Broaden into additional QA variants such as regression triage and release-readiness QA. |
 | Security / compliance / DevSecOps | Available now | `security-review` is an official local workflow that validates `.agentops/requests/security.yaml`, consumes bounded local evidence, and emits a `security-report` artifact without widening the default side-effect posture. | Expand beyond `security-review` into additional security/DevSecOps variants, adapters, and evals. |
-| Release / CI/CD | Available now | `release-readiness`, `pipeline-evidence-review`, and `deployment-gate-review` are official local workflows that validate `.agentops/requests/release.yaml`, `.agentops/requests/pipeline.yaml`, and `.agentops/requests/deployment.yaml`, consume bounded local CI and release evidence, and emit `release-report`, `pipeline-report`, and `deployment-gate-report` artifacts without widening the default side-effect posture. | Expand into approval-oriented promotion follow-ons and additional release/deployment review variants after the current review family lands broadly. |
+| Release / CI/CD | Available now | `release-readiness`, `pipeline-evidence-review`, `deployment-gate-review`, and `promotion-approval` are official local workflows on `main` that validate `.agentops/requests/release.yaml`, `.agentops/requests/pipeline.yaml`, `.agentops/requests/deployment.yaml`, and `.agentops/requests/promotion.yaml`, consume bounded local CI and release evidence, and emit `release-report`, `pipeline-report`, `deployment-gate-report`, and `promotion-approval-report` artifacts without widening the default side-effect posture. | Expand into additional approval-oriented release/promotion variants and richer release/deployment review follow-ons after the current review family lands broadly. |
 | Operate / incident response / observability handoff | Available now | `incident-handoff` is an official local workflow that validates `.agentops/requests/incident.yaml`, consumes staged local incident evidence, and emits an `incident-brief` artifact with deterministic provenance and follow-up routing. | Expand into additional incident and operations variants such as postmortem review and alert triage. |
 | Maintain / upgrade / docs / dependency hygiene | Available now | `maintenance-triage` is an official local workflow that validates `.agentops/requests/maintenance.yaml`, consumes bounded maintenance evidence, and emits a `maintenance-report` artifact with deterministic routing support. | Expand into additional maintenance variants such as dependency-upgrade review, docs-hygiene review, and backlog refresh. |
 
@@ -52,6 +52,9 @@ Workflow coverage is not the same thing as plug-and-play external usability. A l
 - `deployment-gate-review`
   - location: `.agentops/workflows/deployment-gate-review.yaml`
   - purpose: validate a deployment gate request, consume bounded local shared CI evidence plus referenced QA, security, release, and pipeline artifacts, and emit a `deployment-gate-report` lifecycle artifact without adding deployment side effects
+- `promotion-approval`
+  - location: `.agentops/workflows/promotion-approval.yaml`
+  - purpose: validate a promotion approval request, consume bounded local shared CI evidence plus ready release and deployment gate artifacts, and emit a `promotion-approval-report` lifecycle artifact without adding deploy or publish side effects
 - `incident-handoff`
   - location: `.agentops/workflows/incident-handoff.yaml`
   - purpose: validate an incident request, consume staged local incident evidence, and emit an `incident-brief` lifecycle artifact with deterministic provenance capture and routing
@@ -63,7 +66,7 @@ Workflow coverage is not the same thing as plug-and-play external usability. A l
 
 - additional QA variants beyond `qa-review`
 - security/DevSecOps
-- approval-oriented promotion follow-ons and additional release/CI-CD variants
+- additional approval-oriented release/promotion variants and release/CI-CD follow-ons
 - additional operations/incident variants
 - additional maintenance/dependency/docs hygiene variants
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -30,10 +30,11 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `release-readiness` | Official | Dedicated release workflow that consumes bounded local release evidence, emits a `release-report` artifact, and keeps publish or promotion follow-ons outside the default read-only path. |
 | `pipeline-evidence-review` | Official | Dedicated provider-agnostic pipeline workflow that consumes bounded local CI evidence, emits a `pipeline-report` artifact, and stays local-first and read-only by default. |
 | `deployment-gate-review` | Official | Dedicated deployment gate workflow that consumes shared CI evidence plus referenced QA, security, release, and pipeline artifacts, and emits a `deployment-gate-report` artifact without adding deployment side effects. |
+| `promotion-approval` | Official | Approval-oriented release review workflow on `main` that consumes shared CI evidence plus ready release and deployment gate artifacts, emits a `promotion-approval-report`, and remains source-build only until the next npm release. |
 | `incident-handoff` | Official | Dedicated operations workflow that consumes staged local incident evidence, emits an `incident-brief` artifact, and keeps the default path local-first and read-only. |
 | `maintenance-triage` | Official | Dedicated maintenance workflow that consumes bounded maintenance evidence, emits a `maintenance-report` artifact, and keeps the default path read-only with deterministic routing support. |
 | security / DevSecOps extensions | Planned | Additional security variants beyond `security-review` are not implemented yet. |
-| promotion / approval release follow-ons | Planned | Approval-oriented release and promotion variants beyond `release-readiness`, `pipeline-evidence-review`, and `deployment-gate-review` are not implemented yet. |
+| promotion / approval release follow-ons | Partial | `promotion-approval` is now implemented on `main`, but broader approval-oriented release and promotion variants beyond the current review-only workflow remain unimplemented. |
 | operations / incident variants | Planned | Additional operations and incident variants beyond `incident-handoff` are not implemented yet. |
 | maintenance / dependency/docs hygiene variants | Planned | Additional maintenance variants beyond `maintenance-triage` are not implemented yet. |
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -43,6 +43,7 @@ AgentForge is currently an early SDLC platform core with an official local workf
 - `.agentops/workflows/release-readiness.yaml`
 - `.agentops/workflows/pipeline-evidence-review.yaml`
 - `.agentops/workflows/deployment-gate-review.yaml`
+- `.agentops/workflows/promotion-approval.yaml`
 - `.agentops/workflows/incident-handoff.yaml`
 - `.agentops/workflows/maintenance-triage.yaml`
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -270,6 +270,7 @@ node packages/cli/dist/bin.js run security-review
 node packages/cli/dist/bin.js run release-readiness
 node packages/cli/dist/bin.js run pipeline-evidence-review
 node packages/cli/dist/bin.js run deployment-gate-review
+node packages/cli/dist/bin.js run promotion-approval
 node packages/cli/dist/bin.js run incident-handoff
 node packages/cli/dist/bin.js run maintenance-triage
 ```

--- a/packages/audit/src/index.test.ts
+++ b/packages/audit/src/index.test.ts
@@ -4,6 +4,7 @@ import type {
   DesignArtifact,
   IncidentArtifact,
   PlanningArtifact,
+  PromotionApprovalArtifact,
   QaArtifact,
   ReleaseArtifact
 } from "@h9-foundry/agentforge-shared-types";
@@ -135,5 +136,19 @@ describe("renderGitHubHandoffSummary", () => {
     expect(summary.body).toContain("Buildkite (buildkite) pipeline `release` run `bk-42` completed from local-export evidence with success.");
     expect(summary.body).toContain("Jenkins (jenkins-ci) pipeline `Jenkins CI` run `jenkins-42` completed from local-export evidence with success.");
     expect(summary.body).toContain("CircleCI (generic-ci) pipeline `CircleCI` run `circleci-42` completed from local-export evidence with success.");
+  });
+
+  it("renders a bounded promotion approval handoff summary", () => {
+    const artifact = cloneFixture(schemaFixtures.promotionApprovalArtifact) as unknown as PromotionApprovalArtifact;
+    artifact.source.scmRefs = [cloneFixture(schemaFixtures.gitlabIssueScmReference)];
+    const summary = renderGitHubHandoffSummary(artifact);
+
+    expect(summary.artifactKind).toBe("promotion-approval-report");
+    expect(summary.sections.some((section) => section.heading === "Approval Status")).toBe(true);
+    expect(summary.sections.some((section) => section.heading === "Required Approvals")).toBe(true);
+    expect(summary.sections.some((section) => section.heading === "SCM References")).toBe(true);
+    expect(summary.sections.some((section) => section.heading === "CI Evidence")).toBe(true);
+    expect(summary.body).toContain("gitlab issue: gitlab.com/h9-foundry/platform/agentforge#123");
+    expect(summary.body).toContain("Jenkins (jenkins-ci) pipeline `Jenkins CI` run `jenkins-42` completed from local-export evidence with success.");
   });
 });

--- a/packages/audit/src/index.ts
+++ b/packages/audit/src/index.ts
@@ -8,6 +8,7 @@ import type {
   GithubWorkflowStatusMapping,
   IncidentArtifact,
   PlanningArtifact,
+  PromotionApprovalArtifact,
   QaArtifact,
   ReleaseCiEvidenceSummary,
   ReleaseArtifact,
@@ -15,7 +16,13 @@ import type {
   WorkflowStateEnvelope
 } from "@h9-foundry/agentforge-shared-types";
 
-type GitHubRenderableArtifact = PlanningArtifact | DesignArtifact | IncidentArtifact | QaArtifact | ReleaseArtifact;
+type GitHubRenderableArtifact =
+  | PlanningArtifact
+  | DesignArtifact
+  | IncidentArtifact
+  | QaArtifact
+  | ReleaseArtifact
+  | PromotionApprovalArtifact;
 
 export function createAuditEntry(entry: AuditEntry): AuditEntry {
   return entry;
@@ -115,6 +122,19 @@ function renderReleaseSections(artifact: ReleaseArtifact): GithubHandoffSection[
   ].filter((section) => section.lines.length > 0);
 }
 
+function renderPromotionApprovalSections(artifact: PromotionApprovalArtifact): GithubHandoffSection[] {
+  return [
+    { heading: "Summary", lines: [artifact.summary] },
+    { heading: "Approval Status", lines: [artifact.payload.approvalStatus] },
+    {
+      heading: "Verification Checks",
+      lines: artifact.payload.verificationChecks.map((check) => `${check.name}: ${check.status}${check.detail ? ` (${check.detail})` : ""}`)
+    },
+    { heading: "Required Approvals", lines: artifact.payload.requiredApprovals ?? [] },
+    { heading: "Recommended Next Steps", lines: artifact.payload.recommendedNextSteps ?? [] }
+  ].filter((section) => section.lines.length > 0);
+}
+
 function renderSharedScmSection(artifact: GitHubRenderableArtifact): GithubHandoffSection[] {
   const githubCanonicals = new Set((artifact.source.githubRefs ?? []).map((entry) => entry.canonical));
   const lines = [...new Set(
@@ -131,6 +151,7 @@ function readArtifactCiEvidenceSummary(artifact: GitHubRenderableArtifact): Rele
     case "qa-report":
       return artifact.payload.ciEvidenceSummary ?? [];
     case "release-report":
+    case "promotion-approval-report":
       return artifact.payload.ciEvidenceSummary ?? [];
     default:
       return [];
@@ -165,6 +186,8 @@ function buildGitHubHandoffSections(artifact: GitHubRenderableArtifact): GithubH
       return renderQaSections(artifact);
     case "release-report":
       return renderReleaseSections(artifact);
+    case "promotion-approval-report":
+      return renderPromotionApprovalSections(artifact);
     }
   })();
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -66,7 +66,7 @@ program
   .description("Run an official local workflow wedge in safe mode.")
   .argument(
     "<workflow>",
-    "Workflow name. Run an initialized workflow under .agentops/workflows, for example: pr-review, planning-discovery, release-readiness, pipeline-evidence-review, or deployment-gate-review."
+    "Workflow name. Run an initialized workflow under .agentops/workflows, for example: pr-review, planning-discovery, release-readiness, pipeline-evidence-review, deployment-gate-review, or promotion-approval."
   )
   .option("--json", "Print machine-readable JSON output.")
   .action(async (workflow, options: { json?: boolean }) => {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -2439,6 +2439,155 @@ describe("cli smoke flows", () => {
     );
   });
 
+  it("fails promotion-approval before reasoning when the request is missing", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+
+    await expect(runLocalWorkflow("promotion-approval", root)).rejects.toThrow("Missing promotion request");
+  });
+
+  it("rejects underspecified promotion-approval requests before reasoning", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+    writeYamlFile(join(root, ".agentops", "requests", "promotion.yaml"), {
+      promotionScope: "Review approval readiness for the current release candidate.",
+      targetEnvironment: "production",
+      evidenceSources: [".agentops/evidence/jenkins-ci.json"]
+    });
+
+    await expect(runLocalWorkflow("promotion-approval", root)).rejects.toThrow(
+      /Add at least one releaseReportRef and one deploymentGateReportRef/i
+    );
+  });
+
+  it("blocks promotion-approval when the deployment gate report is not ready for approval", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+
+    writeBundleFixture(root, "run-qa", [cloneFixture(schemaFixtures.qaArtifact)]);
+    writeBundleFixture(root, "run-security", [cloneFixture(schemaFixtures.securityArtifact)]);
+    writeBundleFixture(root, "run-release", [cloneFixture(schemaFixtures.releaseArtifact)]);
+    writeBundleFixture(root, "run-deployment", [cloneFixture(schemaFixtures.deploymentGateArtifact)]);
+
+    writeFileSync(
+      join(root, ".agentops", "evidence", "jenkins-ci.json"),
+      JSON.stringify(schemaFixtures.jenkinsCiEvidenceExport, null, 2)
+    );
+
+    writeYamlFile(join(root, ".agentops", "requests", "promotion.yaml"), {
+      promotionScope: "Review approval readiness for the current release candidate.",
+      targetEnvironment: "production",
+      issueRefs: ["#261"],
+      qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+      securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+      releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+      deploymentGateReportRefs: [".agentops/runs/run-deployment/bundle.json"],
+      evidenceSources: [".agentops/evidence/jenkins-ci.json"]
+    });
+
+    const promotionRun = await runLocalWorkflow("promotion-approval", root);
+    const bundle = readJson<{
+      workflow: string;
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: {
+          approvalStatus?: string;
+          blockers?: string[];
+        };
+      }>;
+    }>(promotionRun.jsonPath);
+
+    expect(promotionRun.status).toBe("success");
+    expect(bundle.workflow).toBe("promotion-approval");
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("promotion-approval-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.approvalStatus).toBe("blocked");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.blockers).toEqual(
+      expect.arrayContaining([expect.stringContaining("cannot satisfy promotion approval yet")])
+    );
+  });
+
+  it("runs promotion-approval with ready release and deployment gate artifacts", async () => {
+    const root = createFixtureRepo();
+    initializeWorkspace(root);
+    ensureRequestsDir(root);
+    mkdirSync(join(root, ".agentops", "evidence"), { recursive: true });
+
+    const readyDeploymentGateArtifact = {
+      ...cloneFixture(schemaFixtures.deploymentGateArtifact),
+      payload: {
+        ...cloneFixture(schemaFixtures.deploymentGateArtifact).payload,
+        targetEnvironment: "production",
+        gateStatus: "ready_for_approval" as const
+      }
+    };
+
+    writeBundleFixture(root, "run-qa", [cloneFixture(schemaFixtures.qaArtifact)]);
+    writeBundleFixture(root, "run-security", [cloneFixture(schemaFixtures.securityArtifact)]);
+    writeBundleFixture(root, "run-release", [cloneFixture(schemaFixtures.releaseArtifact)]);
+    writeBundleFixture(root, "run-deployment", [readyDeploymentGateArtifact]);
+
+    writeFileSync(
+      join(root, ".agentops", "evidence", "jenkins-ci.json"),
+      JSON.stringify(schemaFixtures.jenkinsCiEvidenceExport, null, 2)
+    );
+    writeFileSync(
+      join(root, ".agentops", "evidence", "generic-ci.json"),
+      JSON.stringify(schemaFixtures.genericCiEvidenceExport, null, 2)
+    );
+
+    writeYamlFile(join(root, ".agentops", "requests", "promotion.yaml"), {
+      promotionScope: "Review approval readiness for promoting the current release candidate.",
+      targetEnvironment: "production",
+      issueRefs: ["#261"],
+      constraints: ["Keep the workflow read-only"],
+      qaReportRefs: [".agentops/runs/run-qa/bundle.json"],
+      securityReportRefs: [".agentops/runs/run-security/bundle.json"],
+      releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+      deploymentGateReportRefs: [".agentops/runs/run-deployment/bundle.json"],
+      evidenceSources: [
+        ".agentops/evidence/jenkins-ci.json",
+        ".agentops/evidence/generic-ci.json"
+      ]
+    });
+
+    const promotionRun = await runLocalWorkflow("promotion-approval", root);
+    const bundle = readJson<{
+      workflow: string;
+      lifecycleArtifacts: Array<{
+        artifactKind: string;
+        payload?: {
+          approvalStatus?: string;
+          blockers?: string[];
+          referencedArtifactKinds?: string[];
+          ciEvidenceSummary?: Array<{ provider: string; platform: string }>;
+          requiredApprovals?: string[];
+        };
+      }>;
+    }>(promotionRun.jsonPath);
+
+    expect(promotionRun.status).toBe("success");
+    expect(promotionRun.artifactKinds).toContain("promotion-approval-report");
+    expect(bundle.workflow).toBe("promotion-approval");
+    expect(bundle.lifecycleArtifacts[0]?.artifactKind).toBe("promotion-approval-report");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.approvalStatus).toBe("approval_recommended");
+    expect(bundle.lifecycleArtifacts[0]?.payload?.blockers).toEqual([]);
+    expect(bundle.lifecycleArtifacts[0]?.payload?.referencedArtifactKinds).toEqual(
+      expect.arrayContaining(["qa-report", "security-report", "release-report", "deployment-gate-report"])
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.ciEvidenceSummary).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ provider: "Jenkins", platform: "jenkins-ci" }),
+        expect.objectContaining({ provider: "CircleCI", platform: "generic-ci" })
+      ])
+    );
+    expect(bundle.lifecycleArtifacts[0]?.payload?.requiredApprovals).toEqual(
+      expect.arrayContaining([expect.stringContaining("Obtain explicit maintainer approval before any promotion or publish action.")])
+    );
+  });
+
   it("fails incident-handoff before reasoning when the request is missing", async () => {
     const root = createFixtureRepo();
     initializeWorkspace(root);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -23,6 +23,7 @@ import {
   pipelineRequestSchema,
   planningArtifactSchema,
   planningRequestSchema,
+  promotionRequestSchema,
   qaRequestSchema,
   releaseRequestSchema,
   schemaFixtures,
@@ -51,6 +52,7 @@ import type {
   PipelineRequest,
   PlanningArtifact,
   PlanningRequest,
+  PromotionRequest,
   QaRequest,
   ReleaseRequest,
   ScmReference,
@@ -380,6 +382,33 @@ nodes:
     kind: reasoning
     agent: deployment-gate-analyst
     outputs_to: agentResults.deployment
+  - id: report
+    kind: report
+    outputs_to: reports.final
+`;
+
+const promotionApprovalWorkflowTemplate = `version: 1
+name: promotion-approval
+description: Review promotion approval readiness using bounded CI evidence plus ready release and deployment gate artifacts.
+trigger: manual
+catalog:
+  domain: release
+  supportLevel: official
+  maturity: mvp
+  trustScope: official-core-only
+nodes:
+  - id: intake
+    kind: deterministic
+    agent: promotion-approval-intake
+    outputs_to: agentResults.intake
+  - id: evidence
+    kind: deterministic
+    agent: promotion-approval-evidence-normalizer
+    outputs_to: agentResults.evidence
+  - id: promotion
+    kind: reasoning
+    agent: promotion-approval-analyst
+    outputs_to: agentResults.promotion
   - id: report
     kind: report
     outputs_to: reports.final
@@ -1046,6 +1075,28 @@ function validateDeploymentRequestCompleteness(request: DeploymentRequest): Depl
   return request;
 }
 
+function validatePromotionRequestCompleteness(request: PromotionRequest): PromotionRequest {
+  const evidenceSignalCount =
+    request.evidenceSources.length +
+    request.qaReportRefs.length +
+    request.securityReportRefs.length +
+    request.releaseReportRefs.length +
+    request.deploymentGateReportRefs.length;
+  if (evidenceSignalCount === 0) {
+    throw new Error(
+      "Promotion request is underspecified. Add at least one of evidenceSources, qaReportRefs, securityReportRefs, releaseReportRefs, or deploymentGateReportRefs."
+    );
+  }
+
+  if (request.releaseReportRefs.length === 0 || request.deploymentGateReportRefs.length === 0) {
+    throw new Error(
+      "Promotion request is underspecified. Add at least one releaseReportRef and one deploymentGateReportRef."
+    );
+  }
+
+  return request;
+}
+
 function addSourceReferences(
   refs: { issueRefs: Set<string>; scmRefMap: Map<string, ScmReference>; githubRefMap: Map<string, GithubReference> },
   incoming: { issueRefs: string[]; scmRefs: ScmReference[]; githubRefs: GithubReference[] }
@@ -1400,6 +1451,68 @@ function prepareWorkflowInputs(
       deploymentIssueRefs: [...deploymentRefs.issueRefs],
       deploymentScmRefs: [...deploymentRefs.scmRefMap.values()],
       deploymentGithubRefs: [...deploymentRefs.githubRefMap.values()],
+      requestFile: requestPath
+    };
+  }
+
+  if (workflow.name === "promotion-approval") {
+    const requestPath = ".agentops/requests/promotion.yaml";
+    ensureReadablePath(policyEngine, requestPath, "promotion request");
+    const promotionRequest = validatePromotionRequestCompleteness(
+      readYamlFile(join(root, requestPath), promotionRequestSchema, "promotion request")
+    );
+
+    const scmRepoContext = inferScmRepoContext(root);
+    const gitHubRepoContext = inferGitHubRepoContext(root);
+    const promotionRefs = {
+      issueRefs: new Set<string>(promotionRequest.issueRefs),
+      scmRefMap: new Map<string, ScmReference>(),
+      githubRefMap: new Map<string, GithubReference>()
+    };
+
+    for (const scmRef of normalizeScmReferences(promotionRequest.issueRefs, scmRepoContext)) {
+      promotionRefs.scmRefMap.set(scmRef.canonical, scmRef);
+    }
+    for (const githubRef of normalizeGitHubReferences(promotionRequest.issueRefs, gitHubRepoContext)) {
+      promotionRefs.githubRefMap.set(githubRef.canonical, githubRef);
+    }
+
+    for (const qaReportRef of promotionRequest.qaReportRefs) {
+      ensureReadablePath(policyEngine, qaReportRef, "QA report reference");
+      ensureBundleContainsArtifactKind(root, qaReportRef, "qa-report", "QA report reference");
+      addSourceReferences(promotionRefs, loadLifecycleArtifactSourceReferences(root, qaReportRef));
+    }
+
+    for (const securityReportRef of promotionRequest.securityReportRefs) {
+      ensureReadablePath(policyEngine, securityReportRef, "security report reference");
+      ensureBundleContainsArtifactKind(root, securityReportRef, "security-report", "security report reference");
+      addSourceReferences(promotionRefs, loadLifecycleArtifactSourceReferences(root, securityReportRef));
+    }
+
+    for (const releaseReportRef of promotionRequest.releaseReportRefs) {
+      ensureReadablePath(policyEngine, releaseReportRef, "release report reference");
+      ensureBundleContainsArtifactKind(root, releaseReportRef, "release-report", "release report reference");
+      addSourceReferences(promotionRefs, loadLifecycleArtifactSourceReferences(root, releaseReportRef));
+    }
+
+    for (const deploymentGateReportRef of promotionRequest.deploymentGateReportRefs) {
+      ensureReadablePath(policyEngine, deploymentGateReportRef, "deployment gate report reference");
+      ensureBundleContainsArtifactKind(root, deploymentGateReportRef, "deployment-gate-report", "deployment gate report reference");
+      addSourceReferences(promotionRefs, loadLifecycleArtifactSourceReferences(root, deploymentGateReportRef));
+    }
+
+    for (const evidenceSource of promotionRequest.evidenceSources) {
+      ensureReadablePath(policyEngine, evidenceSource, "promotion evidence source");
+      if (!existsSync(join(root, evidenceSource))) {
+        throw new Error(`Promotion evidence source not found: ${evidenceSource}`);
+      }
+    }
+
+    return {
+      promotionRequest: promotionRequest satisfies PromotionRequest,
+      promotionIssueRefs: [...promotionRefs.issueRefs],
+      promotionScmRefs: [...promotionRefs.scmRefMap.values()],
+      promotionGithubRefs: [...promotionRefs.githubRefMap.values()],
       requestFile: requestPath
     };
   }
@@ -2338,6 +2451,10 @@ function ensureInitFiles(root: string): string[] {
     {
       path: join(workflowsDir, "deployment-gate-review.yaml"),
       contents: deploymentGateWorkflowTemplate
+    },
+    {
+      path: join(workflowsDir, "promotion-approval.yaml"),
+      contents: promotionApprovalWorkflowTemplate
     },
     {
       path: join(workflowsDir, "incident-handoff.yaml"),

--- a/packages/cli/src/internal/builtin-agents.ts
+++ b/packages/cli/src/internal/builtin-agents.ts
@@ -30,6 +30,9 @@ import {
   qaArtifactSchema,
   qaEvidenceNormalizationSchema,
   qaRequestSchema,
+  promotionApprovalArtifactSchema,
+  promotionApprovalEvidenceNormalizationSchema,
+  promotionRequestSchema,
   releaseApprovalRecommendationSchema,
   releaseArtifactSchema,
   releaseCiEvidenceSummarySchema,
@@ -73,6 +76,9 @@ import type {
   PipelineRequest,
   PlanningArtifact,
   PlanningRequest,
+  PromotionApprovalArtifact,
+  PromotionApprovalEvidenceNormalization,
+  PromotionRequest,
   QaArtifact,
   QaEvidenceNormalization,
   QaRequest,
@@ -626,6 +632,54 @@ function evaluatePipelineReportReadiness(bundlePath: string): { ready: boolean; 
   return {
     ready: true,
     detail: `Using ${bundlePath} as a ready pipeline-report reference.`
+  };
+}
+
+function evaluateDeploymentGateApprovalReadiness(
+  bundlePath: string,
+  targetEnvironment?: string
+): { ready: boolean; detail: string } {
+  const artifact = loadBundleLifecycleArtifact(bundlePath, "deployment-gate-report");
+  if (!artifact) {
+    return {
+      ready: false,
+      detail: `Deployment gate bundle is missing a deployment-gate-report artifact: ${bundlePath}`
+    };
+  }
+
+  const parsed = deploymentGateArtifactSchema.safeParse(artifact);
+  if (!parsed.success) {
+    return {
+      ready: false,
+      detail: `Deployment gate bundle could not be parsed as a bounded deployment-gate-report artifact: ${bundlePath}`
+    };
+  }
+
+  const deploymentGateArtifact = parsed.data;
+  if (deploymentGateArtifact.status !== "complete") {
+    return {
+      ready: false,
+      detail: `Deployment gate report ${bundlePath} is ${deploymentGateArtifact.status} and cannot satisfy promotion approval yet.`
+    };
+  }
+
+  if (deploymentGateArtifact.payload.gateStatus !== "ready_for_approval") {
+    return {
+      ready: false,
+      detail: `Deployment gate report ${bundlePath} is ${deploymentGateArtifact.payload.gateStatus} and cannot satisfy promotion approval yet.`
+    };
+  }
+
+  if (targetEnvironment && deploymentGateArtifact.payload.targetEnvironment !== targetEnvironment) {
+    return {
+      ready: false,
+      detail: `Deployment gate report ${bundlePath} targets ${deploymentGateArtifact.payload.targetEnvironment}, not ${targetEnvironment}.`
+    };
+  }
+
+  return {
+    ready: true,
+    detail: `Using ${bundlePath} as a ready deployment-gate-report reference for ${targetEnvironment ?? deploymentGateArtifact.payload.targetEnvironment}.`
   };
 }
 
@@ -3710,6 +3764,411 @@ const deploymentGateAnalystAgent: RuntimeAgent = {
   }
 };
 
+const promotionApprovalIntakeAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "promotion-approval-intake",
+    displayName: "Promotion Approval Intake",
+    category: "release",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "context"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "release",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const promotionRequest = getWorkflowInput<PromotionRequest>(stateSlice, "promotionRequest");
+    const promotionIssueRefs = getWorkflowInput<string[]>(stateSlice, "promotionIssueRefs") ?? [];
+    const promotionScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "promotionScmRefs") ?? [];
+    const promotionGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "promotionGithubRefs") ?? [];
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!promotionRequest) {
+      throw new Error("promotion-approval requires a validated promotion request before runtime execution.");
+    }
+
+    return agentOutputSchema.parse({
+      summary: `Loaded promotion approval request from ${requestFile ?? ".agentops/requests/promotion.yaml"} for ${promotionRequest.targetEnvironment}.`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: {
+        ...promotionRequestSchema.parse(promotionRequest),
+        promotionIssueRefs,
+        promotionScmRefs,
+        promotionGithubRefs,
+        evidenceSourceCount:
+          promotionRequest.evidenceSources.length +
+          promotionRequest.qaReportRefs.length +
+          promotionRequest.securityReportRefs.length +
+          promotionRequest.releaseReportRefs.length +
+          promotionRequest.deploymentGateReportRefs.length
+      }
+    });
+  }
+};
+
+const promotionApprovalEvidenceNormalizationAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "promotion-approval-evidence-normalizer",
+    displayName: "Promotion Approval Evidence Normalizer",
+    category: "release",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "deterministic"
+    },
+    permissions: {
+      model: false,
+      network: false,
+      tools: [],
+      readPaths: [".agentops/requests/**", ".agentops/runs/**", "**/*.json", "**/*.md"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "agentResults"],
+    outputs: ["summary", "metadata"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "release",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ stateSlice }) {
+    const promotionRequest = getWorkflowInput<PromotionRequest>(stateSlice, "promotionRequest");
+    if (!promotionRequest) {
+      throw new Error("promotion-approval requires validated promotion request inputs before evidence normalization.");
+    }
+
+    const repoRoot = stateSlice.repo?.root;
+    const intakeMetadata = isRecord(stateSlice.agentResults?.intake?.metadata) ? stateSlice.agentResults.intake.metadata : {};
+    const qaReportRefs = asStringArray(intakeMetadata.qaReportRefs).length > 0
+      ? asStringArray(intakeMetadata.qaReportRefs)
+      : promotionRequest.qaReportRefs;
+    const securityReportRefs = asStringArray(intakeMetadata.securityReportRefs).length > 0
+      ? asStringArray(intakeMetadata.securityReportRefs)
+      : promotionRequest.securityReportRefs;
+    const releaseReportRefs = asStringArray(intakeMetadata.releaseReportRefs).length > 0
+      ? asStringArray(intakeMetadata.releaseReportRefs)
+      : promotionRequest.releaseReportRefs;
+    const deploymentGateReportRefs = asStringArray(intakeMetadata.deploymentGateReportRefs).length > 0
+      ? asStringArray(intakeMetadata.deploymentGateReportRefs)
+      : promotionRequest.deploymentGateReportRefs;
+    const evidenceSources = asStringArray(intakeMetadata.evidenceSources).length > 0
+      ? asStringArray(intakeMetadata.evidenceSources)
+      : promotionRequest.evidenceSources;
+    const normalizedEvidenceSources = [
+      ...new Set([...qaReportRefs, ...securityReportRefs, ...releaseReportRefs, ...deploymentGateReportRefs, ...evidenceSources])
+    ];
+    const missingEvidenceSources = normalizedEvidenceSources.filter((pathValue) => repoRoot && !existsSync(join(repoRoot, pathValue)));
+    if (missingEvidenceSources.length > 0) {
+      throw new Error(`Promotion evidence source not found: ${missingEvidenceSources[0]}`);
+    }
+
+    const referencedArtifactKinds = [
+      ...new Set(
+        [...qaReportRefs, ...securityReportRefs, ...releaseReportRefs, ...deploymentGateReportRefs].flatMap((bundleRef) =>
+          repoRoot ? loadBundleArtifactKinds(join(repoRoot, bundleRef)) : []
+        )
+      )
+    ];
+    const releaseReportReadiness = releaseReportRefs.map((bundleRef) =>
+      repoRoot
+        ? evaluateReleaseReportReadiness(join(repoRoot, bundleRef))
+        : { ready: false, detail: `Release report reference cannot be evaluated without a repository root: ${bundleRef}` }
+    );
+    const deploymentGateReadiness = deploymentGateReportRefs.map((bundleRef) =>
+      repoRoot
+        ? evaluateDeploymentGateApprovalReadiness(join(repoRoot, bundleRef), promotionRequest.targetEnvironment)
+        : { ready: false, detail: `Deployment gate reference cannot be evaluated without a repository root: ${bundleRef}` }
+    );
+    const ciEvidence = normalizeImportedCiEvidence(repoRoot, normalizedEvidenceSources);
+    const ciEvidenceSummary = ciEvidence.map((entry) => summarizeCiEvidenceForRelease(entry));
+    const failingChecks = ciEvidenceSummary.flatMap((entry) => entry.failingChecks);
+    const verificationChecks = [
+      {
+        name: "qa-report-refs",
+        status: qaReportRefs.length > 0 ? "passed" : "skipped",
+        detail: qaReportRefs.length > 0 ? `Using ${qaReportRefs.length} validated QA report reference(s).` : "No QA report references were supplied."
+      },
+      {
+        name: "security-report-refs",
+        status: securityReportRefs.length > 0 ? "passed" : "skipped",
+        detail: securityReportRefs.length > 0
+          ? `Using ${securityReportRefs.length} validated security report reference(s).`
+          : "No security report references were supplied."
+      },
+      {
+        name: "release-report-refs",
+        status:
+          releaseReportRefs.length === 0
+            ? "failed"
+            : releaseReportReadiness.some((entry) => !entry.ready)
+              ? "failed"
+              : "passed",
+        detail: releaseReportRefs.length > 0
+          ? releaseReportReadiness.some((entry) => !entry.ready)
+            ? releaseReportReadiness.filter((entry) => !entry.ready).map((entry) => entry.detail).join(" ")
+            : `Using ${releaseReportRefs.length} ready release report reference(s).`
+          : "At least one ready release report reference is required."
+      },
+      {
+        name: "deployment-gate-report-refs",
+        status:
+          deploymentGateReportRefs.length === 0
+            ? "failed"
+            : deploymentGateReadiness.some((entry) => !entry.ready)
+              ? "failed"
+              : "passed",
+        detail: deploymentGateReportRefs.length > 0
+          ? deploymentGateReadiness.some((entry) => !entry.ready)
+            ? deploymentGateReadiness.filter((entry) => !entry.ready).map((entry) => entry.detail).join(" ")
+            : `Using ${deploymentGateReportRefs.length} ready deployment gate report reference(s) for ${promotionRequest.targetEnvironment}.`
+          : "At least one ready deployment gate report reference is required."
+      },
+      {
+        name: "imported-ci-evidence",
+        status: ciEvidence.length === 0 ? "failed" : failingChecks.length > 0 ? "failed" : "passed",
+        detail:
+          ciEvidence.length === 0
+            ? "No imported CI evidence exports were supplied."
+            : failingChecks.length > 0
+              ? `Imported CI evidence still reports failing checks: ${failingChecks.join(", ")}.`
+              : `Using ${ciEvidence.length} imported CI evidence export(s) across ${[...new Set(ciEvidence.map((entry) => entry.pipelineName))].length} pipeline(s).`
+      }
+    ] as const;
+    const approvalStatus =
+      verificationChecks.some((check) => check.status === "failed")
+        ? "blocked"
+        : qaReportRefs.length > 0 && securityReportRefs.length > 0
+          ? "approval_recommended"
+          : "needs_follow_up";
+    const approvalRecommendations = [
+      {
+        action: "promote-release",
+        classification: approvalStatus === "approval_recommended" ? "approval_required" : "deny",
+        reason:
+          approvalStatus === "approval_recommended"
+            ? "Promotion remains a release-significant side effect and requires explicit maintainer approval."
+            : "Keep release promotion blocked until bounded release and deployment gate evidence is complete."
+      },
+      {
+        action: "publish-packages",
+        classification: approvalStatus === "approval_recommended" ? "approval_required" : "deny",
+        reason:
+          approvalStatus === "approval_recommended"
+            ? "Package publication remains outside the default read-only workflow path."
+            : "Do not publish packages while promotion approval remains blocked or incomplete."
+      }
+    ];
+
+    const normalization = promotionApprovalEvidenceNormalizationSchema.parse({
+      qaReportRefs,
+      securityReportRefs,
+      releaseReportRefs,
+      deploymentGateReportRefs,
+      normalizedEvidenceSources,
+      missingEvidenceSources: [],
+      ciEvidence,
+      ciEvidenceSummary,
+      referencedArtifactKinds,
+      verificationChecks,
+      approvalRecommendations,
+      approvalStatus,
+      provenanceRefs: normalizedEvidenceSources
+    });
+
+    return agentOutputSchema.parse({
+      summary: `Normalized promotion approval evidence across ${normalization.normalizedEvidenceSources.length} source(s) and ${normalization.ciEvidence.length} imported CI evidence export(s).`,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: normalization satisfies PromotionApprovalEvidenceNormalization
+    });
+  }
+};
+
+const promotionApprovalAnalystAgent: RuntimeAgent = {
+  manifest: agentManifestSchema.parse({
+    version: 1,
+    name: "promotion-approval-analyst",
+    displayName: "Promotion Approval Analyst",
+    category: "release",
+    runtime: {
+      minVersion: "0.1.0",
+      kind: "reasoning"
+    },
+    permissions: {
+      model: true,
+      network: false,
+      tools: [],
+      readPaths: ["**/*"],
+      writePaths: []
+    },
+    inputs: ["workflowInputs", "repo", "agentResults"],
+    outputs: ["lifecycleArtifacts"],
+    contextPolicy: {
+      sections: ["workflowInputs", "repo", "agentResults"],
+      minimalContext: true
+    },
+    catalog: {
+      domain: "release",
+      supportLevel: "internal",
+      maturity: "mvp",
+      trustScope: "official-core-only"
+    },
+    trust: {
+      tier: "core",
+      source: "official",
+      reviewed: true
+    }
+  }),
+  outputSchema: agentOutputSchema,
+  async execute({ state, stateSlice }) {
+    const promotionRequest = getWorkflowInput<PromotionRequest>(stateSlice, "promotionRequest");
+    const promotionIssueRefs = getWorkflowInput<string[]>(stateSlice, "promotionIssueRefs") ?? [];
+    const promotionScmRefs = getWorkflowInput<ScmReference[]>(stateSlice, "promotionScmRefs") ?? [];
+    const promotionGithubRefs = getWorkflowInput<GithubReference[]>(stateSlice, "promotionGithubRefs") ?? [];
+    const requestFile = getWorkflowInput<string>(stateSlice, "requestFile");
+    if (!promotionRequest) {
+      throw new Error("promotion-approval requires validated promotion inputs before analysis.");
+    }
+
+    const evidenceMetadata = promotionApprovalEvidenceNormalizationSchema.safeParse(stateSlice.agentResults?.evidence?.metadata);
+    const normalizedEvidence = evidenceMetadata.success ? evidenceMetadata.data : undefined;
+    const evidenceSources =
+      normalizedEvidence?.normalizedEvidenceSources && normalizedEvidence.normalizedEvidenceSources.length > 0
+        ? normalizedEvidence.normalizedEvidenceSources
+        : promotionRequest.evidenceSources;
+    const ciEvidenceSummary = normalizedEvidence?.ciEvidenceSummary ?? [];
+    const verificationChecks = normalizedEvidence?.verificationChecks ?? [];
+    const referencedArtifactKinds = normalizedEvidence?.referencedArtifactKinds ?? [];
+    const blockers = [
+      ...verificationChecks
+        .filter((check) => check.status === "failed")
+        .map((check) => check.detail ?? `${check.name} failed during deterministic promotion approval review.`)
+    ];
+    const approvalStatus = blockers.length > 0 ? "blocked" : normalizedEvidence?.approvalStatus ?? "needs_follow_up";
+    const requiredApprovals = [
+      "Obtain explicit maintainer approval before any promotion or publish action.",
+      `Confirm the ${promotionRequest.targetEnvironment} deployment owner accepts the current promotion window.`
+    ];
+    const recommendedNextSteps = [
+      ...ciEvidenceSummary.map(
+        (entry) => `Review ${entry.displayLabel} (${formatCiEvidenceStatus(entry)}) before approving promotion.`
+      ),
+      ...(promotionRequest.qaReportRefs.length > 0 || promotionRequest.securityReportRefs.length > 0
+        ? ["Carry the validated QA and security artifacts into the promotion approval packet."]
+        : ["Attach QA and security artifacts if additional assurance is required before promotion."]),
+      "Keep deployment, publication, and tag creation outside this review-only workflow.",
+      ...(promotionRequest.constraints.length > 0 ? [`Keep follow-up bounded by: ${promotionRequest.constraints.join("; ")}.`] : [])
+    ];
+    const approvalRecommendations = normalizedEvidence?.approvalRecommendations ?? [
+      {
+        action: "promote-release",
+        classification: approvalStatus === "approval_recommended" ? "approval_required" : "deny",
+        reason:
+          approvalStatus === "approval_recommended"
+            ? "Promotion remains a release-significant side effect and requires explicit maintainer approval."
+            : "Keep release promotion blocked until bounded release and deployment gate evidence is complete."
+      }
+    ];
+    const summary = `Promotion approval report prepared for ${promotionRequest.targetEnvironment}.`;
+    const promotionApprovalReport = promotionApprovalArtifactSchema.parse({
+      ...buildLifecycleArtifactEnvelopeBase(
+        state,
+        "Promotion Approval Review",
+        summary,
+        [requestFile ?? ".agentops/requests/promotion.yaml", ...new Set(evidenceSources)],
+        promotionIssueRefs,
+        promotionScmRefs,
+        promotionGithubRefs
+      ),
+      artifactKind: "promotion-approval-report",
+      lifecycleDomain: "release",
+      payload: {
+        promotionScope: promotionRequest.promotionScope,
+        targetEnvironment: promotionRequest.targetEnvironment,
+        evidenceSources,
+        verificationChecks,
+        ciEvidenceSummary,
+        approvalStatus,
+        blockers,
+        requiredApprovals,
+        recommendedNextSteps,
+        approvalRecommendations: approvalRecommendations.map((recommendation) =>
+          releaseApprovalRecommendationSchema.parse(recommendation)
+        ),
+        referencedArtifactKinds,
+        provenanceRefs: normalizedEvidence?.provenanceRefs ?? evidenceSources
+      }
+    });
+
+    return agentOutputSchema.parse({
+      summary,
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [promotionApprovalReport satisfies PromotionApprovalArtifact],
+      requestedTools: [],
+      blockedActionFlags: [],
+      confidence: 0.78,
+      metadata: {
+        deterministicInputs: {
+          targetEnvironment: promotionRequest.targetEnvironment,
+          evidenceSources,
+          ciEvidenceSummary,
+          verificationChecks,
+          referencedArtifactKinds,
+          constraints: promotionRequest.constraints
+        },
+        synthesizedAssessment: {
+          approvalStatus,
+          blockers,
+          requiredApprovals,
+          recommendedNextSteps
+        }
+      }
+    });
+  }
+};
+
 const securityEvidenceNormalizationAgent: RuntimeAgent = {
   manifest: agentManifestSchema.parse({
     version: 1,
@@ -4982,6 +5441,9 @@ export function createBuiltinAgentRegistry(): Map<string, RuntimeAgent> {
     ["deployment-gate-intake", deploymentGateIntakeAgent],
     ["deployment-gate-evidence-normalizer", deploymentGateEvidenceNormalizationAgent],
     ["deployment-gate-analyst", deploymentGateAnalystAgent],
+    ["promotion-approval-intake", promotionApprovalIntakeAgent],
+    ["promotion-approval-evidence-normalizer", promotionApprovalEvidenceNormalizationAgent],
+    ["promotion-approval-analyst", promotionApprovalAnalystAgent],
     ["security-evidence-normalizer", securityEvidenceNormalizationAgent],
     ["security-analyst", securityAnalystAgent],
     ["qa-evidence-normalizer", qaEvidenceNormalizationAgent],

--- a/packages/schemas/src/index.test.ts
+++ b/packages/schemas/src/index.test.ts
@@ -13,6 +13,9 @@ import {
   deploymentGateArtifactSchema,
   deploymentGateEvidenceNormalizationSchema,
   deploymentRequestSchema,
+  promotionApprovalArtifactSchema,
+  promotionApprovalEvidenceNormalizationSchema,
+  promotionRequestSchema,
   genericCiEvidenceExportSchema,
   gitlabCiEvidenceExportSchema,
   jenkinsCiEvidenceExportSchema,
@@ -77,6 +80,7 @@ describe("schema fixtures", () => {
     expect(() => evalFixtureCorpusSchema.parse(schemaFixtures.evalFixtureCorpus)).not.toThrow();
     expect(() => releaseRequestSchema.parse(schemaFixtures.releaseRequest)).not.toThrow();
     expect(() => deploymentRequestSchema.parse(schemaFixtures.deploymentRequest)).not.toThrow();
+    expect(() => promotionRequestSchema.parse(schemaFixtures.promotionRequest)).not.toThrow();
     expect(() => githubReferenceSchema.parse(schemaFixtures.githubReference)).not.toThrow();
     expect(() => scmReferenceSchema.parse(schemaFixtures.scmReference)).not.toThrow();
     expect(() => scmReferenceSchema.parse(schemaFixtures.gitlabIssueScmReference)).not.toThrow();
@@ -117,9 +121,11 @@ describe("schema fixtures", () => {
     expect(() => securityEvidenceNormalizationSchema.parse(schemaFixtures.securityEvidenceNormalization)).not.toThrow();
     expect(() => pipelineEvidenceNormalizationSchema.parse(schemaFixtures.pipelineEvidenceNormalization)).not.toThrow();
     expect(() => deploymentGateEvidenceNormalizationSchema.parse(schemaFixtures.deploymentGateEvidenceNormalization)).not.toThrow();
+    expect(() => promotionApprovalEvidenceNormalizationSchema.parse(schemaFixtures.promotionApprovalEvidenceNormalization)).not.toThrow();
     expect(() => releaseEvidenceNormalizationSchema.parse(schemaFixtures.releaseEvidenceNormalization)).not.toThrow();
     expect(() => releaseCiEvidenceSummarySchema.parse(schemaFixtures.releaseArtifact.payload.ciEvidenceSummary[0])).not.toThrow();
     expect(() => maintenanceEvidenceNormalizationSchema.parse(schemaFixtures.maintenanceEvidenceNormalization)).not.toThrow();
+    expect(() => promotionApprovalArtifactSchema.parse(schemaFixtures.promotionApprovalArtifact)).not.toThrow();
   });
 
   it("rejects invalid manifests", () => {
@@ -147,6 +153,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.evalFixtureCorpus).toBeDefined();
     expect(jsonSchemas.releaseRequest).toBeDefined();
     expect(jsonSchemas.deploymentRequest).toBeDefined();
+    expect(jsonSchemas.promotionRequest).toBeDefined();
     expect(jsonSchemas.githubReference).toBeDefined();
     expect(jsonSchemas.scmReference).toBeDefined();
     expect(jsonSchemas.ciArtifactEvidence).toBeDefined();
@@ -171,6 +178,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.securityEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.pipelineEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.deploymentGateEvidenceNormalization).toBeDefined();
+    expect(jsonSchemas.promotionApprovalEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.maintenanceEvidenceNormalization).toBeDefined();
     expect(jsonSchemas.releaseCiEvidenceSummary).toBeDefined();
     expect(jsonSchemas.releaseEvidenceNormalization).toBeDefined();
@@ -187,6 +195,7 @@ describe("schema fixtures", () => {
     expect(jsonSchemas.reviewArtifact).toBeDefined();
     expect(jsonSchemas.releaseArtifact).toBeDefined();
     expect(jsonSchemas.deploymentGateArtifact).toBeDefined();
+    expect(jsonSchemas.promotionApprovalArtifact).toBeDefined();
     expect(jsonSchemas.maintenanceArtifact).toBeDefined();
   });
 

--- a/packages/schemas/src/index.ts
+++ b/packages/schemas/src/index.ts
@@ -31,6 +31,7 @@ export const lifecycleArtifactKindSchema = z.enum([
   "review-report",
   "release-report",
   "deployment-gate-report",
+  "promotion-approval-report",
   "maintenance-report"
 ]);
 export const lifecycleDomainSchema = z.enum(["plan", "design", "build", "test", "security", "evaluate", "review", "release", "operate", "maintain"]);
@@ -828,7 +829,14 @@ export const githubWorkflowStatusMappingSchema = z.object({
   reason: z.string().min(1)
 });
 
-export const githubHandoffArtifactKindSchema = z.enum(["planning-brief", "design-record", "incident-brief", "qa-report", "release-report"]);
+export const githubHandoffArtifactKindSchema = z.enum([
+  "planning-brief",
+  "design-record",
+  "incident-brief",
+  "qa-report",
+  "release-report",
+  "promotion-approval-report"
+]);
 
 export const githubHandoffSectionSchema = z.object({
   heading: z.string().min(1),
@@ -1038,6 +1046,18 @@ export const deploymentRequestSchema = z.object({
   constraints: z.array(z.string().min(1)).default([])
 });
 
+export const promotionRequestSchema = z.object({
+  promotionScope: z.string().min(1),
+  targetEnvironment: z.string().min(1),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  qaReportRefs: z.array(z.string().min(1)).default([]),
+  securityReportRefs: z.array(z.string().min(1)).default([]),
+  releaseReportRefs: z.array(z.string().min(1)).default([]),
+  deploymentGateReportRefs: z.array(z.string().min(1)).default([]),
+  issueRefs: z.array(z.string().min(1)).default([]),
+  constraints: z.array(z.string().min(1)).default([])
+});
+
 export const incidentRequestSchema = z.object({
   incidentSummary: z.string().min(1),
   severityHint: z.enum(["unknown", "low", "medium", "high", "critical"]).default("unknown"),
@@ -1240,6 +1260,39 @@ export const deploymentGateArtifactPayloadSchema = z.object({
   provenanceRefs: z.array(z.string().min(1)).default([])
 });
 
+export const promotionApprovalStatusSchema = z.enum(["approval_recommended", "needs_follow_up", "blocked"]);
+
+export const promotionApprovalEvidenceNormalizationSchema = z.object({
+  qaReportRefs: z.array(z.string().min(1)).default([]),
+  securityReportRefs: z.array(z.string().min(1)).default([]),
+  releaseReportRefs: z.array(z.string().min(1)).default([]),
+  deploymentGateReportRefs: z.array(z.string().min(1)).default([]),
+  normalizedEvidenceSources: z.array(z.string().min(1)).default([]),
+  missingEvidenceSources: z.array(z.string().min(1)).default([]),
+  ciEvidence: z.array(ciEvidenceSchema).default([]),
+  ciEvidenceSummary: z.array(releaseCiEvidenceSummarySchema).default([]),
+  referencedArtifactKinds: z.array(z.string().min(1)).default([]),
+  verificationChecks: z.array(releaseVerificationCheckSchema).default([]),
+  approvalRecommendations: z.array(releaseApprovalRecommendationSchema).default([]),
+  approvalStatus: promotionApprovalStatusSchema,
+  provenanceRefs: z.array(z.string().min(1)).default([])
+});
+
+export const promotionApprovalArtifactPayloadSchema = z.object({
+  promotionScope: z.string().min(1),
+  targetEnvironment: z.string().min(1),
+  evidenceSources: z.array(z.string().min(1)).default([]),
+  verificationChecks: z.array(releaseVerificationCheckSchema).default([]),
+  ciEvidenceSummary: z.array(releaseCiEvidenceSummarySchema).default([]),
+  approvalStatus: promotionApprovalStatusSchema,
+  blockers: z.array(z.string().min(1)).default([]),
+  requiredApprovals: z.array(z.string().min(1)).default([]),
+  recommendedNextSteps: z.array(z.string().min(1)).default([]),
+  approvalRecommendations: z.array(releaseApprovalRecommendationSchema).default([]),
+  referencedArtifactKinds: z.array(z.string().min(1)).default([]),
+  provenanceRefs: z.array(z.string().min(1)).default([])
+});
+
 export const maintenanceArtifactPayloadSchema = z.object({
   maintenanceScope: z.string().min(1),
   evidenceSources: z.array(z.string().min(1)).default([]),
@@ -1404,6 +1457,12 @@ export const deploymentGateArtifactSchema = lifecycleArtifactEnvelopeSchema.exte
   payload: deploymentGateArtifactPayloadSchema
 });
 
+export const promotionApprovalArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
+  artifactKind: z.literal("promotion-approval-report"),
+  lifecycleDomain: z.literal("release"),
+  payload: promotionApprovalArtifactPayloadSchema
+});
+
 export const maintenanceArtifactSchema = lifecycleArtifactEnvelopeSchema.extend({
   artifactKind: z.literal("maintenance-report"),
   lifecycleDomain: z.literal("maintain"),
@@ -1423,6 +1482,7 @@ export const lifecycleArtifactSchema = z.discriminatedUnion("artifactKind", [
   reviewArtifactSchema,
   releaseArtifactSchema,
   deploymentGateArtifactSchema,
+  promotionApprovalArtifactSchema,
   maintenanceArtifactSchema
 ]);
 
@@ -1514,6 +1574,7 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   releaseArtifactPayload: releaseArtifactPayloadSchema,
   pipelineArtifactPayload: pipelineArtifactPayloadSchema,
   deploymentGateArtifactPayload: deploymentGateArtifactPayloadSchema,
+  promotionApprovalArtifactPayload: promotionApprovalArtifactPayloadSchema,
   maintenanceArtifactPayload: maintenanceArtifactPayloadSchema,
   planningArtifact: planningArtifactSchema,
   designArtifact: designArtifactSchema,
@@ -1527,6 +1588,7 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   reviewArtifact: reviewArtifactSchema,
   releaseArtifact: releaseArtifactSchema,
   deploymentGateArtifact: deploymentGateArtifactSchema,
+  promotionApprovalArtifact: promotionApprovalArtifactSchema,
   maintenanceArtifact: maintenanceArtifactSchema,
   lifecycleArtifact: lifecycleArtifactSchema,
   agentOutput: agentOutputSchema,
@@ -1541,6 +1603,7 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   pipelineRequest: pipelineRequestSchema,
   releaseRequest: releaseRequestSchema,
   deploymentRequest: deploymentRequestSchema,
+  promotionRequest: promotionRequestSchema,
   incidentRequest: incidentRequestSchema,
   maintenanceRequest: maintenanceRequestSchema,
   evalPolicyExpectation: evalPolicyExpectationSchema,
@@ -1554,6 +1617,7 @@ export const schemaRegistry: Record<string, ZodTypeAny> = {
   securityEvidenceNormalization: securityEvidenceNormalizationSchema,
   pipelineEvidenceNormalization: pipelineEvidenceNormalizationSchema,
   deploymentGateEvidenceNormalization: deploymentGateEvidenceNormalizationSchema,
+  promotionApprovalEvidenceNormalization: promotionApprovalEvidenceNormalizationSchema,
   incidentEvidenceNormalization: incidentEvidenceNormalizationSchema,
   maintenanceEvidenceNormalization: maintenanceEvidenceNormalizationSchema,
   policyDocument: policyDocumentSchema,
@@ -1997,6 +2061,95 @@ const deploymentGateArtifactFixture = {
   }
 } as const;
 
+const promotionApprovalArtifactFixture = {
+  ...lifecycleArtifactFixtureBase,
+  artifactKind: "promotion-approval-report",
+  lifecycleDomain: "release",
+  summary: "Promotion approval review report for the production candidate.",
+  payload: {
+    promotionScope: "Review approval readiness for promoting the current release candidate.",
+    targetEnvironment: "production",
+    evidenceSources: [
+      ".agentops/evidence/jenkins-ci.json",
+      ".agentops/evidence/generic-ci.json",
+      ".agentops/runs/run-release/bundle.json",
+      ".agentops/runs/run-deployment/bundle.json"
+    ],
+    verificationChecks: [
+      { name: "release-report-refs", status: "passed", detail: "Using 1 ready release report reference(s)." },
+      {
+        name: "deployment-gate-report-refs",
+        status: "passed",
+        detail: "Using 1 ready deployment gate report reference(s) for production."
+      },
+      { name: "imported-ci-evidence", status: "passed", detail: "Using 2 imported CI evidence export(s) across 2 pipeline(s)." }
+    ],
+    ciEvidenceSummary: [
+      {
+        provider: "Jenkins",
+        platform: "jenkins-ci",
+        host: "jenkins.local",
+        repository: "H9-Foundry/AgentForge",
+        pipelineName: "Jenkins CI",
+        pipelineRunId: "jenkins-42",
+        status: "completed",
+        conclusion: "success",
+        branch: "main",
+        commitSha: "abc123",
+        failingChecks: [],
+        provenanceSource: "local-export",
+        displayLabel: "Jenkins (jenkins-ci) pipeline `Jenkins CI` run `jenkins-42`",
+        statusSummary: "Jenkins (jenkins-ci) pipeline `Jenkins CI` run `jenkins-42` completed from local-export evidence with success."
+      },
+      {
+        provider: "CircleCI",
+        platform: "generic-ci",
+        host: "circleci.local",
+        repository: "H9-Foundry/AgentForge",
+        pipelineName: "CircleCI",
+        pipelineRunId: "circleci-42",
+        status: "completed",
+        conclusion: "success",
+        branch: "main",
+        commitSha: "abc123",
+        failingChecks: [],
+        provenanceSource: "local-export",
+        displayLabel: "CircleCI (generic-ci) pipeline `CircleCI` run `circleci-42`",
+        statusSummary: "CircleCI (generic-ci) pipeline `CircleCI` run `circleci-42` completed from local-export evidence with success."
+      }
+    ],
+    approvalStatus: "approval_recommended",
+    blockers: [],
+    requiredApprovals: [
+      "Obtain explicit maintainer approval before any promotion or publish action.",
+      "Confirm the production deployment owner accepts the current promotion window."
+    ],
+    recommendedNextSteps: [
+      "Use the ready release and deployment-gate reports as the bounded approval package for promotion review.",
+      "Keep deployment and publish execution outside this review-only workflow."
+    ],
+    approvalRecommendations: [
+      {
+        action: "promote-release",
+        classification: "approval_required",
+        reason: "Promotion remains a release-significant side effect and requires explicit maintainer approval."
+      },
+      {
+        action: "publish-packages",
+        classification: "approval_required",
+        reason: "Package publication remains outside the default read-only workflow path."
+      }
+    ],
+    referencedArtifactKinds: ["qa-report", "security-report", "release-report", "deployment-gate-report"],
+    provenanceRefs: [
+      ".agentops/evidence/jenkins-ci.json",
+      ".agentops/evidence/generic-ci.json",
+      ".agentops/runs/run-release/bundle.json",
+      ".agentops/runs/run-deployment/bundle.json"
+    ]
+  }
+} as const;
+
 const maintenanceArtifactFixture = {
   ...lifecycleArtifactFixtureBase,
   artifactKind: "maintenance-report",
@@ -2193,6 +2346,21 @@ const deploymentRequestFixture = {
   pipelineReportRefs: [".agentops/runs/run-pipeline/bundle.json"],
   issueRefs: ["#245", "#260"],
   constraints: ["Keep deployment gate review read-only"]
+} as const;
+
+const promotionRequestFixture = {
+  promotionScope: "Review approval readiness for promoting the current release candidate.",
+  targetEnvironment: "production",
+  evidenceSources: [
+    ".agentops/evidence/jenkins-ci.json",
+    ".agentops/evidence/generic-ci.json"
+  ],
+  qaReportRefs: [".agentops/runs/run-789/bundle.json"],
+  securityReportRefs: [".agentops/runs/run-790/bundle.json"],
+  releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+  deploymentGateReportRefs: [".agentops/runs/run-deployment/bundle.json"],
+  issueRefs: ["#245", "#261"],
+  constraints: ["Keep promotion approval review read-only"]
 } as const;
 
 const incidentRequestFixture = {
@@ -3259,6 +3427,36 @@ const deploymentGateEvidenceNormalizationFixture = {
   ]
 } as const;
 
+const promotionApprovalEvidenceNormalizationFixture = {
+  qaReportRefs: [".agentops/runs/run-789/bundle.json"],
+  securityReportRefs: [".agentops/runs/run-790/bundle.json"],
+  releaseReportRefs: [".agentops/runs/run-release/bundle.json"],
+  deploymentGateReportRefs: [".agentops/runs/run-deployment/bundle.json"],
+  normalizedEvidenceSources: [
+    ".agentops/runs/run-789/bundle.json",
+    ".agentops/runs/run-790/bundle.json",
+    ".agentops/runs/run-release/bundle.json",
+    ".agentops/runs/run-deployment/bundle.json",
+    ".agentops/evidence/jenkins-ci.json",
+    ".agentops/evidence/generic-ci.json"
+  ],
+  missingEvidenceSources: [],
+  ciEvidence: [jenkinsCiEvidenceFixture, genericCiEvidenceFixture],
+  ciEvidenceSummary: promotionApprovalArtifactFixture.payload.ciEvidenceSummary,
+  referencedArtifactKinds: ["qa-report", "security-report", "release-report", "deployment-gate-report"],
+  verificationChecks: promotionApprovalArtifactFixture.payload.verificationChecks,
+  approvalRecommendations: promotionApprovalArtifactFixture.payload.approvalRecommendations,
+  approvalStatus: "approval_recommended",
+  provenanceRefs: [
+    ".agentops/runs/run-789/bundle.json",
+    ".agentops/runs/run-790/bundle.json",
+    ".agentops/runs/run-release/bundle.json",
+    ".agentops/runs/run-deployment/bundle.json",
+    ".agentops/evidence/jenkins-ci.json",
+    ".agentops/evidence/generic-ci.json"
+  ]
+} as const;
+
 export const schemaFixtures = {
   finding: {
     id: "finding-1",
@@ -3471,6 +3669,7 @@ export const schemaFixtures = {
   pipelineRequest: pipelineRequestFixture,
   releaseRequest: releaseRequestFixture,
   deploymentRequest: deploymentRequestFixture,
+  promotionRequest: promotionRequestFixture,
   incidentRequest: incidentRequestFixture,
   maintenanceRequest: maintenanceRequestFixture,
   evalSpec: evalFixtureCorpusFixture.specs[1],
@@ -3504,6 +3703,7 @@ export const schemaFixtures = {
   securityEvidenceNormalization: securityEvidenceNormalizationFixture,
   pipelineEvidenceNormalization: pipelineEvidenceNormalizationFixture,
   deploymentGateEvidenceNormalization: deploymentGateEvidenceNormalizationFixture,
+  promotionApprovalEvidenceNormalization: promotionApprovalEvidenceNormalizationFixture,
   incidentEvidenceNormalization: incidentEvidenceNormalizationFixture,
   maintenanceEvidenceNormalization: maintenanceEvidenceNormalizationFixture,
   releaseEvidenceNormalization: releaseEvidenceNormalizationFixture,
@@ -3520,6 +3720,7 @@ export const schemaFixtures = {
   reviewArtifact: reviewArtifactFixture,
   releaseArtifact: releaseArtifactFixture,
   deploymentGateArtifact: deploymentGateArtifactFixture,
+  promotionApprovalArtifact: promotionApprovalArtifactFixture,
   maintenanceArtifact: maintenanceArtifactFixture,
   invalidLifecycleArtifactEnvelope: invalidLifecycleArtifactEnvelopeFixture,
   invalidPlanningArtifact: invalidPlanningArtifactFixture,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -46,6 +46,10 @@ import {
   deploymentGateArtifactSchema,
   deploymentGateEvidenceNormalizationSchema,
   deploymentRequestSchema,
+  promotionApprovalArtifactPayloadSchema,
+  promotionApprovalArtifactSchema,
+  promotionApprovalEvidenceNormalizationSchema,
+  promotionRequestSchema,
   dependencyIntegrityEvidenceSchema,
   dependencyInventoryEntrySchema,
   ciJobEvidenceSchema,
@@ -143,6 +147,10 @@ export type DeploymentGateArtifactPayload = Infer<typeof deploymentGateArtifactP
 export type DeploymentGateArtifact = Infer<typeof deploymentGateArtifactSchema>;
 export type DeploymentGateEvidenceNormalization = Infer<typeof deploymentGateEvidenceNormalizationSchema>;
 export type DeploymentRequest = Infer<typeof deploymentRequestSchema>;
+export type PromotionApprovalArtifactPayload = Infer<typeof promotionApprovalArtifactPayloadSchema>;
+export type PromotionApprovalArtifact = Infer<typeof promotionApprovalArtifactSchema>;
+export type PromotionApprovalEvidenceNormalization = Infer<typeof promotionApprovalEvidenceNormalizationSchema>;
+export type PromotionRequest = Infer<typeof promotionRequestSchema>;
 export type AdapterCapabilityMetadata = Infer<typeof adapterCapabilityMetadataSchema>;
 export type GithubActionsJobEvidence = Infer<typeof githubActionsJobEvidenceSchema>;
 export type GithubActionsCheckRunEvidence = Infer<typeof githubActionsCheckRunEvidenceSchema>;


### PR DESCRIPTION
## Summary
- add the `promotion-approval` workflow, request contract, and `promotion-approval-report` artifact
- normalize ready release and deployment-gate evidence plus shared CI evidence for approval-oriented review
- extend audit rendering and maintainer/docs truth for the new source-build-only workflow surface

## Testing
- pnpm exec vitest run packages/schemas/src/index.test.ts packages/audit/src/index.test.ts packages/cli/src/index.test.ts
- pnpm typecheck
- pnpm lint
- pnpm build
- pnpm build:packages
- pnpm test; echo EXIT:$?