### PR TITLE
Flip visualizer docs to published CLI wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The preset writes an explicit starter request to `.agentops/requests/planning.ya
 
 If you want the fuller published-CLI walkthrough, use [docs/quickstart.md](docs/quickstart.md). If you want to develop AgentForge itself, use [CONTRIBUTING.md](CONTRIBUTING.md) and the contributor/source-build path lower in this README.
 
-CLI surface on `main`:
+Available in the published CLI:
 
 - `agentforge visualizer --open` now launches the official local read-only visualizer for `.agentops/runs`, including runs, `/outcomes`, run detail, and benchmark views
 - `agentforge visualizer export --format json|markdown` now exports a normalized outcomes snapshot for CI artifacts or team review without introducing a hosted dependency
@@ -277,14 +277,14 @@ The last command should point you to:
 
 ### Visualizer Quickstart
 
-Once local runs exist, the CLI surface on `main` also supports the local visualizer directly:
+Once local runs exist, the published CLI also supports the local visualizer directly:
 
 ```bash
 agentforge visualizer --open
 agentforge visualizer export --format markdown
 ```
 
-Use the first command for local inspection and the second command when you want a shareable outcomes snapshot without standing up a hosted dashboard. Until the next npm publish lands, use the source-build/local-build path documented in [docs/VISUALIZER.md](docs/VISUALIZER.md).
+Use the first command for local inspection and the second command when you want a shareable outcomes snapshot without standing up a hosted dashboard. If you are developing AgentForge itself, the contributor/source-build path remains documented in [docs/VISUALIZER.md](docs/VISUALIZER.md).
 
 ### Planning To Design Evaluator Path
 

--- a/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
+++ b/docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md
@@ -11,7 +11,7 @@ Can AgentForge be used in another repository today as a local-only pre-PR qualit
 
 Today, a technical evaluator can install the published CLI, run the official local workflow surface, and inspect bounded run artifacts without GitHub wiring. That is enough for pilot-style local usage in another repository.
 
-The new visualizer plus benchmark-authoring CLI surface is release-ready on `main`, but it is not yet part of the published-CLI claim until the next npm release is cut and verified. That surface is shipped through the CLI, not as a separately installed public package.
+The visualizer plus benchmark-authoring CLI surface is now part of the published-CLI claim. That surface is shipped through the CLI, not as a separately installed public package.
 
 It is not yet fully plug-and-play for less technical adopters. The published CLI now includes preset-based startup and the canonical four-step quick path, and the external support boundary is explicit: the CLI plus official workflows and presets are the supported external surface, while `agents/*` and `packages/registry-client` remain repo-internal. The remaining gap is broader ease-of-use beyond the first bounded local-first path.
 
@@ -43,7 +43,7 @@ The local-only adoption bar is met only when all of these are true:
 | Quick path without maintainer docs | Pass | The published CLI now provides one canonical four-step quick path for the first request-driven workflow. |
 | No-YAML startup for a common path | Pass | `init --preset planning-discovery` is now available in the published CLI. |
 | External starter-agent packaging clarity | Pass | The support boundary is now explicit: external users consume workflows and presets through the CLI, while `agents/*` and `packages/registry-client` remain repo-internal. |
-| Visualizer and benchmark CLI surface | Source-build only | `agentforge visualizer`, `visualizer export`, and `eval benchmark-wizard` are release-ready on `main`, but they should not be described as published-CLI capability until the next npm release is verified. |
+| Visualizer and benchmark CLI surface | Pass | `agentforge visualizer`, `visualizer export`, and `eval benchmark-wizard` are available in the published CLI through `@h9-foundry/agentforge-cli`. |
 
 ## Decision Guidance
 

--- a/docs/SUPPORT_MATRIX.md
+++ b/docs/SUPPORT_MATRIX.md
@@ -16,7 +16,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 - **Published now**: available in the latest npm release of `@h9-foundry/agentforge-cli`
 - **Source-build only**: implemented on `main`, but not yet in the latest npm release
 - Product-facing docs must say `available in the published CLI` only after published parity is verified
-- The packaged visualizer and benchmark CLI surface are release-ready on `main`, but they must keep `source-build only` or equivalent wording until the next npm publish is verified
+- The packaged visualizer and benchmark CLI surface are now available in the published CLI through `@h9-foundry/agentforge-cli`, not as a separately installed npm package
 
 ## Workflow Support
 
@@ -84,6 +84,7 @@ Manifest-level catalog metadata now exists for official workflow and agent asset
 | `@h9-foundry/agentforge-policy-engine` | Official | Public policy engine package. |
 | `@h9-foundry/agentforge-runtime` | Official | Public runtime package. |
 | `@h9-foundry/agentforge-audit` | Official | Public audit/reporting package. |
+| `visualizer` CLI surface | Official | Shipped through `@h9-foundry/agentforge-cli`, not as a separately installed public package. |
 | `packages/registry-client` | Internal | Future-facing registry surface. |
 | `agents/*` | Internal | Official in-repo agents used by the workflow surface, not individually supported public packages. |
 | `adapters/*` | Internal | Internal starter adapters, not yet public packages. |
@@ -123,7 +124,7 @@ See [docs/EXTERNAL_LOCAL_ADOPTION_READINESS.md](EXTERNAL_LOCAL_ADOPTION_READINES
 
 ## Compatibility Notes
 
-- Workflow maturity and published CLI availability are related but not identical. A workflow can be official on `main` and still need an explicit `source-build only` note until the latest npm release includes it; the current quick path, preset startup, and release/CI review family are already available in the published CLI.
+- Workflow maturity and published CLI availability are related but not identical. A workflow can be official on `main` and still need an explicit `source-build only` note until the latest npm release includes it; the current quick path, preset startup, release/CI review family, and visualizer/benchmark CLI surface are now available in the published CLI.
 - Current support is strongest for local repository execution and GitHub-centric release workflows.
 - Public compatibility commitments are intentionally narrow until broader workflow and integration support exists.
 - Planned support in this matrix should be treated as roadmap direction, not shipped capability.

--- a/docs/VISUALIZER.md
+++ b/docs/VISUALIZER.md
@@ -1,6 +1,6 @@
 # Visualizer
 
-AgentForge now includes an officially supported local visualizer surface in the CLI on `main` for inspecting workflow runs, outcomes, and benchmark summaries.
+AgentForge now includes an officially supported local visualizer surface in the published CLI for inspecting workflow runs, outcomes, and benchmark summaries.
 
 The visualizer is shipped through `@h9-foundry/agentforge-cli`, not as a separately installed public npm package.
 
@@ -33,13 +33,13 @@ The visualizer reads the same audit bundles and lifecycle artifacts that `agentf
 
 ## Local Launch
 
-Current release-ready command surface:
+Published CLI launch path:
 
 ```bash
 agentforge visualizer --open
 ```
 
-Until the next npm publish lands, use it from a source checkout or a locally built CLI:
+Contributor/source-build path:
 
 ```bash
 pnpm build:packages
@@ -56,10 +56,10 @@ Default behavior:
 Optional flags:
 
 ```bash
-node packages/cli/dist/bin.js visualizer --runs-root /absolute/path/to/.agentops/runs --benchmark-ledger /absolute/path/to/.agentops/benchmark-ledger.json --port 4314 --host 127.0.0.1
+agentforge visualizer --runs-root /absolute/path/to/.agentops/runs --benchmark-ledger /absolute/path/to/.agentops/benchmark-ledger.json --port 4314 --host 127.0.0.1
 ```
 
-Contributor/source-build path:
+Contributor/source-build path for local package development:
 
 ```bash
 pnpm install
@@ -152,7 +152,7 @@ Use it to inspect local run state and benchmark value signals more quickly than 
 
 Supported in this phase:
 
-- packaged local app via the official CLI surface on `main`
+- packaged local app via the published CLI
 - local outcomes export for sharing
 - local benchmark-ledger workflows
 


### PR DESCRIPTION
## Summary
- update the remaining pre-publish wording now that the visualizer CLI surface is published
- align README, visualizer docs, support matrix, and external readiness docs with the shipped CLI reality
- keep the docs explicit that the visualizer ships through `@h9-foundry/agentforge-cli`, not as a separate npm package

## Testing
- rg verification for stale pre-publish wording
