### PR TITLE
Add AgentForge-first dogfood benchmark playbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ AgentForge is moving from a single secure `pr-review` wedge toward a broader SDL
 Current dogfooding posture:
 
 - use AgentForge on AgentForge for planning, design, review, QA, and release verification
+- benchmark AgentForge on AgentForge against the same agent's default workflow before expanding the pilot to other repositories
 - do not treat it as a broad autonomous implementation engine yet
 
 Current onboarding focus:
@@ -350,7 +351,7 @@ Current onboarding focus:
 - keep the current wedge CLI-first and as frictionless as possible for new evaluators
 - improve README, quickstart, examples, and contributor entry points in parallel with the Phase 1 foundation work
 
-See [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md), [docs/CONTEXT_SLICE_CONTRACTS.md](docs/CONTEXT_SLICE_CONTRACTS.md), and [docs/QUEUE_EXECUTION_FLOW.md](docs/QUEUE_EXECUTION_FLOW.md).
+See [docs/SELF_HOSTING.md](docs/SELF_HOSTING.md), [docs/AGENTFORGE_DOGFOOD_BENCHMARK.md](docs/AGENTFORGE_DOGFOOD_BENCHMARK.md), [docs/CONTEXT_SLICE_CONTRACTS.md](docs/CONTEXT_SLICE_CONTRACTS.md), and [docs/QUEUE_EXECUTION_FLOW.md](docs/QUEUE_EXECUTION_FLOW.md).
 
 Roadmap docs:
 

