### PR TITLE
Refresh post-release queue truth

### DIFF
--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -50,7 +50,7 @@ Rules:
 Current active lane:
 
 1. [#245](https://github.com/H9-Foundry/AgentForge/issues/245) Phase 2 provider and integration expansion tracker
-2. [#261](https://github.com/H9-Foundry/AgentForge/issues/261) Promotion approval review follow-on
+2. no active implementation slice assigned after the current release and CI review family shipped and was verified from npm
 
 ### Ready Lane
 
@@ -58,9 +58,9 @@ Work that is explicitly designed or queued next, but should not start until the 
 
 Current ready lane:
 
-3. additional generic release and CI workflow consumption after the current provider-agnostic review family is published and validated from npm
-4. additional provider-specific SCM and CI wedges after the generic release and CI workflow family is stable
-5. deeper supply-chain and enterprise trust work reopened only after the next provider/integration family is defined explicitly
+3. additional generic release and CI workflow consumption after the next bounded Phase 2 family is chosen explicitly
+4. additional provider-specific SCM and CI wedges after the current generic release and CI workflow family is stable
+5. deeper supply-chain and enterprise trust work reopened only after the next provider or integration family is defined explicitly
 
 ### Parallel Safe Lane
 

--- a/docs/RELEASE_CICD_WORKFLOWS.md
+++ b/docs/RELEASE_CICD_WORKFLOWS.md
@@ -60,7 +60,7 @@ Phase 2 now builds on the current official local release and CI review family:
 - `deployment-gate-review`
 - `promotion-approval`
 
-The four current workflows are implemented on `main`. `promotion-approval` remains source-build only until the next npm release; later release-family work should extend this bounded review family rather than reopening first-wedge planning.
+The four current workflows are implemented on `main` and published in the current npm release. Later release-family work should extend this bounded review family rather than reopening first-wedge planning.
 
 ## User Jobs
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -30,7 +30,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `release-readiness` | Official | Dedicated release workflow that consumes bounded local release evidence, emits a `release-report` artifact, and keeps publish or promotion follow-ons outside the default read-only path. |
 | `pipeline-evidence-review` | Official | Dedicated provider-agnostic pipeline workflow that consumes bounded local CI evidence, emits a `pipeline-report` artifact, and stays local-first and read-only by default. |
 | `deployment-gate-review` | Official | Dedicated deployment gate workflow that consumes shared CI evidence plus referenced QA, security, release, and pipeline artifacts, and emits a `deployment-gate-report` artifact without adding deployment side effects. |
-| `promotion-approval` | Official | Approval-oriented release review workflow on `main` that consumes shared CI evidence plus ready release and deployment gate artifacts, emits a `promotion-approval-report`, and remains source-build only until the next npm release. |
+| `promotion-approval` | Official | Approval-oriented release review workflow that consumes shared CI evidence plus ready release and deployment gate artifacts and emits a `promotion-approval-report`. |
 | `incident-handoff` | Official | Dedicated operations workflow that consumes staged local incident evidence, emits an `incident-brief` artifact, and keeps the default path local-first and read-only. |
 | `maintenance-triage` | Official | Dedicated maintenance workflow that consumes bounded maintenance evidence, emits a `maintenance-report` artifact, and keeps the default path read-only with deterministic routing support. |
 | security / DevSecOps extensions | Planned | Additional security variants beyond `security-review` are not implemented yet. |
@@ -120,7 +120,7 @@ See [docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md](EXTERNAL_LOCAL_ADOPTION_READINES
 
 ## Compatibility Notes
 
-- Workflow maturity and published CLI availability are related but not identical. A workflow can be official on `main` and still need an explicit `source-build only` note until the latest npm release includes it, but the current quick path and preset startup are already available in the published CLI.
+- Workflow maturity and published CLI availability are related but not identical. A workflow can be official on `main` and still need an explicit `source-build only` note until the latest npm release includes it; the current quick path, preset startup, and release/CI review family are already available in the published CLI.
 - Current support is strongest for local repository execution and GitHub-centric release workflows.
 - Public compatibility commitments are intentionally narrow until broader workflow and integration support exists.
 - Planned support in this matrix should be treated as roadmap direction, not shipped capability.


### PR DESCRIPTION
## Summary
- remove the stale `#261` active-lane entry after the `0.11.0` publish loop completed
- update release/support docs so `promotion-approval` is no longer described as source-build only
- leave Phase 2 with no fake active implementation slice after published parity is verified

## Testing
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test; echo EXIT:$?
