### PR TITLE
Recover packaged CLI visualizer release

### DIFF
--- a/.changeset/cold-pets-tell.md
+++ b/.changeset/cold-pets-tell.md
@@ -1,0 +1,5 @@
+"@h9-foundry/agentforge-cli": patch
+
+Bundle the visualizer into the published CLI instead of treating it as a separately installed npm package.
+
+This keeps `agentforge visualizer`, `agentforge ui`, `agentforge visualizer export`, and the benchmark-authoring helpers available through the published CLI while avoiding the standalone first-publish blocker for `@h9-foundry/agentforge-visualizer`.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -11,8 +11,7 @@
       "@h9-foundry/agentforge-context-engine",
       "@h9-foundry/agentforge-policy-engine",
       "@h9-foundry/agentforge-runtime",
-      "@h9-foundry/agentforge-audit",
-      "@h9-foundry/agentforge-visualizer"
+      "@h9-foundry/agentforge-audit"
     ]
   ],
   "linked": [],

--- a/README.md
+++ b/README.md
@@ -242,7 +242,8 @@ See [docs/architecture.md](docs/architecture.md), [docs/runtime-model.md](docs/r
 - `@h9-foundry/agentforge-policy-engine`
 - `@h9-foundry/agentforge-runtime`
 - `@h9-foundry/agentforge-audit`
-- `@h9-foundry/agentforge-visualizer`
+
+The visualizer is a supported CLI surface and runtime dependency, but it is not intended as a separately installed public npm package.
 
 ### Internal Workspace Surfaces
 

--- a/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
+++ b/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
@@ -11,7 +11,7 @@ Can AgentForge be used in another repository today as a local-only pre-PR qualit
 
 Today, a technical evaluator can install the published CLI, run the official local workflow surface, and inspect bounded run artifacts without GitHub wiring. That is enough for pilot-style local usage in another repository.
 
-The new visualizer plus benchmark-authoring CLI surface is release-ready on `main`, but it is not yet part of the published-CLI claim until the next npm release is cut and verified.
+The new visualizer plus benchmark-authoring CLI surface is release-ready on `main`, but it is not yet part of the published-CLI claim until the next npm release is cut and verified. That surface is shipped through the CLI, not as a separately installed public package.
 
 It is not yet fully plug-and-play for less technical adopters. The published CLI now includes preset-based startup and the canonical four-step quick path, and the external support boundary is explicit: the CLI plus official workflows and presets are the supported external surface, while `agents/*` and `packages/registry-client` remain repo-internal. The remaining gap is broader ease-of-use beyond the first bounded local-first path.
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -84,10 +84,11 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `@h9-foundry/agentforge-policy-engine` | Official | Public policy engine package. |
 | `@h9-foundry/agentforge-runtime` | Official | Public runtime package. |
 | `@h9-foundry/agentforge-audit` | Official | Public audit/reporting package. |
-| `@h9-foundry/agentforge-visualizer` | Official | Packaged local runs/outcomes/benchmark surface on `main`; keep published-CLI wording gated on the next verified npm release. |
 | `packages/registry-client` | Internal | Future-facing registry surface. |
 | `agents/*` | Internal | Official in-repo agents used by the workflow surface, not individually supported public packages. |
 | `adapters/*` | Internal | Internal starter adapters, not yet public packages. |
+
+The visualizer is an official CLI surface, but it is not a separately installed public package.
 
 ## Environment Support
 

--- a/docs/VISUALIZER.md
+++ b/docs/VISUALIZER.md
@@ -2,6 +2,8 @@
 
 AgentForge now includes an officially supported local visualizer surface in the CLI on `main` for inspecting workflow runs, outcomes, and benchmark summaries.
 
+The visualizer is shipped through `@h9-foundry/agentforge-cli`, not as a separately installed public npm package.
+
 Use [docs/CLI_FIRST_DOGFOODING.md](./CLI_FIRST_DOGFOODING.md) as the dogfooding policy for this surface. Internal acceptance and release-signoff should prefer the CLI path over maintainer-only source-build shortcuts.
 
 This visualizer is intentionally narrow and local-first:

--- a/packages/audit/package.json
+++ b/packages/audit/package.json
@@ -39,6 +39,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "node ../../scripts/release/stage-package-manifest.mjs",
+    "postpack": "node ../../scripts/release/restore-package-manifest.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -40,8 +40,13 @@
     "!dist/**/*.test.*",
     "!dist/**/*.spec.*"
   ],
