### PR TITLE
Define CreateCVs portability phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Source-build only:
 
 - `pnpm visualizer:dev` starts a local read-only visualizer for `.agentops/runs`, including outcomes, risk, and benchmark views
 - `agentforge eval benchmark-ledger --json` and `agentforge eval benchmark-record ...` support the local dogfood benchmark ledger that powers adjudicated `/outcomes` overlays
+- the next benchmark expansion after the AgentForge-first dogfood phase is the bounded CreateCVs portability phase in [docs/CREATECVS_PORTABILITY_PHASE.md](docs/CREATECVS_PORTABILITY_PHASE.md)
 - see [docs/VISUALIZER.md](docs/VISUALIZER.md) for the current boundary and launch path
 
 ## What Success Looks Like

--- a/docs/AGENTFORGE_DOGFOOD_BENCHMARK.md
+++ b/docs/AGENTFORGE_DOGFOOD_BENCHMARK.md
@@ -186,6 +186,8 @@ Do not treat the benchmark as ready to expand to another repository until:
 - median cycle-time penalty stays acceptable for the team
 - at least two workflows clearly produce reusable value instead of generic noise
 
+When those conditions are met, move to the first external portability benchmark defined in [docs/CREATECVS_PORTABILITY_PHASE.md](CREATECVS_PORTABILITY_PHASE.md).
+
 ## Non-Goals
 
 This benchmark does not:

