### PR TITLE
Realign CLI docs and add runtime package README

### DIFF
--- a/.changeset/swift-cars-walk.md
+++ b/.changeset/swift-cars-walk.md
@@ -1,0 +1,5 @@
+---
+"@h9-foundry/agentforge-runtime": patch
+---
+
+Add a package README for `@h9-foundry/agentforge-runtime` so the npm package page renders documentation directly.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,32 @@ AgentForge is an open-source, secure-by-default SDLC workflow platform core for 
 
 It is workflow-first, not chat-first: workflows define the job, policy defines what is allowed, the runtime decides what executes, tools perform the work, and humans approve side effects when required.
 
+## Try AgentForge Now
+
+If you want to evaluate AgentForge in another repository, use the published CLI through `npx`. This is the primary first-run path for external evaluators and does not require cloning this monorepo.
+
+```bash
+mkdir agentforge-demo
+cd agentforge-demo
+git init
+npx @h9-foundry/agentforge-cli init --preset planning-discovery
+npx @h9-foundry/agentforge-cli run planning-discovery --json
+npx @h9-foundry/agentforge-cli explain last-run --json
+```
+
+That path is intentionally four steps only:
+1. create a local repo
+2. start the preset
+3. run the planning workflow
+4. inspect the latest run through `agentforge explain last-run`
+
+After the first run, inspect:
+
+- `.agentops/runs/<run-id>/bundle.json`
+- `.agentops/runs/<run-id>/summary.md`
+
+These docs use `npx` throughout because it is the lowest-friction evaluator path. If you plan to run AgentForge repeatedly, a persistent install is optional, but it is not the default path here.
+
 ## What You Can Do Today
 
 - try the current official workflow surface with the published CLI, without cloning this monorepo
@@ -13,9 +39,11 @@ It is workflow-first, not chat-first: workflows define the job, policy defines w
 - run `agentforge eval run` and `agentforge eval compare` locally against the deterministic workflow fixture corpus in the latest published CLI
 - evaluate the secure-by-default runtime model before broader provider, adapter, and integration support lands
 
-## Adoption Target
+## Audience And Adoption Target
 
 AgentForge is ready now for technical early adopters who want local-first, read-only workflow tooling before PR creation. Plug-and-play external adoption for less technical users is an active product target, not a completed claim: the goal is to make the published CLI installable, understandable, and usable in other repositories without monorepo knowledge or hand-authoring request YAML for common paths.
+
+If you are trying the product, stay on the published CLI path in this README and in [docs/quickstart.md](docs/quickstart.md). If you want to work on AgentForge itself, use [CONTRIBUTING.md](CONTRIBUTING.md) and the contributor/source-build section lower in this README.
 
 See [docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md](docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md) for the current local-only readiness rubric and the exact constraints on external use today.
 
@@ -25,7 +53,7 @@ Published CLI wording rule:
 - `source-build only` means the capability exists on `main` but has not reached the latest npm release yet
 - product-facing docs must use those terms consistently whenever repo `main` is ahead of npm
 
-## Quick Path
+## Canonical Quick Path
 
 The current canonical quick path for the first request-driven workflow is available in the published CLI.
 
@@ -46,7 +74,7 @@ That path is intentionally four steps only:
 
 The preset writes an explicit starter request to `.agentops/requests/planning.yaml`, never auto-runs the workflow, and never overwrites an existing request file.
 
-If you want to develop AgentForge itself, use the contributor/source-build path in [CONTRIBUTING.md](CONTRIBUTING.md) and [docs/quickstart.md](docs/quickstart.md).
+If you want the fuller published-CLI walkthrough, use [docs/quickstart.md](docs/quickstart.md). If you want to develop AgentForge itself, use [CONTRIBUTING.md](CONTRIBUTING.md) and the contributor/source-build path lower in this README.
 
 CLI surface on `main`:
 
@@ -228,7 +256,7 @@ Internal packages remain private until their APIs stabilize and their support ex
 
 See [docs/EXTERNAL_STARTER_AGENT_PACKAGING.md](docs/EXTERNAL_STARTER_AGENT_PACKAGING.md) for the current external support boundary for starter agents, presets, and registry-facing surfaces.
 
-## Quickstart
+## Expanded CLI Walkthrough
 
 ### Fastest Evaluator Path
 
@@ -303,6 +331,8 @@ That flow gives you:
 - a fully local, read-only planning-to-design evaluator path
 
 ### Contributor And Source-Build Path
+
+This section is for contributors working on AgentForge itself, not for evaluators trying the published CLI in another repository.
 
 Install and build the monorepo if you want to work on AgentForge itself:
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,6 +1,6 @@
 # Quickstart
 