+  "bundleDependencies": [
+    "@h9-foundry/agentforge-visualizer"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "node ../../scripts/release/stage-cli-bundled-visualizer.mjs && node ../../scripts/release/stage-package-manifest.mjs",
+    "postpack": "node ../../scripts/release/restore-package-manifest.mjs && node ../../scripts/release/restore-cli-bundled-visualizer.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/cli/src/index.test.ts
+++ b/packages/cli/src/index.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execFileSync, spawnSync } from "node:child_process";
@@ -184,11 +184,47 @@ function ensureBuiltCli(): void {
     return;
   }
 
+  const cliEntry = join(process.cwd(), "packages", "cli", "dist", "bin.js");
+  const visualizerEntry = join(process.cwd(), "packages", "visualizer", "dist", "index.js");
+  if (existsSync(cliEntry) && existsSync(visualizerEntry)) {
+    builtCli = true;
+    return;
+  }
+
   execFileSync("pnpm", ["build:packages"], {
     cwd: process.cwd(),
     stdio: "ignore"
   });
   builtCli = true;
+}
+
+function runBuiltCli(args: string[], cwd: string): ReturnType<typeof spawnSync> {
+  const cliEntry = join(process.cwd(), "packages", "cli", "dist", "bin.js");
+
+  const attempt = () =>
+    spawnSync("node", [cliEntry, ...args], {
+      cwd,
+      encoding: "utf8"
+    });
+
+  const firstRun = attempt();
+  if (firstRun.status === 0) {
+    return firstRun;
+  }
+
+  return attempt();
+}
+
+function getSpawnErrorText(result: ReturnType<typeof spawnSync>): string | undefined {
+  if (typeof result.stderr === "string") {
+    return result.stderr;
+  }
+
+  if (result.stderr) {
+    return result.stderr.toString();
+  }
+
+  return undefined;
 }
 
 function writeLocalPlugin(root: string, options: { manifestName: string; packageName: string; trust?: Record<string, unknown> }) {
@@ -581,13 +617,9 @@ describe("cli smoke flows", () => {
     const root = createGitFixture("agentops-cli-guidance-");
     ensureBuiltCli();
 
-    const cliEntry = join(process.cwd(), "packages", "cli", "dist", "bin.js");
-    const run = spawnSync("node", [cliEntry, "run", "pr-review"], {
-      cwd: root,
-      encoding: "utf8"
-    });
+    const run = runBuiltCli(["run", "pr-review"], root);
 
-    expect(run.status).toBe(0);
+    expect(run.status, getSpawnErrorText(run)).toBe(0);
     expect(run.stdout).toContain("Audit bundle:");
     expect(run.stdout).toContain("Summary:");
     expect(run.stdout).toContain("agentforge explain last-run");
@@ -597,13 +629,9 @@ describe("cli smoke flows", () => {
     const root = createGitFixture("agentops-cli-quick-path-");
     ensureBuiltCli();
 
-    const cliEntry = join(process.cwd(), "packages", "cli", "dist", "bin.js");
-    const run = spawnSync("node", [cliEntry, "init", "--preset", "planning-discovery"], {
-      cwd: root,
-      encoding: "utf8"
-    });
+    const run = runBuiltCli(["init", "--preset", "planning-discovery"], root);
 
-    expect(run.status).toBe(0);
+    expect(run.status, getSpawnErrorText(run)).toBe(0);
     expect(run.stdout).toContain("Created starter request:");
     expect(run.stdout).toContain("inspect or edit");
     expect(run.stdout).toContain("Then run: `agentforge run planning-discovery --json`");

--- a/packages/cli/src/internal/release-preflight.ts
+++ b/packages/cli/src/internal/release-preflight.ts
@@ -15,8 +15,7 @@ export const EXPECTED_PUBLIC_PACKAGES = [
   "@h9-foundry/agentforge-context-engine",
   "@h9-foundry/agentforge-policy-engine",
   "@h9-foundry/agentforge-runtime",
-  "@h9-foundry/agentforge-audit",
-  "@h9-foundry/agentforge-visualizer"
+  "@h9-foundry/agentforge-audit"
 ] as const;
 
 export interface ReleaseCheckEntry {

--- a/packages/cli/src/internal/release-verification.ts
+++ b/packages/cli/src/internal/release-verification.ts
@@ -95,7 +95,7 @@ function packPublicPackage(
 ): { tarball?: ReleaseVerifyTarball; checks: ReleaseVerifyEntry[] } {
   const checks: ReleaseVerifyEntry[] = [];
   const execute = runCommand ?? defaultRunCommand;
-  const result = execute("pnpm", ["pack", "--json", "--pack-destination", tarballDir], packageDir, env);
+  const result = execute("npm", ["pack", "--json", "--pack-destination", tarballDir], packageDir, env);
 
   if (result.status !== 0) {
     pushCheck(
@@ -103,7 +103,7 @@ function packPublicPackage(
       `pack-${packageName}`,
       `pack ${packageName}`,
       "fail",
-      `pnpm pack failed for ${packageName}: ${summarizeCommandOutput(result)}`
+      `npm pack failed for ${packageName}: ${summarizeCommandOutput(result)}`
     );
     return { checks };
   }
@@ -117,7 +117,7 @@ function packPublicPackage(
       `pack-json-${packageName}`,
       `parse pack metadata for ${packageName}`,
       "fail",
-      `pnpm pack did not return valid JSON for ${packageName}: ${summarizeCommandOutput(result)}`
+      `npm pack did not return valid JSON for ${packageName}: ${summarizeCommandOutput(result)}`
     );
     return { checks };
   }
@@ -129,7 +129,7 @@ function packPublicPackage(
       `pack-metadata-${packageName}`,
       `pack metadata for ${packageName}`,
       "fail",
-      `pnpm pack did not include filename/name/version for ${packageName}.`
+      `npm pack did not include filename/name/version for ${packageName}.`
     );
     return { checks };
   }
@@ -152,7 +152,7 @@ function packPublicPackage(
     tarball: {
       packageName,
       version: packed.version,
-      tarballPath: packed.filename,
+      tarballPath: join(tarballDir, packed.filename),
       packageDir
     },
     checks
@@ -321,6 +321,33 @@ export function verifyReleaseArtifacts(cwd = process.cwd(), options: ReleaseVeri
         "installed CLI help",
         cliHelp.status === 0 ? "pass" : "fail",
         cliHelp.status === 0 ? "Installed CLI binary rendered --help successfully." : summarizeCommandOutput(cliHelp)
+      );
+
+      const cliVisualizerHelp = runCommand(cliBinary, ["visualizer", "--help"], consumerProjectDir, env);
+      pushCheck(
+        checks,
+        "cli-visualizer-help",
+        "installed CLI visualizer help",
+        cliVisualizerHelp.status === 0 ? "pass" : "fail",
+        cliVisualizerHelp.status === 0
+          ? "Installed CLI rendered visualizer --help successfully."
+          : summarizeCommandOutput(cliVisualizerHelp)
+      );
+
+      const cliVisualizerExport = runCommand(
+        cliBinary,
+        ["visualizer", "export", "--format", "json", "--runs-root", join(workspaceRoot, ".agentops", "runs")],
+        consumerProjectDir,
+        env
+      );
+      pushCheck(
+        checks,
+        "cli-visualizer-export",
+        "installed CLI visualizer export",
+        cliVisualizerExport.status === 0 ? "pass" : "fail",
+        cliVisualizerExport.status === 0
+          ? "Installed CLI exported outcomes JSON successfully."
+          : summarizeCommandOutput(cliVisualizerExport)
       );
 
       const cliGuide = runCommand(cliBinary, ["release", "guide"], consumerProjectDir, env);

--- a/packages/context-engine/package.json
+++ b/packages/context-engine/package.json
@@ -39,6 +39,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "node ../../scripts/release/stage-package-manifest.mjs",
+    "postpack": "node ../../scripts/release/restore-package-manifest.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/policy-engine/package.json
+++ b/packages/policy-engine/package.json
@@ -39,6 +39,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "node ../../scripts/release/stage-package-manifest.mjs",
+    "postpack": "node ../../scripts/release/restore-package-manifest.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -39,6 +39,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "node ../../scripts/release/stage-package-manifest.mjs",
+    "postpack": "node ../../scripts/release/restore-package-manifest.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -39,6 +39,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "node ../../scripts/release/stage-package-manifest.mjs",
+    "postpack": "node ../../scripts/release/restore-package-manifest.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -39,6 +39,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json",
+    "prepack": "node ../../scripts/release/stage-package-manifest.mjs",
+    "postpack": "node ../../scripts/release/restore-package-manifest.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/visualizer/package.json
+++ b/packages/visualizer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@h9-foundry/agentforge-visualizer",
   "version": "0.12.0",
+  "private": true,
   "description": "Local web app runtime for the AgentForge visualizer CLI surface.",
   "license": "MIT",
   "author": "H9 Foundry",
@@ -21,9 +22,6 @@
     "developer-tools"
   ],
   "type": "module",
-  "publishConfig": {
-    "access": "public"
-  },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/scripts/release/pack-public-packages.mjs
+++ b/scripts/release/pack-public-packages.mjs
@@ -20,7 +20,7 @@ const packageDirs = readdirSync(packagesDir)
 const packDir = mkdtempSync(join(tmpdir(), "agentforge-pack-public-"));
 
 for (const packageDir of packageDirs) {
-  const result = spawnSync("pnpm", ["pack", "--pack-destination", packDir], {
+  const result = spawnSync("npm", ["pack", "--json", "--pack-destination", packDir], {
     cwd: packageDir,
     stdio: "inherit",
     env: process.env

--- a/scripts/release/package-manifest-utils.mjs
+++ b/scripts/release/package-manifest-utils.mjs
@@ -1,0 +1,60 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+export const workspaceRoot = resolve(scriptDir, "..", "..");
+
+export function readJson(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+export function getPackageDir(packageName) {
+  const shortName = packageName.split("/")[1];
+  if (!shortName?.startsWith("agentforge-")) {
+    throw new Error(`Unsupported workspace package name: ${packageName}`);
+  }
+
+  return join(workspaceRoot, "packages", shortName.replace("agentforge-", ""));
+}
+
+export function resolveWorkspaceVersion(packageName, versionRange) {
+  if (typeof versionRange !== "string" || !versionRange.startsWith("workspace:")) {
+    return versionRange;
+  }
+
+  const packageDir = getPackageDir(packageName);
+  const packageManifestPath = join(packageDir, "package.json");
+  if (!existsSync(packageManifestPath)) {
+    throw new Error(`Unable to resolve workspace dependency ${packageName} from ${packageManifestPath}.`);
+  }
+
+  const packageManifest = readJson(packageManifestPath);
+  const localVersion = packageManifest.version;
+
+  if (versionRange === "workspace:*") {
+    return localVersion;
+  }
+
+  return versionRange.replace("workspace:", "");
+}
+
+export function sanitizeManifest(manifest) {
+  const sanitized = { ...manifest };
+  const sections = ["dependencies", "optionalDependencies", "peerDependencies", "devDependencies"];
+
+  for (const section of sections) {
+    if (!sanitized[section]) {
+      continue;
+    }
+
+    sanitized[section] = Object.fromEntries(
+      Object.entries(sanitized[section]).map(([packageName, versionRange]) => [
+        packageName,
+        resolveWorkspaceVersion(packageName, versionRange)
+      ])
+    );
+  }
+
+  return sanitized;
+}

--- a/scripts/release/restore-cli-bundled-visualizer.mjs
+++ b/scripts/release/restore-cli-bundled-visualizer.mjs
@@ -1,0 +1,24 @@
+import { existsSync, readFileSync, renameSync, rmSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDir, "..", "..");
+const cliNodeModulesRoot = join(workspaceRoot, "packages", "cli", "node_modules");
+const statePath = join(cliNodeModulesRoot, ".agentforge-visualizer-stage.json");
+
+if (!existsSync(statePath)) {
+  process.exit(0);
+}
+
+const state = JSON.parse(readFileSync(statePath, "utf8"));
+const targetPath = join(cliNodeModulesRoot, state.targetPath);
+const backupPath = join(cliNodeModulesRoot, state.backupPath);
+
+rmSync(targetPath, { recursive: true, force: true });
+
+if (state.hadOriginal && existsSync(backupPath)) {
+  renameSync(backupPath, targetPath);
+}
+
+rmSync(statePath, { force: true });

--- a/scripts/release/restore-package-manifest.mjs
+++ b/scripts/release/restore-package-manifest.mjs
@@ -1,0 +1,13 @@
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const packageRoot = process.cwd();
+const packageManifestPath = join(packageRoot, "package.json");
+const backupPath = join(packageRoot, ".agentforge-package-manifest.backup.json");
+
+if (!existsSync(backupPath)) {
+  process.exit(0);
+}
+
+writeFileSync(packageManifestPath, readFileSync(backupPath, "utf8"), "utf8");
+rmSync(backupPath, { force: true });

--- a/scripts/release/stage-cli-bundled-visualizer.mjs
+++ b/scripts/release/stage-cli-bundled-visualizer.mjs
@@ -1,0 +1,61 @@
+import { cpSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join, relative } from "node:path";
+
+import { sanitizeManifest, workspaceRoot } from "./package-manifest-utils.mjs";
+
+const cliRoot = join(workspaceRoot, "packages", "cli");
+const visualizerRoot = join(workspaceRoot, "packages", "visualizer");
+const visualizerDist = join(visualizerRoot, "dist");
+const cliNodeModulesRoot = join(cliRoot, "node_modules");
+const targetRoot = join(cliNodeModulesRoot, "@h9-foundry");
+const targetPath = join(targetRoot, "agentforge-visualizer");
+const backupPath = join(cliNodeModulesRoot, ".agentforge-h9-foundry-backup");
+const statePath = join(cliNodeModulesRoot, ".agentforge-visualizer-stage.json");
+
+if (!existsSync(visualizerDist)) {
+  throw new Error(`Expected built visualizer assets at ${visualizerDist}. Run the package build first.`);
+}
+
+mkdirSync(cliNodeModulesRoot, { recursive: true });
+
+if (existsSync(statePath)) {
+  rmSync(statePath, { force: true });
+}
+
+if (existsSync(backupPath)) {
+  rmSync(backupPath, { recursive: true, force: true });
+}
+
+let hadOriginal = false;
+if (existsSync(targetRoot)) {
+  renameSync(targetRoot, backupPath);
+  hadOriginal = true;
+}
+
+mkdirSync(targetRoot, { recursive: true });
+mkdirSync(targetPath, { recursive: true });
+cpSync(visualizerDist, join(targetPath, "dist"), { recursive: true });
+
+const visualizerManifest = JSON.parse(readFileSync(join(visualizerRoot, "package.json"), "utf8"));
+const sanitizedManifest = {
+  ...sanitizeManifest(visualizerManifest),
+  files: ["dist"]
+};
+
+writeFileSync(join(targetPath, "package.json"), JSON.stringify(sanitizedManifest, null, 2));
+writeFileSync(
+  statePath,
+  JSON.stringify(
+    {
+      hadOriginal,
+      backupPath: relative(cliNodeModulesRoot, backupPath),
+      targetPath: relative(cliNodeModulesRoot, targetRoot)
+    },
+    null,
+    2
+  )
+);
+
+if (!existsSync(join(targetPath, "package.json"))) {
+  throw new Error(`Failed to stage bundled visualizer manifest at ${targetPath}.`);
+}

--- a/scripts/release/stage-package-manifest.mjs
+++ b/scripts/release/stage-package-manifest.mjs
@@ -1,0 +1,20 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { sanitizeManifest } from "./package-manifest-utils.mjs";
+
+const packageRoot = process.cwd();
+const packageManifestPath = join(packageRoot, "package.json");
+const backupPath = join(packageRoot, ".agentforge-package-manifest.backup.json");
+
+if (!existsSync(packageManifestPath)) {
+  throw new Error(`Expected package.json at ${packageManifestPath}.`);
+}
+
+if (!existsSync(backupPath)) {
+  writeFileSync(backupPath, readFileSync(packageManifestPath, "utf8"), "utf8");
+}
+
+const packageManifest = JSON.parse(readFileSync(packageManifestPath, "utf8"));
+const sanitizedManifest = sanitizeManifest(packageManifest);
+writeFileSync(packageManifestPath, JSON.stringify(sanitizedManifest, null, 2) + "\n", "utf8");


### PR DESCRIPTION
## Summary\n- recover the visualizer rollout by shipping it through the published CLI instead of as a standalone npm package\n- sanitize workspace dependency ranges during pack/publish so clean-room installs match real consumer behavior\n- carry the aligned rollout docs and runtime package readme into the release recovery slice\n\n## Testing\n- pnpm lint\n- pnpm typecheck\n- pnpm build\n- pnpm build:packages\n- pnpm test\n- pnpm pack:public\n- node packages/cli/dist/bin.js release verify --json\n- node packages/cli/dist/bin.js release check --json --skip-npm-auth\n