--- a/docs/AGENTFORGE_DOGFOOD_BENCHMARK.md
+++ b/docs/AGENTFORGE_DOGFOOD_BENCHMARK.md
@@ -1,0 +1,189 @@
+# AgentForge-First Dogfood Benchmark
+
+This document defines how AgentForge should benchmark itself on the AgentForge repository before expanding the benchmark to other repositories.
+
+It is an operational playbook, not a shipped workflow or product guarantee.
+
+Use [#268](https://github.com/H9-Foundry/AgentForge/issues/268) as the benchmark feedback sink and scorecard log.
+
+## Goal
+
+Measure whether AgentForge improves the same agent's SDLC behavior on this repository when compared with that agent's normal default workflow.
+
+The benchmark optimizes first for:
+
+- confirmed risk caught before merge or release decisions
+- evidence completeness and decision clarity
+
+It treats the following as secondary:
+
+- cycle time
+- workflow friction
+- override rate
+
+## Benchmark Model
+
+Use the same agent, model, repository, and task brief style in both arms.
+
+- **Control arm:** the agent follows the normal repository workflow with the same validation commands but does not run AgentForge workflows
+- **Treatment arm:** the agent follows the same task brief plus the relevant AgentForge workflows and advisory-gate rules
+
+This benchmark does not try to measure model quality. It measures whether AgentForge improves SDLC outcomes around the same agent.
+
+## Task Source
+
+Run the benchmark in two stages.
+
+### Stage 1: Replay Calibration
+
+Use three to four recent completed AgentForge tasks to calibrate the scorecard quickly.
+
+Recommended replay mix:
+
+- one implementation or review task
+- one SCM/CI or release task
+- one promotion or deployment review task
+- optional one security or reliability-sensitive task
+
+Replay tasks should be used to tune the rubric, not to make final product claims.
+
+### Stage 2: Live Benchmark
+
+Benchmark the next six to eight real AgentForge tasks.
+
+Required live mix:
+
+- feature or refactor work
+- schema, runtime, policy, or security-sensitive work
+- release, pipeline, deployment, or promotion review work
+
+Final conclusions should be weighted toward the live phase.
+
+## Workflow Routing
+
+Treatment tasks should use this fixed routing.
+
+### Feature Or Refactor Work
+
+- `planning-discovery`
+- `implementation-proposal`
+- `qa-review`
+- `pr-review`
+
+### Schema / Runtime / Policy / Security-Sensitive Work
+
+- `planning-discovery`
+- `architecture-design-review`
+- `implementation-proposal`
+- `qa-review`
+- `security-review`
+- `pr-review`
+
+### Release / Pipeline / Deployment / Promotion Review
+
+- `release-readiness`
+- `pipeline-evidence-review`
+- `deployment-gate-review`
+- `promotion-approval`
+
+### Incident Or Regression Handling
+
+- `incident-handoff`
+- optionally `maintenance-triage`
+
+Control tasks should use the same repository validation commands and evidence sources without any AgentForge workflow requirement.
+
+## Validation Commands
+
+Use the normal repository validation surface in both arms as relevant:
+
+- `pnpm lint`
+- `pnpm test`
+- `pnpm typecheck`
+- `pnpm build`
+- `pnpm build:packages` when public package contracts change
+
+Use direct-shell exit checks for long-running test wrappers when needed:
+
+- `pnpm test; echo EXIT:$?`
+
+## Scorecard
+
+Create one scorecard entry per task with these fields:
+
+- task id or link
+- source: `replay` or `live`
+- task type
+- arm: `control` or `agentforge`
+- agent and model
+- start and end timestamps
+- validations run
+- workflow statuses for treatment runs
+- confirmed risks or issues caught before merge
+- reviewer judgment on validity and severity
+- whether AgentForge changed the plan or decision
+- cycle time
+- evidence completeness notes
+- friction notes
+- override note if treatment proceeded past a blocked or partial result
+
+## Scoring
+
+### Primary Metric: Risk-Caught Index
+
+Only count issues that were surfaced before merge or release and later confirmed by review or validation.
+
+Severity weighting:
+
+- high: release blocker, security issue, or broken critical flow
+- medium: missing validation, missing evidence, or important design inconsistency
+- low: process improvement only
+
+### Secondary Metrics
+
+- cycle time
+- evidence completeness
+- reviewer confidence
+- override rate
+- friction score
+
+## Feedback Loop
+
+Each benchmarked task should add one comment to [#268](https://github.com/H9-Foundry/AgentForge/issues/268) with:
+
+- task summary
+- task source
+- task type
+- arm
+- workflows run
+- final statuses
+- whether AgentForge changed the plan or decision
+- confirmed findings
+- friction or false positives
+- override note if applicable
+- keep / tighten / simplify / deprioritize recommendation
+
+After every three benchmarked tasks, summarize:
+
+- workflows that changed decisions
+- repeated false positives
+- repeated request or evidence friction
+- workflows that added little value
+
+## Success Bar Before External Expansion
+
+Do not treat the benchmark as ready to expand to another repository until:
+
+- AgentForge catches at least one meaningful issue class that the default flow misses
+- treatment tasks do not show a repeated severe usability failure pattern
+- median cycle-time penalty stays acceptable for the team
+- at least two workflows clearly produce reusable value instead of generic noise
+
+## Non-Goals
+
+This benchmark does not:
+
+- create new product runtime surface
+- turn dogfood results into public marketing claims
+- replace normal repository validation or review
+- broaden self-hosted behavior beyond the current narrow-assist posture

--- a/docs/EVALS_BENCHMARKS_FRAMEWORK.md
+++ b/docs/EVALS_BENCHMARKS_FRAMEWORK.md
@@ -39,6 +39,7 @@ Available now:
 - local benchmark comparison via `agentforge eval compare <baseline-run> <candidate-run...>`
 - `benchmark-summary` lifecycle artifact emission for deterministic local eval comparisons
 - support matrix and roadmap framing
+- a concrete internal dogfood benchmark playbook for AgentForge-on-AgentForge comparison in [docs/AGENTFORGE_DOGFOOD_BENCHMARK.md](AGENTFORGE_DOGFOOD_BENCHMARK.md)
 
 Not yet available:
 
@@ -149,6 +150,17 @@ Evals should grow with the workflow catalog:
 - then for build, QA, security, release, maintenance, and operations workflows
 
 The eval framework should never assume a broader workflow surface than the support matrix currently claims.
+
+## Relationship To Internal Dogfooding
+
+The current dogfood benchmark should remain narrower than the full eval roadmap:
+
+- use the existing workflow surface and validation commands
+- compare the same agent's default flow against AgentForge-gated flow
+- keep adjudication explicit and human-reviewed
+- treat replay tasks as calibration and live tasks as the real signal
+
+See [docs/AGENTFORGE_DOGFOOD_BENCHMARK.md](AGENTFORGE_DOGFOOD_BENCHMARK.md) and [#268](https://github.com/H9-Foundry/AgentForge/issues/268).
 
 ## Follow-On Implementation Slices
 

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -51,6 +51,7 @@ Current active lane:
 
 1. [#245](https://github.com/H9-Foundry/AgentForge/issues/245) Phase 2 provider and integration expansion tracker
 2. no active implementation slice assigned after the current release and CI review family shipped and was verified from npm
+3. [#268](https://github.com/H9-Foundry/AgentForge/issues/268) AgentForge-first dogfood benchmark log may run in parallel as a docs-and-ops slice while no new implementation family is active
 
 ### Ready Lane
 
@@ -180,6 +181,7 @@ While the queue is being executed, AgentForge should be used on itself for:
 - planning and design
 - PR review and QA
 - release/readiness verification
+- benchmarked comparison against the same agent's default workflow using [docs/AGENTFORGE_DOGFOOD_BENCHMARK.md](AGENTFORGE_DOGFOOD_BENCHMARK.md)
 
 It should **not** be used as a general autonomous implementation engine until:
 

--- a/docs/SELF_HOSTING.md
+++ b/docs/SELF_HOSTING.md
@@ -114,6 +114,7 @@ Additionally:
 - review or QA runs must emit structured findings or an explicit no-findings result
 - release-oriented checks must stay deterministic and machine-readable where possible
 - documentation must not describe a self-hosted capability as official until it actually exists in the repo
+- dogfood benchmarking should follow [docs/AGENTFORGE_DOGFOOD_BENCHMARK.md](AGENTFORGE_DOGFOOD_BENCHMARK.md) and log results in [#268](https://github.com/H9-Foundry/AgentForge/issues/268)
 
 ## Graduation Criteria For Broader Self-Hosting
 


### PR DESCRIPTION
## Summary
- add an AgentForge-on-AgentForge dogfood benchmark playbook and scorecard guidance
- thread the benchmark into the self-hosting, evals, queue, and README docs
- create the concrete benchmark log issue to use as the feedback sink

## Links
- closes #268
- tracker: #245

## Validation
- `pnpm lint`
- `pnpm test; echo EXIT:$?`
- `pnpm typecheck`
- `pnpm build`
- `node packages/cli/dist/bin.js run pr-review --json`
- `node packages/cli/dist/bin.js explain last-run --json`

## Notes
- left `.agentops/evals/` untouched as local scratch
- benchmark remains docs-and-ops only; no new runtime surface is introduced