--- a/docs/CREATECVS_PORTABILITY_PHASE.md
+++ b/docs/CREATECVS_PORTABILITY_PHASE.md
@@ -1,0 +1,155 @@
+# CreateCVs Portability Phase
+
+This document defines the first external portability phase after the AgentForge-on-AgentForge dogfood benchmark.
+
+It is an operational benchmark playbook, not a shipped runtime workflow or hosted integration promise.
+
+Use it only after the AgentForge-first benchmark loop is stable enough to support comparison in another repository without changing the benchmark rules mid-stream.
+
+## Goal
+
+Prove that the current published AgentForge CLI and official workflow surface can improve SDLC behavior in a second real repository without relying on AgentForge-repo-specific maintainer intuition.
+
+The first portability target is:
+
+- `CreateCVs`
+- repository: [H9-Foundry/CreateCVs](https://github.com/H9-Foundry/CreateCVs)
+- feedback sink: [CreateCVs issue #119](https://github.com/H9-Foundry/CreateCVs/issues/119)
+
+## Preconditions
+
+Do not start this phase until all of these are true:
+
+- the AgentForge-first benchmark has at least three live tasks recorded
+- the local benchmark-ledger tooling is available and stable enough to support adjudicated `/outcomes` review
+- the Outcomes page no longer overcounts a single blocked release chain across pipeline, deployment, and promotion
+- the CreateCVs embedded pilot contract is merged in the target repository
+
+## Scope
+
+The portability phase is still:
+
+- local-only
+- advisory-gated
+- read-only by default
+- CLI-first
+
+It is not:
+
+- a hosted service test
+- a multi-repo aggregation benchmark
+- a broad plug-and-play claim for less technical users
+
+## Benchmark Model
+
+Use the same comparison model as the AgentForge-first benchmark:
+
+- **Control arm:** same agent, same repo, same task brief style, same validations, no AgentForge workflow requirement
+- **Treatment arm:** same agent, same repo, same task brief style, relevant AgentForge workflows required through the embedded CreateCVs pilot contract
+
+The portability phase measures process value, not model quality.
+
+## Task Mix
+
+Run at least three portability tasks in `CreateCVs`.
+
+Required mix:
+
+- one feature or UI/content task
+- one cross-domain or security-sensitive task
+- one release, pipeline, deployment, or promotion review task
+
+Preferred examples:
+
+- onboarding or dashboard UX change
+- auth, Supabase, export, billing, or edge-function change
+- release/deployment candidate review using the published release/CI review family
+
+## Workflow Routing
+
+Follow the embedded CreateCVs pilot contract exactly.
+
+### Feature / UI / Content
+
+- `planning-discovery`
+- `implementation-proposal`
+- `qa-review`
+- `pr-review`
+
+### Cross-Domain / Risk-Sensitive
+
+- `planning-discovery`
+- `architecture-design-review`
+- `implementation-proposal`
+- `qa-review`
+- `security-review`
+- `pr-review`
+
+### Release / Deployment Review
+
+- `release-readiness`
+- `pipeline-evidence-review`
+- `deployment-gate-review`
+- `promotion-approval`
+
+## Evidence
+
+Use CreateCVs-native evidence only. Do not add benchmark-only validation commands.
+
+Default validation surface:
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run build`
+- `npm test`
+- `npm run test:e2e` when relevant
+- `npm run journeys:check`
+- `npm run resources:audit`
+
+Important repo context:
+
+- `docs/user-journeys.md`
+- `docs/ux-spec.md`
+- `docs/qa-checklist.md`
+- `docs/release-runbook.md`
+- `docs/github-hardening.md`
+
+## Outputs
+
+For every treatment task:
+
+- run the relevant AgentForge workflow set
+- inspect `.agentops/runs/<run-id>/bundle.json`
+- inspect `.agentops/runs/<run-id>/summary.md`
+- append a structured comment to [CreateCVs issue #119](https://github.com/H9-Foundry/CreateCVs/issues/119)
+
+For the benchmark comparison:
+
+- keep one local benchmark ledger entry per arm when adjudication is complete
+- use the same benchmark field set as the AgentForge-first benchmark wherever possible
+
+## Success Bar
+
+Do not treat the portability phase as successful until all of these are true:
+
+- at least one CreateCVs task shows a real decision change or meaningful risk catch in the AgentForge arm
+- the embedded pilot contract can be followed without repeated user command prompts
+- the portability tasks expose at least one reusable workflow value and at least one concrete friction theme
+- the CreateCVs results do not depend on AgentForge-repo-specific context to stay interpretable
+
+## What To Learn
+
+This phase should answer:
+
+- which official workflows still transfer cleanly into a non-AgentForge repository
+- where request authoring or evidence collection is still too heavy
+- whether the published CLI surface is sufficient without source-build knowledge
+- whether the Outcomes dashboard remains understandable outside the home repo
+
+## Decision After This Phase
+
+After the first bounded CreateCVs phase, choose one of three paths:
+
+- continue external portability work if the benchmark remains clean and useful
+- refine one or two noisy workflows if portability exposed reusable friction
+- stop external expansion temporarily if the benchmark shows the current workflow surface does not generalize cleanly

--- a/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
+++ b/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
@@ -53,6 +53,19 @@ Yes, if all of these are acceptable:
 - the team accepts proposal/reporting workflows rather than autonomous write-heavy behavior
 - the team can inspect `.agentops/runs/<run-id>/bundle.json` and `.agentops/runs/<run-id>/summary.md`
 
+## Next Proof Phase
+
+The next adoption proof step is not a broad plug-and-play claim. It is the first bounded external portability benchmark in a real second repository.
+
+Current next target:
+
+- `CreateCVs`
+- use the published CLI plus official workflows only
+- use the embedded pilot contract already merged in that repository
+- compare the same agent's default flow versus the AgentForge-gated flow using the same benchmark rules established in the AgentForge-first dogfood phase
+
+See [docs/CREATECVS_PORTABILITY_PHASE.md](CREATECVS_PORTABILITY_PHASE.md) for the current portability benchmark contract.
+
 ### Do Not Describe As Plug-And-Play Yet
 
 Do not describe AgentForge as plug-and-play for less technical adopters until:

--- a/docs/QUEUE_EXECUTION_FLOW.md
+++ b/docs/QUEUE_EXECUTION_FLOW.md
@@ -59,9 +59,10 @@ Work that is explicitly designed or queued next, but should not start until the 
 
 Current ready lane:
 
-3. additional generic release and CI workflow consumption after the next bounded Phase 2 family is chosen explicitly
-4. additional provider-specific SCM and CI wedges after the current generic release and CI workflow family is stable
-5. deeper supply-chain and enterprise trust work reopened only after the next provider or integration family is defined explicitly
+3. the first bounded external portability phase in `CreateCVs` after the local benchmark-ledger tooling and Outcomes refinement land cleanly
+4. additional generic release and CI workflow consumption after the next bounded Phase 2 family is chosen explicitly
+5. additional provider-specific SCM and CI wedges after the current generic release and CI workflow family is stable
+6. deeper supply-chain and enterprise trust work reopened only after the next provider or integration family is defined explicitly
 
 ### Parallel Safe Lane
 


### PR DESCRIPTION
## Summary
- add a bounded CreateCVs portability benchmark playbook as the next external proof phase after the AgentForge-first dogfood benchmark
- thread that next-stage decision through the benchmark, adoption-readiness, queue, and README docs
- keep the scope local-only, advisory-gated, and published-CLI-only rather than broad plug-and-play claims

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm test; echo EXIT:$?`
  - first full-suite run hit one timeout-sensitive existing CLI smoke test
  - targeted rerun of `consumes host-agnostic imported CI evidence during release-readiness` passed
  - second full-suite run passed cleanly (`159 passed`, `EXIT:0`)