-This quickstart walks through the current official AgentForge wedges: secure local repository review plus the planning-to-design-to-implementation-to-QA-to-security-to-maintenance lifecycle handoff, all with auditable outputs.
+This quickstart is the expanded published-CLI walkthrough for external evaluators. It starts with the zero-install `npx` path, then walks through the current official AgentForge wedges: secure local repository review plus the planning-to-design-to-implementation-to-QA-to-security-to-maintenance lifecycle handoff, all with auditable outputs.
 
 Published CLI wording rule:
 
@@ -25,6 +25,8 @@ npx @h9-foundry/agentforge-cli explain last-run --json
 ```
 
 That flow creates `.agentops/` locally and writes run artifacts under `.agentops/runs/<run-id>/`.
+
+All examples in this document use `npx @h9-foundry/agentforge-cli ...` as the default invocation method. If you plan to run AgentForge repeatedly, a persistent install is optional, but it is not required for the first-run path.
 
 ## Canonical Quick Path
 
@@ -237,6 +239,8 @@ npx @h9-foundry/agentforge-cli explain last-run --json
 The maintenance bundle should include one `maintenance-report` lifecycle artifact with deterministic evidence sources, affected packages or docs, routing recommendation, and bounded next-step guidance. The default path remains read-only and does not apply dependency updates or docs edits automatically.
 
 ## Contributor And Source-Build Path
+
+This section is for contributors working on AgentForge itself. If you are only evaluating the product in another repository, stop at the published-CLI sections above.
 
 If you want to work on AgentForge itself, build the monorepo locally:
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,0 +1,178 @@
+# @h9-foundry/agentforge-runtime
+
+Deterministic workflow orchestration and tool mediation for AgentForge.
+
+This package runs ordered workflow nodes, enforces policy decisions around tool use, records audit entries, links lifecycle artifacts, and returns a final audit bundle for the run.
+
+## Install
+
+```bash
+npm install @h9-foundry/agentforge-runtime
+```
+
+## What It Does
+
+- Executes workflow nodes in order.
+- Invokes registered agents with minimal state slices.
+- Mediates tool requests through registered adapters and a policy engine.
+- Blocks denied or approval-gated tool calls before execution.
+- Redacts sensitive values before audit output is persisted.
+- Returns the updated workflow state and the generated audit bundle.
+
+## Usage
+
+```ts
+import { runWorkflow } from "@h9-foundry/agentforge-runtime";
+import { agentOutputSchema } from "@h9-foundry/agentforge-schemas";
+import type { RuntimeAgent } from "@h9-foundry/agentforge-sdk";
+import type { WorkflowStateEnvelope } from "@h9-foundry/agentforge-shared-types";
+
+const initialState: WorkflowStateEnvelope = {
+  version: "1.0.0",
+  runId: "run-1",
+  workflow: "pr-review",
+  mode: "inspect",
+  repo: {
+    root: "/repo",
+    name: "repo",
+    branch: "main",
+    packageManager: "pnpm",
+    languages: ["typescript"],
+    ci: false,
+    detectedFiles: []
+  },
+  changes: {
+    changedFiles: [],
+    stagedFiles: [],
+    untrackedFiles: [],
+    impactedPaths: [],
+    diffStats: { filesChanged: 0, insertions: 0, deletions: 0 },
+    fileDetails: []
+  },
+  context: {
+    localExecution: true,
+    ciExecution: false,
+    trigger: "manual",
+    timestamp: new Date().toISOString()
+  },
+  policy: {
+    version: 1,
+    environment: "local",
+    resolvedAt: new Date().toISOString(),
+    defaults: {
+      executionMode: "inspect",
+      modelAccess: false,
+      network: "deny",
+      writes: "approval_required"
+    },
+    paths: {
+      allowedRead: ["**/*"],
+      allowedWrite: [".agentops/runs/**"],
+      blocked: [".env*"]
+    },
+    plugins: {
+      allowedTiers: ["core", "verified"],
+      allowedSources: ["official", "local"],
+      requireReviewed: true
+    },
+    tools: {}
+  },
+  approvals: [],
+  findings: [],
+  proposedActions: [],
+  lifecycleArtifacts: [],
+  blockedPlugins: [],
+  workflowInputs: {},
+  agentResults: {},
+  auditTrail: []
+};
+
+const noopAgent: RuntimeAgent = {
+  manifest: {
+    version: 1,
+    name: "noop",
+    displayName: "Noop",
+    category: "test",
+    runtime: { minVersion: "0.1.0", kind: "deterministic" },
+    permissions: { model: false, network: false, tools: [], readPaths: [], writePaths: [] },
+    inputs: [],
+    outputs: ["summary"],
+    contextPolicy: { sections: ["repo", "changes"], minimalContext: true },
+    trust: { tier: "core", source: "official", reviewed: true }
+  },
+  outputSchema: agentOutputSchema,
+  async execute() {
+    return {
+      summary: "Completed",
+      findings: [],
+      proposedActions: [],
+      lifecycleArtifacts: [],
+      requestedTools: [],
+      blockedActionFlags: [],
+      metadata: {}
+    };
+  }
+};
+
+const result = await runWorkflow({
+  workflow: {
+    version: 1,
+    name: "pr-review",
+    trigger: "manual",
+    nodes: [
+      { id: "context", kind: "deterministic", agent: "noop", outputsTo: "agentResults.context", contextSections: [], tools: [] },
+      { id: "report", kind: "report", outputsTo: "report.final", contextSections: [], tools: [] }
+    ]
+  },
+  initialState,
+  agents: new Map([["noop", noopAgent]]),
+  adapters: new Map(),
+  policyEngine: {
+    snapshot: initialState.policy,
+    canReadPath: () => ({ allowed: true, effect: "allow", requiresApproval: false }),
+    canWritePath: () => ({ allowed: false, effect: "approval_required", requiresApproval: true, reason: "Write requires approval." }),
+    evaluateToolRequest: () => ({ allowed: false, effect: "deny", requiresApproval: false }),
+    redactSecrets: (value) => value,
+    sanitizeLifecycleArtifact: (artifact) => artifact
+  },
+  artifactJsonPath: ".agentops/runs/run-1/bundle.json",
+  artifactMarkdownPath: ".agentops/runs/run-1/summary.md"
+});
+
+console.log(result.bundle.workflow);
+console.log(result.state.auditTrail.length);
+```
+
+## API
+
+### `runWorkflow(deps)`
+
+Runs a workflow and returns:
+
+- `state`: the updated `WorkflowStateEnvelope`
+- `bundle`: the generated audit bundle
+
+`deps` includes:
+
+- `workflow`: workflow definition to execute
+- `initialState`: normalized workflow state envelope
+- `agents`: registered runtime agents by name
+- `adapters`: registered tool adapters by name
+- `policyEngine`: policy mediation and redaction hooks
+- `provider`: optional reasoning provider for bounded reasoning nodes
+- `artifactJsonPath`: output path recorded in the audit bundle for JSON artifacts
+- `artifactMarkdownPath`: output path recorded in the audit bundle for Markdown artifacts
+
+## Related Packages
+
+- [`@h9-foundry/agentforge-cli`](https://www.npmjs.com/package/@h9-foundry/agentforge-cli)
+- [`@h9-foundry/agentforge-sdk`](https://www.npmjs.com/package/@h9-foundry/agentforge-sdk)
+- [`@h9-foundry/agentforge-schemas`](https://www.npmjs.com/package/@h9-foundry/agentforge-schemas)
+- [`@h9-foundry/agentforge-policy-engine`](https://www.npmjs.com/package/@h9-foundry/agentforge-policy-engine)
+- [`@h9-foundry/agentforge-audit`](https://www.npmjs.com/package/@h9-foundry/agentforge-audit)
+
+## Source
+
+- Repository: [github.com/H9-Foundry/AgentForge](https://github.com/H9-Foundry/AgentForge)
+- Package directory: [packages/runtime](https://github.com/H9-Foundry/AgentForge/tree/main/packages/runtime)
+- Runtime model: [docs/runtime-model.md](https://github.com/H9-Foundry/AgentForge/blob/main/docs/runtime-model.md)


### PR DESCRIPTION
## Summary
- make the GitHub README lead with the published CLI `npx` evaluator path
- align `docs/quickstart.md` around the same CLI-first onboarding flow
- add a package README and runtime patch changeset so `@h9-foundry/agentforge-runtime` will render docs on npm after the next publish

## Testing
- `pnpm build:packages`
- `pnpm pack:public`
- `pnpm release:verify`
- `cd packages/runtime && npm pack --dry-run --json`
- `npx -y @h9-foundry/agentforge-cli init --preset planning-discovery`
- `npx -y @h9-foundry/agentforge-cli run planning-discovery --json`
- `npx -y @h9-foundry/agentforge-cli explain last-run --json`

## Notes
- The existing pending changeset assumed in the original rollout plan had already been consumed on `main`, so this PR adds a new runtime patch changeset to ensure the npm README ships on the next publish.
- The unrelated local `.gitignore` modification in the original workspace is intentionally excluded from this PR.
