### PR TITLE
Run release publish with hoisted linker

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "changeset": "changeset",
     "lint": "eslint .",
     "pack:public": "node scripts/release/pack-public-packages.mjs",
-    "release:publish": "changeset publish",
+    "release:publish": "node scripts/release/run-changeset-publish.mjs",
     "release:verify": "pnpm exec tsx packages/cli/src/bin.ts release verify",
     "release:version": "changeset version && pnpm install --lockfile-only",
     "test": "vitest run",

--- a/scripts/release/run-changeset-publish.mjs
+++ b/scripts/release/run-changeset-publish.mjs
@@ -1,0 +1,11 @@
+import { spawnSync } from "node:child_process";
+
+const result = spawnSync("changeset", ["publish", ...process.argv.slice(2)], {
+  stdio: "inherit",
+  env: {
+    ...process.env,
+    npm_config_node_linker: "hoisted"
+  }
+});
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- run the changeset publish step through a small wrapper that sets pnpm's linker mode to hoisted
- unblock publishing the bundled CLI package while keeping the repo on the default isolated linker for normal installs

## Testing
- pnpm typecheck
- pnpm release:publish --help
